### PR TITLE
Make assistant tokenization error message more specific

### DIFF
--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -290,7 +290,7 @@ class SentencePieceInstructTokenizerV2(SentencePieceInstructTokenizer):
         elif message.content:
             curr_tokens = self.tokenizer.encode(message.content, bos=False, eos=False)
         elif message.content == "":
-            raise TokenizerException(f"Empty assistant message.")
+            raise TokenizerException("Empty assistant message.")
         else:
             raise TokenizerException(f"Invalid assistant message: {message.content}")
 


### PR DESCRIPTION
Most tokenizer exception arguably come from the message being empty. Currently this gives the following error message:
```sh
'Invalid assistant message: '
```

which looks a bit incomplete. I think it'd be better to throw:
```sh
'Empty assistant message.'
```