### PR TITLE
typo: Change "users" to "user's" for possessive form in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ tokenized = tokenizer.encode_chat_completion(
                             "format": {
                                 "type": "string",
                                 "enum": ["celsius", "fahrenheit"],
-                                "description": "The temperature unit to use. Infer this from the users location.",
+                                "description": "The temperature unit to use. Infer this from the user's location.",
                             },
                         },
                         "required": ["location", "format"],


### PR DESCRIPTION
Fix typo: Change "users" to "user's" for possessive form in README