### PR TITLE
feat: add TextChunk as possible content type for Assistant message

### DIFF
--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -77,7 +77,7 @@ class SystemMessage(BaseMessage):
 
 class AssistantMessage(BaseMessage):
     role: Literal[Roles.assistant] = Roles.assistant
-    content: Optional[str] = None
+    content: Optional[Union[str, List[TextChunk]]] = None
     tool_calls: Optional[List[ToolCall]] = None
     prefix: bool = False
 


### PR DESCRIPTION
Currently, the `AssistantMessage` class only accepts `str` as type.

This means that payload from external systems also using `TextChunk` as content for the Assistant message, will break:

```
"messages": [
    {
        "role": "system",
        "content": [
            {
                "type": "text", "text": "\nCurrent model: pixtral-12b-2409\nCurrent date: 2024-09-23T07:14:36.737Z\n\nYou are a helpful assistant. You can help me by answering my questions. You can also ask me questions."
                }
        ]
    },
    {
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "Does the animal in the first image could live in what is describe in the second image ?"
            },
            {
                "type": "image_url",
                "image_url": {
                "url": "https://some-urls"
                }
            },
            {
                "type": "image_url",
                "image_url": {
                    "url": "https://some-urls"
                }
            }
        ]
    },
    {
        "role": "assistant",
        "content": [
            {
                "type": "text",
                "text": "Some response from Pixtral."
            }
        ]
    },
    {
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "What time is it ?"
            }
        ]
    }
]
```


This MR adds `TextChunk` as possible content type for the `AssistantMessage` class.
