### PR TITLE
Update sentence piece & Update tokenizer table

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ We are releasing three versions of our tokenizer powering different sets of mode
 | Mistral 7B Instruct v0.1 | v1 |
 | Mistral 7B Instruct v0.2 | v1 |
 | Mistral 7B Instruct v0.3 | v3 |
-| Mistral 8x7B Instruct v0.1 | v1 |
-| Mistral 8x22B Instruct v0.1 | v3 |
-| Mistral 8x22B Instruct v0.3 | v3 |
+| Mixtral 8x7B Instruct v0.1 | v1 |
+| Mixtral 8x22B Instruct v0.1 | v3 |
+| Mixtral 8x22B Instruct v0.3 | v3 |
 | Codestral 22B v0.1 | v3 |
 
 </td>

--- a/README.md
+++ b/README.md
@@ -7,25 +7,37 @@ Our first release contains tokenization. Our tokenizers go beyond  the usual tex
 
 We are releasing three versions of our tokenizer powering different sets of models. 
 
+<table>
+  <tr>
+    <td>
+
 | Open Model | Tokenizer |
-|----------|----------|
-| Mistral 7B Instruct v0.1    | v1   |
-| Mistral 7B Instruct v0.2    | v1   |
-| Mistral 7B Instruct v0.3    | v3   |
-| Mistral 8x7B Instruct v0.1    | v1   |
-| Mistral 8x22B Instruct v0.1    | v3   |
-| Mistral 8x22B Instruct v0.3    | v3   |
-| Codestral 22B v0.1    | v3   |
+|------------|-----------|
+| Mistral 7B Instruct v0.1 | v1 |
+| Mistral 7B Instruct v0.2 | v1 |
+| Mistral 7B Instruct v0.3 | v3 |
+| Mistral 8x7B Instruct v0.1 | v1 |
+| Mistral 8x22B Instruct v0.1 | v3 |
+| Mistral 8x22B Instruct v0.3 | v3 |
+| Codestral 22B v0.1 | v3 |
+
+</td>
+<td>
 
 | Endpoint Model | Tokenizer |
-|----------|----------|
-| mistral-embed    | v1   |
-| open-mistral-7b    | v3   |
-| open-mixtral-8x7b    | v1   |
-| open-mixtral-8x22b    | v3   |
-| mistral-small-latest    | v2   |
-| mistral-large-latest    | v2   |
-| codestral-22b    | v3   |
+|---------------|-----------|
+| mistral-embed | v1 |
+| open-mistral-7b | v3 |
+| open-mixtral-8x7b | v1 |
+| open-mixtral-8x22b | v3 |
+| mistral-small-latest | v2 |
+| mistral-large-latest | v2 |
+| codestral-22b | v3 |
+
+</td>
+  </tr>
+</table>
+
 
 ## Installation 
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,25 @@ Our first release contains tokenization. Our tokenizers go beyond  the usual tex
 
 We are releasing three versions of our tokenizer powering different sets of models. 
 
-- v1: open-mistral-7b, open-mixtral-8x7b, mistral-embed
-- v2: mistral-small-latest, mistral-large-latest
-- v3: open-mixtral-8x22b, codestral-22b
+| Open Model | Tokenizer |
+|----------|----------|
+| Mistral 7B Instruct v0.1    | v1   |
+| Mistral 7B Instruct v0.2    | v1   |
+| Mistral 7B Instruct v0.3    | v3   |
+| Mistral 8x7B Instruct v0.1    | v1   |
+| Mistral 8x22B Instruct v0.1    | v3   |
+| Mistral 8x22B Instruct v0.3    | v3   |
+| Codestral 22B v0.1    | v3   |
+
+| Endpoint Model | Tokenizer |
+|----------|----------|
+| mistral-embed    | v1   |
+| open-mistral-7b    | v3   |
+| open-mixtral-8x7b    | v1   |
+| open-mixtral-8x22b    | v3   |
+| mistral-small-latest    | v2   |
+| mistral-large-latest    | v2   |
+| codestral-22b    | v3   |
 
 ## Installation 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ ignore_missing_imports = true
 python = "^3.8.10"
 pydantic = "2.6.1"
 jsonschema = "4.21.1"
-sentencepiece = "0.1.99"
+sentencepiece = "0.2.0"
 typing-extensions = "^4.11.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This PR will update to `sentence-piece 0.2.0` as requested from other PRs, and update the README table with hopefully the right tokenizers for the most recent releases:

<table>
  <tr>
    <td>

| Open Model | Tokenizer |
|------------|-----------|
| Mistral 7B Instruct v0.1 | v1 |
| Mistral 7B Instruct v0.2 | v1 |
| Mistral 7B Instruct v0.3 | v3 |
| Mixtral 8x7B Instruct v0.1 | v1 |
| Mixtral 8x22B Instruct v0.1 | v3 |
| Mixtral 8x22B Instruct v0.3 | v3 |
| Codestral 22B v0.1 | v3 |

</td>
<td>

| Endpoint Model | Tokenizer |
|---------------|-----------|
| mistral-embed | v1 |
| open-mistral-7b | v3 |
| open-mixtral-8x7b | v1 |
| open-mixtral-8x22b | v3 |
| mistral-small-latest | v2 |
| mistral-large-latest | v2 |
| codestral-22b | v3 |

</td>
  </tr>
</table>