### PR TITLE
typo: Correct "nornmalized" to "normalized" in SentencePieceTokenizer

### DIFF
--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -236,7 +236,7 @@ class InstructTokenizerV2(
         system_prompt: Optional[str] = None,
     ) -> List[int]:
         assert message.content is not None
-        assert isinstance(message.content, str), "Message content must be nornmalized"
+        assert isinstance(message.content, str), "Message content must be normalized"
         content = ""
         tools_tokens: List[int] = []
         if is_last and available_tools:


### PR DESCRIPTION
Corrected a typo in the SentencePieceTokenizer implementation. The word "nornmalized" was misspelled and has been changed to "normalized" to ensure proper spelling in the assertion message "Message content must be normalized".