### PR TITLE
Use HF hub API for download

### DIFF
--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -194,21 +194,21 @@ class MistralTokenizer(
 
     @staticmethod
     def from_hf_hub(
-        model_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
+        repo_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
     ) -> "MistralTokenizer":
-        r"""Get the Mistral tokenizer for a given Hugging Face model ID.
+        r"""Download the Mistral tokenizer for a given Hugging Face repository ID.
 
         See [here](../../../../models.md#list-of-open-models) for a list of our OSS models.
 
         Args:
-            model_id: The Hugging Face model ID.
+            repo_id: The Hugging Face repo ID.
             token: The Hugging Face token to use to download the tokenizer.
             revision: The revision of the model to use. If `None`, the latest revision will be used.
 
         Returns:
             The Mistral tokenizer for the given model.
         """
-        tokenizer_path = download_tokenizer_from_hf_hub(model_id, token=token, revision=revision)
+        tokenizer_path = download_tokenizer_from_hf_hub(repo_id=repo_id, token=token, revision=revision)
         return MistralTokenizer.from_file(tokenizer_path)
 
     @classmethod

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -1,6 +1,6 @@
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, Generic, List, Optional, Union
+from typing import Callable, Dict, Generic, List, Optional, Union
 
 from mistral_common.exceptions import (
     TokenizerException,
@@ -193,19 +193,22 @@ class MistralTokenizer(
         return MODEL_NAME_TO_TOKENIZER_CLS[model]()
 
     @staticmethod
-    def from_hf_hub(model_id: str, **kwargs: Any) -> "MistralTokenizer":
+    def from_hf_hub(
+        model_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
+    ) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer for a given Hugging Face model ID.
 
         See [here](../../../../models.md#list-of-open-models) for a list of our OSS models.
 
         Args:
             model_id: The Hugging Face model ID.
-            kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
+            token: The Hugging Face token to use to download the tokenizer.
+            revision: The revision of the model to use. If `None`, the latest revision will be used.
 
         Returns:
             The Mistral tokenizer for the given model.
         """
-        tokenizer_path = download_tokenizer_from_hf_hub(model_id, **kwargs)
+        tokenizer_path = download_tokenizer_from_hf_hub(model_id, token=token, revision=revision)
         return MistralTokenizer.from_file(tokenizer_path)
 
     @classmethod

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -34,9 +34,9 @@ def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
 
 
 def download_tokenizer_from_hf_hub(
-    model_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
+    repo_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
 ) -> str:
-    r"""Download the configuration file of an official Mistral tokenizer from the Hugging Face Hub.
+    r"""Download the tokenizer file of a Mistral model from the Hugging Face Hub.
 
     See [here](../../../../models.md#list-of-open-models) for a list of our OSS models.
 
@@ -46,7 +46,7 @@ def download_tokenizer_from_hf_hub(
         Please run `pip install mistral-common[hf-hub]` to install it.
 
     Args:
-        model_id: The Hugging Face model ID.
+        repo_id: The Hugging Face repo ID.
         token: The Hugging Face token to use to download the tokenizer.
         revision: The revision of the model to use. If `None`, the latest revision will be used.
 
@@ -60,7 +60,7 @@ def download_tokenizer_from_hf_hub(
         )
 
     hf_api = huggingface_hub.HfApi()
-    repo_files = hf_api.list_repo_files(model_id)
+    repo_files = hf_api.list_repo_files(repo_id)
 
     valid_tokenizer_files = []
     tokenizer_file: str
@@ -79,18 +79,18 @@ def download_tokenizer_from_hf_hub(
             valid_tokenizer_files.append(file_name)
 
     if len(valid_tokenizer_files) == 0:
-        raise ValueError(f"No tokenizer file found for model ID: {model_id}")
+        raise ValueError(f"No tokenizer file found for model ID: {repo_id}")
     # If there are multiple tokenizer files, we use tekken.json if it exists, otherwise the versionned one.
     if len(valid_tokenizer_files) > 1:
         if "tekken.json" in valid_tokenizer_files:
             tokenizer_file = "tekken.json"
         else:
             tokenizer_file = sorted(valid_tokenizer_files)[-1]
-        logger.warning(f"Multiple tokenizer files found for model ID: {model_id}. Using {tokenizer_file}.")
+        logger.warning(f"Multiple tokenizer files found for model ID: {repo_id}. Using {tokenizer_file}.")
     else:
         tokenizer_file = valid_tokenizer_files[0]
 
     tokenizer_path = huggingface_hub.hf_hub_download(
-        repo_id=model_id, filename=tokenizer_file, token=token, revision=revision
+        repo_id=repo_id, filename=tokenizer_file, token=token, revision=revision
     )
     return tokenizer_path

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, Iterator, List
+from typing import Iterator, List, Optional, Union
 
 from mistral_common.tokens.tokenizers.base import TokenizerVersion
 from mistral_common.tokens.tokenizers.multimodal import MultiModalVersion
@@ -33,7 +33,9 @@ def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
         yield lst[i : i + chunk_size]
 
 
-def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
+def download_tokenizer_from_hf_hub(
+    model_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
+) -> str:
     r"""Download the configuration file of an official Mistral tokenizer from the Hugging Face Hub.
 
     See [here](../../../../models.md#list-of-open-models) for a list of our OSS models.
@@ -45,7 +47,8 @@ def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
 
     Args:
         model_id: The Hugging Face model ID.
-        kwargs: Additional keyword arguments to pass to `huggingface_hub.hf_hub_download`.
+        token: The Hugging Face token to use to download the tokenizer.
+        revision: The revision of the model to use. If `None`, the latest revision will be used.
 
     Returns:
         The downloaded tokenizer local path for the given model ID.
@@ -87,5 +90,7 @@ def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
     else:
         tokenizer_file = valid_tokenizer_files[0]
 
-    tokenizer_path = huggingface_hub.hf_hub_download(repo_id=model_id, filename=tokenizer_file, **kwargs)
+    tokenizer_path = huggingface_hub.hf_hub_download(
+        repo_id=model_id, filename=tokenizer_file, token=token, revision=revision
+    )
     return tokenizer_path

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -1,4 +1,9 @@
-from typing import Any, Dict, Iterator, List
+import logging
+from pathlib import Path
+from typing import Any, Iterator, List
+
+from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from mistral_common.tokens.tokenizers.multimodal import MultiModalVersion
 
 _hub_installed: bool
 try:
@@ -7,6 +12,8 @@ try:
     _hub_installed = True
 except ImportError:
     _hub_installed = False
+
+logger = logging.getLogger(__name__)
 
 
 def chunks(lst: List[str], chunk_size: int) -> Iterator[List[str]]:
@@ -49,37 +56,36 @@ def download_tokenizer_from_hf_hub(model_id: str, **kwargs: Any) -> str:
             "Run `pip install mistral-common[hf-hub]` to install it."
         )
 
-    if model_id not in MODEL_HF_ID_TO_TOKENIZER_FILE:
-        raise ValueError(f"Unrecognized model ID: {model_id}")
+    hf_api = huggingface_hub.HfApi()
+    repo_files = hf_api.list_repo_files(model_id)
 
-    tokenizer_file = MODEL_HF_ID_TO_TOKENIZER_FILE[model_id]
+    valid_tokenizer_files = []
+    tokenizer_file: str
+
+    instruct_versions = list(TokenizerVersion.__members__)
+    mm_versions = list(MultiModalVersion.__members__) + [""]  # allow no mm version
+    sentencepiece_suffixes = [f".model.{v}{m}" for v in instruct_versions for m in mm_versions] + [".model"]
+
+    for repo_file in repo_files:
+        pathlib_repo_file = Path(repo_file)
+        file_name = pathlib_repo_file.name
+        suffix = "".join(pathlib_repo_file.suffixes)
+        if file_name == "tekken.json":
+            valid_tokenizer_files.append(file_name)
+        elif suffix in sentencepiece_suffixes:
+            valid_tokenizer_files.append(file_name)
+
+    if len(valid_tokenizer_files) == 0:
+        raise ValueError(f"No tokenizer file found for model ID: {model_id}")
+    # If there are multiple tokenizer files, we use tekken.json if it exists, otherwise the versionned one.
+    if len(valid_tokenizer_files) > 1:
+        if "tekken.json" in valid_tokenizer_files:
+            tokenizer_file = "tekken.json"
+        else:
+            tokenizer_file = sorted(valid_tokenizer_files)[-1]
+        logger.warning(f"Multiple tokenizer files found for model ID: {model_id}. Using {tokenizer_file}.")
+    else:
+        tokenizer_file = valid_tokenizer_files[0]
+
     tokenizer_path = huggingface_hub.hf_hub_download(repo_id=model_id, filename=tokenizer_file, **kwargs)
     return tokenizer_path
-
-
-MODEL_HF_ID_TO_TOKENIZER_FILE: Dict[str, str] = {
-    "mistralai/Mistral-7B-v0.1": "tokenizer.model",
-    "mistralai/Mistral-7B-Instruct-v0.1": "tokenizer.model.v1",
-    "mistralai/Mixtral-8x7B-v0.1": "tokenizer.model",
-    "mistralai/Mixtral-8x7B-Instruct-v0.1": "tokenizer.model",
-    "mistralai/Mistral-7B-Instruct-v0.2": "tokenizer.model",
-    "mistralai/Mixtral-8x22B-v0.1": "tokenizer.model.v1",
-    "mistralai/Mixtral-8x22B-Instruct-v0.1": "tokenizer.model.v3",
-    "mistralai/Mistral-7B-v0.3": "tokenizer.model.v3",
-    "mistralai/Mistral-7B-Instruct-v0.3": "tokenizer.model.v3",
-    "mistralai/Codestral-22B-v0.1": "tokenizer.model.v3",
-    "mistralai/Mathstral-7B-v0.1": "tokenizer.model.v3",
-    "mistralai/Mamba-Codestral-7B-v0.1": "tokenizer.model.v3",
-    "mistralai/Mistral-Nemo-Base-2407": "tekken.json",
-    "mistralai/Mistral-Nemo-Instruct-2407": "tekken.json",
-    "mistralai/Mistral-Large-Instruct-2407": "tokenizer.model.v3",
-    "mistralai/Pixtral-12B-Base-2409": "tekken.json",
-    "mistralai/Pixtral-12B-2409": "tekken.json",
-    "mistralai/Mistral-Large-Instruct-2411": "tokenizer.model.v7",
-    "mistralai/Pixtral-Large-Instruct-2411": "tokenizer.model.v7m1",
-    "mistralai/Mistral-Small-24B-Base-2501": "tekken.json",
-    "mistralai/Mistral-Small-24B-Instruct-2501": "tekken.json",
-    "mistralai/Mistral-Small-3.1-24B-Base-2503": "tekken.json",
-    "mistralai/Mistral-Small-3.1-24B-Instruct-2503": "tekken.json",
-    "mistralai/Devstral-Small-2505": "tekken.json",
-}

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -56,4 +56,3 @@ class TestMistralToknizer:
 
             tokenizer = MistralTokenizer.from_hf_hub("mistralai/Pixtral-Large-Instruct-2411")
             assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV3)
-

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Optional, Union
 from unittest.mock import patch
 
 import pytest
@@ -40,7 +40,9 @@ class TestMistralToknizer:
             assert tokenizer.instruct_tokenizer.decode(encoded) == prompt
 
     def test_from_hf_hub(self) -> None:
-        def _mocked_hf_download(repo_id: str, *args: Any) -> str:
+        def _mocked_hf_download(
+            repo_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
+        ) -> str:
             if repo_id == "mistralai/Mistral-7B-Instruct-v0.1":
                 return str(MistralTokenizer._data_path() / "tokenizer.model.v1")
             elif repo_id == "mistralai/Pixtral-Large-Instruct-2411":
@@ -55,5 +57,3 @@ class TestMistralToknizer:
             tokenizer = MistralTokenizer.from_hf_hub("mistralai/Pixtral-Large-Instruct-2411")
             assert isinstance(tokenizer.instruct_tokenizer, InstructTokenizerV3)
 
-            with pytest.raises(ValueError):
-                MistralTokenizer.from_hf_hub("mistralai/unknown-model")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+from typing import Optional
+from unittest.mock import patch
+
+import huggingface_hub as huggingface_hub
+import pytest
+
+from mistral_common.tokens.tokenizers.utils import download_tokenizer_from_hf_hub
+
+
+@pytest.mark.parametrize(
+    ["files", "expected"],
+    [
+        ([], None),
+        (["unvalid1.txt", "path/to/tekken.json"], "path/to/tekken.json"),
+        (["unvalid1.txt", "tekken.json"], "tekken.json"),
+        (["unvalid1.txt", "sentencepiece.model"], "sentencepiece.model"),
+        (["unvalid1.txt", "sentencepiece.model.v1"], "sentencepiece.model.v1"),
+        (["unvalid1.txt", "sentencepiece.model.v1m1", "sentencepiece.model.v1m1"], "sentencepiece.model.v1m1"),
+        (["unvalid1.txt", "sentencepiece.model", "sentencepiece.model.v1m1"], "sentencepiece.model.v1m1"),
+        (["unvalid1.txt", "unvalid2.txt"], None),
+    ],
+)
+def test_download_tokenizer_from_hf_hub(files: list[str], expected: Optional[str]) -> None:
+    with patch("huggingface_hub.HfApi.list_repo_files", return_value=files):
+        if expected is None:
+            with pytest.raises(ValueError):
+                download_tokenizer_from_hf_hub(model_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
+        else:
+            with patch("huggingface_hub.hf_hub_download", return_value=expected):
+                tokenizer = download_tokenizer_from_hf_hub(
+                    model_id="mistralai/Mistral-7B-v0.1", token=True, revision=None
+                )
+                assert tokenizer == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,10 +24,10 @@ def test_download_tokenizer_from_hf_hub(files: list[str], expected: Optional[str
     with patch("huggingface_hub.HfApi.list_repo_files", return_value=files):
         if expected is None:
             with pytest.raises(ValueError):
-                download_tokenizer_from_hf_hub(model_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
+                download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
         else:
             with patch("huggingface_hub.hf_hub_download", return_value=expected):
                 tokenizer = download_tokenizer_from_hf_hub(
-                    model_id="mistralai/Mistral-7B-v0.1", token=True, revision=None
+                    repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None
                 )
                 assert tokenizer == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from mistral_common.tokens.tokenizers.utils import download_tokenizer_from_hf_hu
         (["unvalid1.txt", "tekken.json"], "tekken.json"),
         (["unvalid1.txt", "sentencepiece.model"], "sentencepiece.model"),
         (["unvalid1.txt", "sentencepiece.model.v1"], "sentencepiece.model.v1"),
-        (["unvalid1.txt", "sentencepiece.model.v1m1", "sentencepiece.model.v1m1"], "sentencepiece.model.v1m1"),
+        (["unvalid1.txt", "sentencepiece.model.v1", "sentencepiece.model.v1m1"], "sentencepiece.model.v1m1"),
         (["unvalid1.txt", "sentencepiece.model", "sentencepiece.model.v1m1"], "sentencepiece.model.v1m1"),
         (["unvalid1.txt", "unvalid2.txt"], None),
     ],


### PR DESCRIPTION
Instead of relying on a dictionary to maintain a mapping between tokenizers and model id, this PR changes the logic to find the right file.