### PR TITLE
Change default tekken special token policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mistral_common"
-version = "1.5.4"
+version = "1.5.5"
 description = ""
 authors = ["bam4d <bam4d@mistral.ai>"]
 readme = "README.md"

--- a/src/mistral_common/tokens/tokenizers/tekken.py
+++ b/src/mistral_common/tokens/tokenizers/tekken.py
@@ -150,7 +150,7 @@ class Tekkenizer(Tokenizer):
         self._all_special_tokens = special_tokens
         self._special_tokens_reverse_vocab = {t["token_str"]: t["rank"] for t in special_tokens}
         self._vocab = [self.id_to_piece(i) for i in range(vocab_size)]
-        self._special_token_policy = SpecialTokenPolicy.RAISE
+        self._special_token_policy = SpecialTokenPolicy.IGNORE
 
     @classmethod
     def from_file(cls: Type["Tekkenizer"], path: Union[str, Path]) -> "Tekkenizer":


### PR DESCRIPTION
I changed the default tekken special token policy so that it works smoothly with transformers.

I also moved up the version so that the next releases can make use of this.