### PR TITLE
Add support for file:// protocol URIs.

### DIFF
--- a/src/mistral_common/tokens/tokenizers/multimodal.py
+++ b/src/mistral_common/tokens/tokenizers/multimodal.py
@@ -48,6 +48,8 @@ def image_from_chunk(chunk: Union[ImageURLChunk, ImageChunk]) -> SerializableIma
         data = chunk.get_url().split(",")[1]
         image_data = base64.b64decode(data)
         return Image.open(BytesIO(image_data))
+    if chunk.get_url().startswith("file"):
+        return Image.open(open(chunk.get_url().replace("file://", ""),'rb'))
     if chunk.get_url().startswith("http"):
         return download_image(chunk.get_url())
 

--- a/src/mistral_common/tokens/tokenizers/multimodal.py
+++ b/src/mistral_common/tokens/tokenizers/multimodal.py
@@ -49,7 +49,7 @@ def image_from_chunk(chunk: Union[ImageURLChunk, ImageChunk]) -> SerializableIma
         image_data = base64.b64decode(data)
         return Image.open(BytesIO(image_data))
     if chunk.get_url().startswith("file"):
-        return Image.open(open(chunk.get_url().replace("file://", ""),'rb'))
+        return Image.open(open(chunk.get_url().replace("file://", ""), "rb"))
     if chunk.get_url().startswith("http"):
         return download_image(chunk.get_url())
 


### PR DESCRIPTION
vLLM supports `file://` urls, but it fails without this when using the Mistral tokenizer. You may wish to place additional security machinery around this; in vLLM, one must pass `--allowed-local-media-path` on the commandline.