### PR TITLE
Allow multiple "assistant" messages to follow each other

### DIFF
--- a/src/mistral_common/protocol/instruct/validator.py
+++ b/src/mistral_common/protocol/instruct/validator.py
@@ -192,7 +192,7 @@ class MistralRequestValidator:
                 elif previous_role == Roles.user:
                     expected_roles = {Roles.assistant, Roles.system, Roles.user}
                 elif previous_role == Roles.assistant:
-                    expected_roles = {Roles.user, Roles.tool}
+                    expected_roles = {Roles.assistant, Roles.user, Roles.tool}
                 elif previous_role == Roles.tool:
                     expected_roles = {Roles.assistant, Roles.tool}
 


### PR DESCRIPTION
This PR makes it possible to send a set of messages within which two consecutive messages have the "assistant" role (it currently does not pass the validation). Doing so streamlines the validation in regards to the other roles (they can all be followed by another message of the same role), and also restores the behaviour of the API as of before April 17.