### PR TITLE
typo: change "users" to "user's" for possessive form

### DIFF
--- a/examples/tokenizer.ipynb
+++ b/examples/tokenizer.ipynb
@@ -101,7 +101,7 @@
     "                            \"format\": {\n",
     "                                \"type\": \"string\",\n",
     "                                \"enum\": [\"celsius\", \"fahrenheit\"],\n",
-    "                                \"description\": \"The temperature unit to use. Infer this from the users location.\",\n",
+    "                                \"description\": \"The temperature unit to use. Infer this from the user's location.\",\n",
     "                            },\n",
     "                        },\n",
     "                        \"required\": [\"location\", \"format\"],\n",


### PR DESCRIPTION
Corrected the typo where "users" should have been "user's" to indicate possession.