### PR TITLE
Fix/adjusting chat completion request import

### DIFF
--- a/examples/tokenizer.ipynb
+++ b/examples/tokenizer.ipynb
@@ -37,7 +37,7 @@
     "    ToolCall,\n",
     "    FunctionCall,\n",
     ")\n",
-    "from mistral_common.tokens.instruct.normalize import ChatCompletionRequest"
+    "from mistral_common.protocol.instruct.request import ChatCompletionRequest"
    ]
   },
   {


### PR DESCRIPTION
**Goal**

Fixed incorrect import in the example tokenizer notebook (it also needs to be adjusted in the Mistral documentation here: https://docs.mistral.ai/guides/tokenization/).

Before correction: `from mistral_common.tokens.instruct.normalize import ChatCompletionRequest`

After correction: `from mistral_common.protocol.instruct.request import ChatCompletionRequest`