### PR TITLE
Cover Edge Case: Empty array instead of None for Assistant tool calls

### DIFF
--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -117,7 +117,7 @@ class InstructRequestNormalizer(
         weight: Optional[float] = None
         for message in messages:
             assert isinstance(message, self._assistant_message_class), "Expected assistant message"
-            if message.tool_calls is not None:
+            if message.tool_calls:
                 for tool_call in message.tool_calls:
                     normalized_tool_call = self._normalize_tool_call(tool_call)
                     tool_calls.append(normalized_tool_call)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -293,6 +293,10 @@ class TestChatCompletionRequestNormalization:
         normalized = normalizer.from_chat_completion_request(request)
         assert normalized == gt
 
+    def test_normalize_empty_array_tool_calls(self, normalizer: InstructRequestNormalizer) -> None:
+        message = AssistantMessage(role="assistant", content="Hello", tool_calls=[])
+        normalized_message = normalizer._aggregate_assistant_messages([message])
+        assert normalized_message.content == "Hello"
 
 class TestFineTuningNormalizer:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
Hey didn't see any contributing guidelines so let me know if I can clean up this PR more 

Adding an empty array check for assistant message normalization to account for a bug I had encountered working with langchain AIMessage default behavior (but also could be a valid edge case working purely with mistral). 

When passing an assistant message to normalizer, if the assistant message has `[]` as tool calls instead of `None`, the content will not be added to the message. Having a message with `content = None` causes errors on chat serving endpoints downstream e.g. vLLM

### Current Behavior: 
```python
# relevant snippet
            if message.tool_calls is not None:
                for tool_call in message.tool_calls:
                    normalized_tool_call = self._normalize_tool_call(tool_call)
                    tool_calls.append(normalized_tool_call)
            elif message.content:
                aggregated_content.append(self._aggregate_content_chunks(message.content))
```

```python
# test code
      message = AssistantMessage(role="assistant", content="Hello", tool_calls=[])
      normalized_message = normalizer._aggregate_assistant_messages([message])
      assert normalized_message.content == "Hello" # message content will be None, and assertion fails
```
If `[]` is passed to this function, the if statement will evaluate as `True`, making it so that the `elif` statement is skipped and any message content is ignored.

### Proposed behavior
```python
# relevant snippet
            if message.tool_calls: # empty array evaluates to false
                for tool_call in message.tool_calls:
                    normalized_tool_call = self._normalize_tool_call(tool_call)
                    tool_calls.append(normalized_tool_call)
            elif message.content:
                aggregated_content.append(self._aggregate_content_chunks(message.content))
```
If `[]` is passed to this function, the if statement will evaluate as `False`, making it so that the `elif` statement will add its message content.

```python
# test code
      message = AssistantMessage(role="assistant", content="Hello", tool_calls=[])
      normalized_message = normalizer._aggregate_assistant_messages([message])
      assert normalized_message.content == "Hello" # message content Hello and assertion fails
```


Hopefully this helps keep our AI ecosystem bug free 👍  


