### PR TITLE
Add check for uv lock

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -37,6 +37,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
+      
+      - name: Check uv lock
+        run: |
+          uv lock --check
 
       # Install
       - name: Install Dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "mistral-common"
-version = "1.6.0"
+version = "1.5.6"
 source = { virtual = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
We recently introduced uv but didn't enforce check of the uv.lock file using `uv lock --check` which might cause problem.

For example, it wasn't updated by me to remove a change version that didn't occur for now.

This PR enforces the check.