### PR TITLE
Specify encoding when opening file

### DIFF
--- a/src/mistral_common/tokens/tokenizers/tekken.py
+++ b/src/mistral_common/tokens/tokenizers/tekken.py
@@ -126,7 +126,7 @@ class Tekkenizer(Tokenizer):
         if isinstance(path, str):
             path = Path(path)
         assert path.exists()
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             model_data: ModelData = json.load(f)
 
         _version_str = model_data["config"].get("version")


### PR DESCRIPTION
On Windows, the encoding for `open` defaults to `Windows-1252 `, which causes an error opening the file.