### PR TITLE
Remove extra="forbid" from the base pydantic model

### DIFF
--- a/src/mistral_common/base.py
+++ b/src/mistral_common/base.py
@@ -6,4 +6,4 @@ class MistralBase(BaseModel):
     Base class for all Mistral Pydantic models.
     """
 
-    model_config = ConfigDict(extra="forbid", validate_default=True, use_enum_values=True)
+    model_config = ConfigDict(validate_default=True, use_enum_values=True)


### PR DESCRIPTION
Remove the extra="forbid" so extra values are ignored.
Extra values should be ignored for better compatibility and to allow usage with other tools. (for example: serving models with vllm)

see: https://github.com/vllm-project/vllm/issues/12864