### PR TITLE
Add the from_hf_hub method to MistralTokenizer

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -45,7 +45,7 @@ jobs:
       # Install
       - name: Install Dependencies
         run: |
-          uv sync --frozen --extra opencv --group dev
+          uv sync --frozen --extra opencv --extra hf-hub --group dev
           uv pip install --editable .
 
       # Ruff Linter

--- a/docs/usage/tokenizers.md
+++ b/docs/usage/tokenizers.md
@@ -14,6 +14,30 @@ Historically, we based our tokenizers on the following libraries:
 For our releases, we provide a tokenizer file that you can use to load a tokenizer. If the tokenizer is based on the `tiktoken` library, the file is generally named `tekken.json`. Here is how you could load the [Devstral Small](https://huggingface.co/mistralai/Devstral-Small-2505)'s tokenizer:
 
 ```python
+from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+
+tokenizer = MistralTokenizer.from_hf_hub("mistralai/Devstral-Small-2505", token="your_hf_token")
+
+chat_completion = ChatCompletionRequest(
+    messages=[
+        UserMessage(role="user", content="Hello, how are you?"),
+    ]
+)
+tokenizer.encode_chat_completion(chat_completion).tokens
+# [1, 3, 22177, 1044, 2606, 1584, 1636, 1063, 4]
+```
+
+We provide three layer of abstraction for our tokenizers:
+
+- [Tekkenizer][mistral_common.tokens.tokenizers.tekken.Tekkenizer] or [SentencePieceTokenizer][mistral_common.tokens.tokenizers.sentencepiece.SentencePieceTokenizer]: raw tokenizers to handle raw data to convert them into ids and vice versa.
+- [InstructTokenizer][mistral_common.tokens.tokenizers.instruct.InstructTokenizer]: instruct tokenizers that wrap the raw tokenizers to add several helper methods for the different tasks (chat completion or FIM). They are versioned.
+- [MistralTokenizer][mistral_common.tokens.tokenizers.mistral.MistralTokenizer]: mistral tokenizers that validate the requests, see [requests section](./requests.md), and call the instruct tokenizers.
+
+For instance, you can directly load the [Tekkenizer][mistral_common.tokens.tokenizers.tekken.Tekkenizer]:
+
+```python
 from huggingface_hub import hf_hub_download
 
 from mistral_common.tokens.tokenizers.tekken  import Tekkenizer
@@ -25,11 +49,5 @@ tokenizer = Tekkenizer.from_file(tekken_file)
 tokenizer.encode("Plz tekkenize me", bos=True, eos=True)
 # [1, 4444, 1122, 16058, 3569, 2033, 1639, 2]
 ```
-
-We provide three layer of abstraction for our tokenizers:
-
-- [Tekkenizer][mistral_common.tokens.tokenizers.tekken.Tekkenizer] or [SentencePieceTokenizer][mistral_common.tokens.tokenizers.sentencepiece.SentencePieceTokenizer]: raw tokenizers to handle raw data to convert them into ids and vice versa.
-- [InstructTokenizer][mistral_common.tokens.tokenizers.instruct.InstructTokenizer]: instruct tokenizers that wrap the raw tokenizers to add several helper methods for the different tasks (chat completion or FIM). They are versioned.
-- [MistralTokenizer][mistral_common.tokens.tokenizers.mistral.MistralTokenizer]: mistral tokenizers that validate the requests, see [requests section](./requests.md), and call the instruct tokenizers.
 
 See the [Examples section](../examples/index.md) for examples on how to use the tokenizers with our models.

--- a/docs/usage/tokenizers.md
+++ b/docs/usage/tokenizers.md
@@ -11,14 +11,14 @@ Historically, we based our tokenizers on the following libraries:
 
 ## Tokenizer
 
-For our releases, we provide a tokenizer file that you can use to load a tokenizer. If the tokenizer is based on the `tiktoken` library, the file is generally named `tekken.json`. Here is how you could load the [Devstral Small](https://huggingface.co/mistralai/Devstral-Small-2505)'s tokenizer:
+For our releases, we provide a tokenizer file that you can use to load a tokenizer. If the tokenizer is based on the `tiktoken` library, the file is generally named `tekken.json`. Here is how you could load the [Mistral Small 3.1 Instruct](https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503)'s tokenizer:
 
 ```python
 from mistral_common.protocol.instruct.messages import UserMessage
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
-tokenizer = MistralTokenizer.from_hf_hub("mistralai/Devstral-Small-2505", token="your_hf_token")
+tokenizer = MistralTokenizer.from_hf_hub("mistralai/Mistral-Small-3.1-24B-Instruct-2503", token="your_hf_token")
 
 chat_completion = ChatCompletionRequest(
     messages=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-opencv = ["opencv-python-headless>=4.0.0" ]
+opencv = ["opencv-python-headless>=4.0.0"]
+hub = ["huggingface-hub>=0.32.4"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 opencv = ["opencv-python-headless>=4.0.0"]
-hub = ["huggingface-hub>=0.32.4"]
+hf-hub = ["huggingface-hub>=0.32.4"]
 
 [dependency-groups]
 dev = [

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -197,6 +197,14 @@ class MistralTokenizer(
         r"""Get the Mistral tokenizer for a given Hugging Face model ID.
 
         See [Models](../../../../models.md) for a list of supported models.
+
+        Args:
+            model_id: The Hugging Face model ID.
+                See [Models](../../../../models.md) for a list of supported models.
+            kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
+
+        Returns:
+            The Mistral tokenizer for the given model.
         """
         tokenizer_path = download_tokenizer_from_hf_hub(model_id, **kwargs)
         return MistralTokenizer.from_file(tokenizer_path)

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -47,14 +47,7 @@ from mistral_common.tokens.tokenizers.sentencepiece import (
     is_sentencepiece,
 )
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer, is_tekken
-
-_hub_installed: bool
-try:
-    import huggingface_hub
-
-    _hub_installed = True
-except ImportError:
-    _hub_installed = False
+from mistral_common.tokens.tokenizers.utils import download_tokenizer_from_hf_hub
 
 
 def load_mm_encoder(
@@ -203,56 +196,9 @@ class MistralTokenizer(
     def from_hf_hub(model_id: str, **kwargs: Any) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer for a given Hugging Face model ID.
 
-        Note:
-            You need to install the `huggingface_hub` package to use this method.
-            please run `pip install huggingface_hub` to install it.
-
-        Args:
-            model_id: The Hugging Face model ID.
-                See [Models](../../../../models.md) for a list of supported models.
-            kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
-
-        Returns:
-            The Mistral tokenizer for the given model ID.
+        See [Models](../../../../models.md) for a list of supported models.
         """
-        if not _hub_installed:
-            raise ImportError(
-                "Please install the `huggingface_hub` package to use this method.\n"
-                "Run `pip install huggingface_hub` to install it."
-            )
-
-        model_id_to_tokenizer_file: Dict[str, str] = {
-            "mistralai/Mistral-7B-v0.1": "tokenizer.model",
-            "mistralai/Mistral-7B-Instruct-v0.1": "tokenizer.model.v1",
-            "mistralai/Mixtral-8x7B-v0.1": "tokenizer.model",
-            "mistralai/Mixtral-8x7B-Instruct-v0.1": "tokenizer.model",
-            "mistralai/Mistral-7B-Instruct-v0.2": "tokenizer.model",
-            "mistralai/Mixtral-8x22B-v0.1": "tokenizer.model.v1",
-            "mistralai/Mixtral-8x22B-Instruct-v0.1": "tokenizer.model.v3",
-            "mistralai/Mistral-7B-v0.3": "tokenizer.model.v3",
-            "mistralai/Mistral-7B-Instruct-v0.3": "tokenizer.model.v3",
-            "mistralai/Codestral-22B-v0.1": "tokenizer.model.v3",
-            "mistralai/Mathstral-7B-v0.1": "tokenizer.model.v3",
-            "mistralai/Mamba-Codestral-7B-v0.1": "tokenizer.model.v3",
-            "mistralai/Mistral-Nemo-Base-2407": "tekken.json",
-            "mistralai/Mistral-Nemo-Instruct-2407": "tekken.json",
-            "mistralai/Mistral-Large-Instruct-2407": "tokenizer.model.v3",
-            "mistralai/Pixtral-12B-Base-2409": "tekken.json",
-            "mistralai/Pixtral-12B-2409": "tekken.json",
-            "mistralai/Mistral-Large-Instruct-2411": "tokenizer.model.v7",
-            "mistralai/Pixtral-Large-Instruct-2411": "tokenizer.model.v7m1",
-            "mistralai/Mistral-Small-24B-Base-2501": "tekken.json",
-            "mistralai/Mistral-Small-24B-Instruct-2501": "tekken.json",
-            "mistralai/Mistral-Small-3.1-24B-Base-2503": "tekken.json",
-            "mistralai/Mistral-Small-3.1-24B-Instruct-2503": "tekken.json",
-            "mistralai/Devstral-Small-2505": "tekken.json",
-        }
-
-        if model_id not in model_id_to_tokenizer_file:
-            raise TokenizerException(f"Unrecognized model ID: {model_id}")
-
-        tokenizer_file = model_id_to_tokenizer_file[model_id]
-        tokenizer_path = huggingface_hub.hf_hub_download(repo_id=model_id, filename=tokenizer_file, **kwargs)
+        tokenizer_path = download_tokenizer_from_hf_hub(model_id, **kwargs)
         return MistralTokenizer.from_file(tokenizer_path)
 
     @classmethod

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -209,7 +209,7 @@ class MistralTokenizer(
 
         Args:
             model_id: The Hugging Face model ID.
-               See [Models](../models.md) for a list of supported models.
+                See [Models](../../../../models.md) for a list of supported models.
             kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
 
         Returns:

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -196,11 +196,10 @@ class MistralTokenizer(
     def from_hf_hub(model_id: str, **kwargs: Any) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer for a given Hugging Face model ID.
 
-        See [Models](../../../../models.md) for a list of supported models.
+        See [here](../../../../models.md#list-of-open-models) for a list of our OSS models.
 
         Args:
             model_id: The Hugging Face model ID.
-                See [Models](../../../../models.md) for a list of supported models.
             kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
 
         Returns:

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -28,7 +28,10 @@ def is_sentencepiece(path: Union[str, Path]) -> bool:
 
 def get_spm_version(tokenizer_filename: str, raise_deprecated: bool = False) -> TokenizerVersion:
     r"""Get the version of the tokenizer from the filename."""
-    _version_str = tokenizer_filename.split(".")[-1].split("m")[0]
+    _version_str = tokenizer_filename.split(".")[-1]
+    if _version_str != "model": # filter tokenizer_filename == "/path/to/tokenizer.model" case
+        _version_str = _version_str.split("m")[0]
+
     if _version_str == "model":
         if raise_deprecated:
             raise TokenizerException(f"Make sure to rename your tokenizer file to end with {tokenizer_filename}.v1.")
@@ -45,7 +48,7 @@ def get_spm_version(tokenizer_filename: str, raise_deprecated: bool = False) -> 
 def get_mm_config(tokenizer_filename: str) -> Optional[MultimodalConfig]:
     r"""Get the multimodal config from the tokenizer filename."""
     _version_str = tokenizer_filename.split(".")[-1]
-    if "m" not in _version_str:
+    if _version_str == "model" or "m" not in _version_str:
         return None
 
     _mm_version_str = "m" + _version_str.split("m")[-1]

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -29,7 +29,7 @@ def is_sentencepiece(path: Union[str, Path]) -> bool:
 def get_spm_version(tokenizer_filename: str, raise_deprecated: bool = False) -> TokenizerVersion:
     r"""Get the version of the tokenizer from the filename."""
     _version_str = tokenizer_filename.split(".")[-1]
-    if _version_str != "model": # filter tokenizer_filename == "/path/to/tokenizer.model" case
+    if _version_str != "model":  # filter tokenizer_filename == "/path/to/tokenizer.model" case
         _version_str = _version_str.split("m")[0]
 
     if _version_str == "model":

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -31,15 +31,15 @@ def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
 def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
     r"""Download the configuration file of an official Mistral tokenizer from the Hugging Face Hub.
 
-    See [Models](../../../../models.md) for a list of supported models.
+    See [here](../../../../models.md#list-of-open-models) for a list of our OSS models.
 
     Note:
         You need to install the `huggingface_hub` package to use this method.
-        please run `pip install mistral-common[hf-hub]` to install it.
+
+        Please run `pip install mistral-common[hf-hub]` to install it.
 
     Args:
         model_id: The Hugging Face model ID.
-            See [Models](../../../../models.md) for a list of supported models.
         kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
 
     Returns:

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, Iterator, List
 
-from mistral_common.exceptions import TokenizerException
-
 _hub_installed: bool
 try:
     import huggingface_hub
@@ -52,7 +50,7 @@ def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
         )
 
     if model_id not in MODEL_HF_ID_TO_TOKENIZER_FILE:
-        raise TokenizerException(f"Unrecognized model ID: {model_id}")
+        raise ValueError(f"Unrecognized model ID: {model_id}")
 
     tokenizer_file = MODEL_HF_ID_TO_TOKENIZER_FILE[model_id]
     tokenizer_path = huggingface_hub.hf_hub_download(repo_id=model_id, filename=tokenizer_file, **kwargs)

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -29,7 +29,7 @@ def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
 
 
 def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
-    r"""Download a Mistral tokenizer from the Hugging Face Hub.
+    r"""Download the configuration file of an official Mistral tokenizer from the Hugging Face Hub.
 
     See [Models](../../../../models.md) for a list of supported models.
 
@@ -43,7 +43,7 @@ def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
         kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
 
     Returns:
-        The Mistral tokenizer local path for the given model ID.
+        The downloaded tokenizer local path for the given model ID.
     """
     if not _hub_installed:
         raise ImportError(

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -1,4 +1,14 @@
-from typing import Iterator, List
+from typing import Any, Dict, Iterator, List
+
+from mistral_common.exceptions import TokenizerException
+
+_hub_installed: bool
+try:
+    import huggingface_hub
+
+    _hub_installed = True
+except ImportError:
+    _hub_installed = False
 
 
 def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
@@ -16,3 +26,62 @@ def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
     """
     for i in range(0, len(lst), chunk_size):
         yield lst[i : i + chunk_size]
+
+
+def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
+    r"""Download a Mistral tokenizer from the Hugging Face Hub.
+
+    See [Models](../../../../models.md) for a list of supported models.
+
+    Note:
+        You need to install the `huggingface_hub` package to use this method.
+        please run `pip install mistral-common[hf-hub]` to install it.
+
+    Args:
+        model_id: The Hugging Face model ID.
+            See [Models](../../../../models.md) for a list of supported models.
+        kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
+
+    Returns:
+        The Mistral tokenizer local path for the given model ID.
+    """
+    if not _hub_installed:
+        raise ImportError(
+            "Please install the `huggingface_hub` package to use this method.\n"
+            "Run `pip install mistral-common[hf-hub]` to install it."
+        )
+
+    if model_id not in MODEL_HF_ID_TO_TOKENIZER_FILE:
+        raise TokenizerException(f"Unrecognized model ID: {model_id}")
+
+    tokenizer_file = MODEL_HF_ID_TO_TOKENIZER_FILE[model_id]
+    tokenizer_path = huggingface_hub.hf_hub_download(repo_id=model_id, filename=tokenizer_file, **kwargs)
+    return tokenizer_path
+
+
+MODEL_HF_ID_TO_TOKENIZER_FILE: Dict[str, str] = {
+    "mistralai/Mistral-7B-v0.1": "tokenizer.model",
+    "mistralai/Mistral-7B-Instruct-v0.1": "tokenizer.model.v1",
+    "mistralai/Mixtral-8x7B-v0.1": "tokenizer.model",
+    "mistralai/Mixtral-8x7B-Instruct-v0.1": "tokenizer.model",
+    "mistralai/Mistral-7B-Instruct-v0.2": "tokenizer.model",
+    "mistralai/Mixtral-8x22B-v0.1": "tokenizer.model.v1",
+    "mistralai/Mixtral-8x22B-Instruct-v0.1": "tokenizer.model.v3",
+    "mistralai/Mistral-7B-v0.3": "tokenizer.model.v3",
+    "mistralai/Mistral-7B-Instruct-v0.3": "tokenizer.model.v3",
+    "mistralai/Codestral-22B-v0.1": "tokenizer.model.v3",
+    "mistralai/Mathstral-7B-v0.1": "tokenizer.model.v3",
+    "mistralai/Mamba-Codestral-7B-v0.1": "tokenizer.model.v3",
+    "mistralai/Mistral-Nemo-Base-2407": "tekken.json",
+    "mistralai/Mistral-Nemo-Instruct-2407": "tekken.json",
+    "mistralai/Mistral-Large-Instruct-2407": "tokenizer.model.v3",
+    "mistralai/Pixtral-12B-Base-2409": "tekken.json",
+    "mistralai/Pixtral-12B-2409": "tekken.json",
+    "mistralai/Mistral-Large-Instruct-2411": "tokenizer.model.v7",
+    "mistralai/Pixtral-Large-Instruct-2411": "tokenizer.model.v7m1",
+    "mistralai/Mistral-Small-24B-Base-2501": "tekken.json",
+    "mistralai/Mistral-Small-24B-Instruct-2501": "tekken.json",
+    "mistralai/Mistral-Small-3.1-24B-Base-2503": "tekken.json",
+    "mistralai/Mistral-Small-3.1-24B-Instruct-2503": "tekken.json",
+    "mistralai/Devstral-Small-2505": "tekken.json",
+}

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -49,7 +49,7 @@ class TestMistralToknizer:
             else:
                 raise ValueError(f"Unknown repo_id: {repo_id}")
 
-        with patch("mistral_common.tokens.tokenizers.mistral.huggingface_hub.hf_hub_download", _mocked_hf_download):
+        with patch("mistral_common.tokens.tokenizers.utils.download_tokenizer_from_hf_hub", _mocked_hf_download):
             tokenizer = MistralTokenizer.from_hf_hub("mistralai/Mistral-7B-Instruct-v0.1")
             assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV1)
 

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -56,5 +56,5 @@ class TestMistralToknizer:
             tokenizer = MistralTokenizer.from_hf_hub("mistralai/Pixtral-Large-Instruct-2411")
             assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV7)
 
-            with pytest.raises(TokenizerException):
+            with pytest.raises(ValueError):
                 MistralTokenizer.from_hf_hub("mistralai/unknown-model")

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -8,7 +8,6 @@ from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerV1,
     InstructTokenizerV2,
     InstructTokenizerV3,
-    InstructTokenizerV7,
 )
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -1,3 +1,6 @@
+from typing import Any
+from unittest.mock import patch
+
 import pytest
 
 from mistral_common.exceptions import TokenizerException
@@ -5,6 +8,7 @@ from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerV1,
     InstructTokenizerV2,
     InstructTokenizerV3,
+    InstructTokenizerV7,
 )
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
@@ -35,3 +39,22 @@ class TestMistralToknizer:
 
             assert tokenizer.decode(encoded) == prompt
             assert tokenizer.instruct_tokenizer.decode(encoded) == prompt
+
+    def test_from_hf_hub(self) -> None:
+        def _mocked_hf_download(repo_id: str, *args: Any) -> str:
+            if repo_id == "mistralai/Mistral-7B-Instruct-v0.1":
+                return str(MistralTokenizer._data_path() / "tokenizer.model.v1")
+            elif repo_id == "mistralai/Pixtral-Large-Instruct-2411":
+                return str(MistralTokenizer._data_path() / "tekken_240911.json")
+            else:
+                raise ValueError(f"Unknown repo_id: {repo_id}")
+
+        with patch("mistral_common.tokens.tokenizers.mistral.huggingface_hub.hf_hub_download", _mocked_hf_download):
+            tokenizer = MistralTokenizer.from_hf_hub("mistralai/Mistral-7B-Instruct-v0.1")
+            assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV1)
+
+            tokenizer = MistralTokenizer.from_hf_hub("mistralai/Pixtral-Large-Instruct-2411")
+            assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV7)
+
+            with pytest.raises(TokenizerException):
+                MistralTokenizer.from_hf_hub("mistralai/unknown-model")

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -49,12 +49,12 @@ class TestMistralToknizer:
             else:
                 raise ValueError(f"Unknown repo_id: {repo_id}")
 
-        with patch("mistral_common.tokens.tokenizers.utils.download_tokenizer_from_hf_hub", _mocked_hf_download):
+        with patch("mistral_common.tokens.tokenizers.mistral.download_tokenizer_from_hf_hub", _mocked_hf_download):
             tokenizer = MistralTokenizer.from_hf_hub("mistralai/Mistral-7B-Instruct-v0.1")
             assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV1)
 
             tokenizer = MistralTokenizer.from_hf_hub("mistralai/Pixtral-Large-Instruct-2411")
-            assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV7)
+            assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV3)
 
             with pytest.raises(ValueError):
                 MistralTokenizer.from_hf_hub("mistralai/unknown-model")

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -147,7 +147,15 @@ def test_image_processing(special_token_ids: SpecialImageIDs, size: Tuple[int, i
 
     content = ImageURLChunk(image_url=url)
 
-    image = mm_encoder(content).image
+    RETRY = 10  # sometimes the image download fails, so we retry a few times
+    for i in range(RETRY):
+        try:
+            image = mm_encoder(content).image
+            break
+        except RuntimeError as e:
+            if i == RETRY - 1:
+                raise e
+            continue
 
     assert image.transpose().shape[:2] == EXP_IMG_SIZES[size], image.transpose().shape[:2]
     assert np.abs(image).sum() - EXP_IMG_SUM[size] < 1e-1, np.abs(image).sum()

--- a/uv.lock
+++ b/uv.lock
@@ -304,6 +304,24 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2025.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/f7/27f15d41f0ed38e8fcc488584b57e902b331da7f7c6dcda53721b15838fc/fsspec-2025.5.1.tar.gz", hash = "sha256:2e55e47a540b91843b755e83ded97c6e897fa0942b11490113f09e9c443c2475", size = 303033, upload-time = "2025-05-24T12:03:23.792Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/61/78c7b3851add1481b048b5fdc29067397a1784e2910592bc81bb3f608635/fsspec-2025.5.1-py3-none-any.whl", hash = "sha256:24d3a2e663d5fc735ab256263c4075f374a174c3410c0b25e5bd1970bceaa462", size = 199052, upload-time = "2025-05-24T12:03:21.66Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -325,6 +343,40 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/3e/5aa9a61f7c3c47b0b52a1d930302992229d191bf4bc76447b324b731510a/griffe-1.7.3.tar.gz", hash = "sha256:52ee893c6a3a968b639ace8015bec9d36594961e156e23315c8e8e51401fa50b", size = 395137, upload-time = "2025-04-23T11:29:09.147Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/c6/5c20af38c2a57c15d87f7f38bee77d63c1d2a3689f74fefaf35915dd12b2/griffe-1.7.3-py3-none-any.whl", hash = "sha256:c6b3ee30c2f0f17f30bcdef5068d6ab7a2a4f1b8bf1a3e74b56fffd21e1c5f75", size = 129303, upload-time = "2025-04-23T11:29:07.145Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/dc/dc091aeeb671e71cbec30e84963f9c0202c17337b24b0a800e7d205543e8/hf_xet-1.1.3.tar.gz", hash = "sha256:a5f09b1dd24e6ff6bcedb4b0ddab2d81824098bb002cf8b4ffa780545fa348c3", size = 488127, upload-time = "2025-06-04T00:47:27.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/1f/bc01a4c0894973adebbcd4aa338a06815c76333ebb3921d94dcbd40dae6a/hf_xet-1.1.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c3b508b5f583a75641aebf732853deb058953370ce8184f5dabc49f803b0819b", size = 2256929, upload-time = "2025-06-04T00:47:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/78/07/6ef50851b5c6b45b77a6e018fa299c69a2db3b8bbd0d5af594c0238b1ceb/hf_xet-1.1.3-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:b788a61977fbe6b5186e66239e2a329a3f0b7e7ff50dad38984c0c74f44aeca1", size = 2153719, upload-time = "2025-06-04T00:47:19.302Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/e929e6e3db6e4758c2adf0f2ca2c59287f1b76229d8bdc1a4c9cfc05212e/hf_xet-1.1.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd2da210856444a34aad8ada2fc12f70dabed7cc20f37e90754d1d9b43bc0534", size = 4820519, upload-time = "2025-06-04T00:47:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/28/2e/03f89c5014a5aafaa9b150655f811798a317036646623bdaace25f485ae8/hf_xet-1.1.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8203f52827e3df65981984936654a5b390566336956f65765a8aa58c362bb841", size = 4964121, upload-time = "2025-06-04T00:47:15.17Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8b/5cd399a92b47d98086f55fc72d69bc9ea5e5c6f27a9ed3e0cdd6be4e58a3/hf_xet-1.1.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:30c575a5306f8e6fda37edb866762140a435037365eba7a17ce7bd0bc0216a8b", size = 5283017, upload-time = "2025-06-04T00:47:23.239Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e3/2fcec58d2fcfd25ff07feb876f466cfa11f8dcf9d3b742c07fe9dd51ee0a/hf_xet-1.1.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7c1a6aa6abed1f696f8099aa9796ca04c9ee778a58728a115607de9cc4638ff1", size = 4970349, upload-time = "2025-06-04T00:47:25.383Z" },
+    { url = "https://files.pythonhosted.org/packages/53/bf/10ca917e335861101017ff46044c90e517b574fbb37219347b83be1952f6/hf_xet-1.1.3-cp37-abi3-win_amd64.whl", hash = "sha256:b578ae5ac9c056296bb0df9d018e597c8dc6390c5266f35b5c44696003cde9f3", size = 2310934, upload-time = "2025-06-04T00:47:29.632Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.32.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/c8/4f7d270285c46324fd66f62159eb16739aa5696f422dba57678a8c6b78e9/huggingface_hub-0.32.4.tar.gz", hash = "sha256:f61d45cd338736f59fb0e97550b74c24ee771bcc92c05ae0766b9116abe720be", size = 424494, upload-time = "2025-06-03T09:59:46.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/8b/222140f3cfb6f17b0dd8c4b9a0b36bd4ebefe9fb0098ba35d6960abcda0f/huggingface_hub-0.32.4-py3-none-any.whl", hash = "sha256:37abf8826b38d971f60d3625229221c36e53fe58060286db9baf619cfbf39767", size = 512101, upload-time = "2025-06-03T09:59:44.099Z" },
 ]
 
 [[package]]
@@ -502,6 +554,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+hub = [
+    { name = "huggingface-hub" },
+]
 opencv = [
     { name = "opencv-python-headless" },
 ]
@@ -531,6 +586,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "huggingface-hub", marker = "extra == 'hub'", specifier = ">=0.32.4" },
     { name = "jsonschema", specifier = ">=4.21.1" },
     { name = "numpy", marker = "python_full_version < '3.9'", specifier = ">=1.22,<1.25" },
     { name = "numpy", marker = "python_full_version >= '3.9'", specifier = ">=1.25" },
@@ -542,7 +598,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
-provides-extras = ["opencv"]
+provides-extras = ["opencv", "hub"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1718,6 +1774,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -554,7 +554,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-hub = [
+hf-hub = [
     { name = "huggingface-hub" },
 ]
 opencv = [
@@ -586,7 +586,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "huggingface-hub", marker = "extra == 'hub'", specifier = ">=0.32.4" },
+    { name = "huggingface-hub", marker = "extra == 'hf-hub'", specifier = ">=0.32.4" },
     { name = "jsonschema", specifier = ">=4.21.1" },
     { name = "numpy", marker = "python_full_version < '3.9'", specifier = ">=1.22,<1.25" },
     { name = "numpy", marker = "python_full_version >= '3.9'", specifier = ">=1.25" },
@@ -598,7 +598,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
-provides-extras = ["opencv", "hub"]
+provides-extras = ["opencv", "hf-hub"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add support to download our tokenizers from the HuggingFace hub directly inside `mistral-common`.

This would ease for users the usage of our tokenizers by preventing them to use a specific code snippet.

To access this method they need to install `mistral-common` like this:
```sh
pip install mistral-common[hf-hub]
```
Or install the hub package by themselves.