### PR TITLE
Improve hf hub support

### DIFF
--- a/docs/usage/images.md
+++ b/docs/usage/images.md
@@ -48,7 +48,7 @@ from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 model_id = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
 
-tokenizer = MistralTokenizer.from_hub(repo_id=model_id)
+tokenizer = MistralTokenizer.from_hub(repo_id=model_id, token="your_hf_token")
 
 tokenizer.encode_chat_completion(
     ChatCompletionRequest(

--- a/docs/usage/images.md
+++ b/docs/usage/images.md
@@ -47,9 +47,8 @@ from mistral_common.protocol.instruct.request import ChatCompletionRequest
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 model_id = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
-tekken_file = hf_hub_download(repo_id=model_id, filename="tekken.json", token="your_hf_token")
 
-tokenizer = MistralTokenizer.from_file(tekken_file)
+tokenizer = MistralTokenizer.from_hub(repo_id=model_id)
 
 tokenizer.encode_chat_completion(
     ChatCompletionRequest(

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -195,7 +195,10 @@ class MistralTokenizer(
 
     @staticmethod
     def from_hf_hub(
-        repo_id: str, token: Optional[Union[bool, str]] = None, revision: Optional[str] = None
+        repo_id: str,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        mode: ValidationMode = ValidationMode.test,
     ) -> "MistralTokenizer":
         r"""Download the Mistral tokenizer for a given Hugging Face repository ID.
 
@@ -205,12 +208,13 @@ class MistralTokenizer(
             repo_id: The Hugging Face repo ID.
             token: The Hugging Face token to use to download the tokenizer.
             revision: The revision of the model to use. If `None`, the latest revision will be used.
+            mode: The validation mode to use.
 
         Returns:
             The Mistral tokenizer for the given model.
         """
         tokenizer_path = download_tokenizer_from_hf_hub(repo_id=repo_id, token=token, revision=revision)
-        return MistralTokenizer.from_file(tokenizer_path)
+        return MistralTokenizer.from_file(tokenizer_path, mode=mode)
 
     @classmethod
     def from_file(

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -56,7 +56,7 @@ def list_local_hf_repo_files(repo_id: str, revision: Optional[str]) -> list[str]
     )
 
     if revision is None:
-        revision_file = repo_cache / "refs" / "main"
+        revision_file = repo_cache / "refs" / huggingface_hub.constants.DEFAULT_REVISION
         if revision_file.is_file():
             with revision_file.open("r") as file:
                 revision = file.read()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,16 +30,15 @@ def test_list_local_hf_repo_files() -> None:
     hf_cache = _create_temporary_hf_model_cache("mistralai/Mistral-7B-v0.1")
     with patch("huggingface_hub.constants.HF_HUB_CACHE", hf_cache):
         # Test without revision
-        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", None)
+        files = sorted(list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", None))
         assert files == ["file2.txt", "tekken.json"]
 
         # Test with a specific revision
-        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "RANDOM_REVISION")
+        files = sorted(list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "RANDOM_REVISION"))
         assert files == ["file2.txt", "tekken.json"]
 
         # Test with non-existent revision
-        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "non_existent_revision")
-        assert files == []
+        assert list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "non_existent_revision") == []
 
     # Test huggingface_hub not installed
     with patch("mistral_common.tokens.tokenizers.utils._hub_installed", False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,11 +63,11 @@ def test_download_tokenizer_from_hf_hub(files: list[str], expected: Optional[str
     with patch("huggingface_hub.HfApi.list_repo_files", return_value=files):
         if expected is None:
             with pytest.raises(ValueError):
-                download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
+                download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=None, revision=None)
         else:
             with patch("huggingface_hub.hf_hub_download", return_value=expected):
                 tokenizer = download_tokenizer_from_hf_hub(
-                    repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None
+                    repo_id="mistralai/Mistral-7B-v0.1", token=None, revision=None
                 )
                 assert tokenizer == expected
 
@@ -85,10 +85,10 @@ def test_download_tokenizer_from_hf_hub_without_connection(mock_list_repo_files:
 
     # Test with local cache
     with patch("huggingface_hub.constants.HF_HUB_CACHE", hf_cache):
-        tokenizer = download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
+        tokenizer = download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=None, revision=None)
         assert tokenizer == str(hf_cache / "models--mistralai--Mistral-7B-v0.1/snapshots/RANDOM_REVISION/tekken.json")
 
     # Test without local cache
     with patch("mistral_common.tokens.tokenizers.utils.list_local_hf_repo_files", return_value=[]):
         with pytest.raises(ConnectionError):
-            download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
+            download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=None, revision=None)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,18 +14,17 @@ def _create_temporary_hf_model_cache(repo_id: str) -> Path:
     hub_folder = Path(tmp_dir) / "hf_hub"
     model_folder = huggingface_hub.constants.REPO_ID_SEPARATOR.join(["models", *repo_id.split("/")])
 
-    revision_file = hub_folder / model_folder / "refs" / "main"
+    revision_file = hub_folder / model_folder / "refs" / huggingface_hub.constants.DEFAULT_REVISION
     revision_file.parent.mkdir(parents=True, exist_ok=True)
-    revision_file.write_text("main")
+    revision_file.write_text("RANDOM_REVISION")
 
-    revision_folder = hub_folder / model_folder / "snapshots/main/"
+    revision_folder = hub_folder / model_folder / "snapshots" / "RANDOM_REVISION"
     revision_folder.mkdir(parents=True, exist_ok=True)
     (revision_folder / "tekken.json").write_text("{'test': 'test'}")
     (revision_folder / "file2.txt").write_text("test")
     return hub_folder
 
 
-# Test cases
 @patch("huggingface_hub.constants.HF_HUB_CACHE", "/tmp/hf_cache")
 def test_list_local_hf_repo_files() -> None:
     hf_cache = _create_temporary_hf_model_cache("mistralai/Mistral-7B-v0.1")
@@ -35,7 +34,7 @@ def test_list_local_hf_repo_files() -> None:
         assert files == ["file2.txt", "tekken.json"]
 
         # Test with a specific revision
-        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "main")
+        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "RANDOM_REVISION")
         assert files == ["file2.txt", "tekken.json"]
 
         # Test with non-existent revision
@@ -78,6 +77,7 @@ def test_download_tokenizer_from_hf_hub(files: list[str], expected: Optional[str
         with pytest.raises(ImportError):
             list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "test_revision")
 
+
 @patch("huggingface_hub.HfApi.list_repo_files")
 def test_download_tokenizer_from_hf_hub_without_connection(mock_list_repo_files: MagicMock) -> None:
     mock_list_repo_files.side_effect = ConnectionError()
@@ -87,7 +87,7 @@ def test_download_tokenizer_from_hf_hub_without_connection(mock_list_repo_files:
     # Test with local cache
     with patch("huggingface_hub.constants.HF_HUB_CACHE", hf_cache):
         tokenizer = download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
-        assert tokenizer == str(hf_cache / "models--mistralai--Mistral-7B-v0.1/snapshots/main/tekken.json")
+        assert tokenizer == str(hf_cache / "models--mistralai--Mistral-7B-v0.1/snapshots/RANDOM_REVISION/tekken.json")
 
     # Test without local cache
     with patch("mistral_common.tokens.tokenizers.utils.list_local_hf_repo_files", return_value=[]):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,51 @@
+import tempfile
+from pathlib import Path
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import huggingface_hub as huggingface_hub
 import pytest
 
-from mistral_common.tokens.tokenizers.utils import download_tokenizer_from_hf_hub
+from mistral_common.tokens.tokenizers.utils import download_tokenizer_from_hf_hub, list_local_hf_repo_files
+
+
+def _create_temporary_hf_model_cache(repo_id: str) -> Path:
+    tmp_dir = tempfile.mkdtemp()
+    hub_folder = Path(tmp_dir) / "hf_hub"
+    model_folder = huggingface_hub.constants.REPO_ID_SEPARATOR.join(["models", *repo_id.split("/")])
+
+    revision_file = hub_folder / model_folder / "refs" / "main"
+    revision_file.parent.mkdir(parents=True, exist_ok=True)
+    revision_file.write_text("main")
+
+    revision_folder = hub_folder / model_folder / "snapshots/main/"
+    revision_folder.mkdir(parents=True, exist_ok=True)
+    (revision_folder / "tekken.json").write_text("{'test': 'test'}")
+    (revision_folder / "file2.txt").write_text("test")
+    return hub_folder
+
+
+# Test cases
+@patch("huggingface_hub.constants.HF_HUB_CACHE", "/tmp/hf_cache")
+def test_list_local_hf_repo_files() -> None:
+    hf_cache = _create_temporary_hf_model_cache("mistralai/Mistral-7B-v0.1")
+    with patch("huggingface_hub.constants.HF_HUB_CACHE", hf_cache):
+        # Test without revision
+        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", None)
+        assert files == ["file2.txt", "tekken.json"]
+
+        # Test with a specific revision
+        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "main")
+        assert files == ["file2.txt", "tekken.json"]
+
+        # Test with non-existent revision
+        files = list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "non_existent_revision")
+        assert files == []
+
+    # Test huggingface_hub not installed
+    with patch("mistral_common.tokens.tokenizers.utils._hub_installed", False):
+        with pytest.raises(ImportError):
+            list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "test_revision")
 
 
 @pytest.mark.parametrize(
@@ -31,3 +72,24 @@ def test_download_tokenizer_from_hf_hub(files: list[str], expected: Optional[str
                     repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None
                 )
                 assert tokenizer == expected
+
+    # Test huggingface_hub not installed
+    with patch("mistral_common.tokens.tokenizers.utils._hub_installed", False):
+        with pytest.raises(ImportError):
+            list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "test_revision")
+
+@patch("huggingface_hub.HfApi.list_repo_files")
+def test_download_tokenizer_from_hf_hub_without_connection(mock_list_repo_files: MagicMock) -> None:
+    mock_list_repo_files.side_effect = ConnectionError()
+
+    hf_cache = _create_temporary_hf_model_cache("mistralai/Mistral-7B-v0.1")
+
+    # Test with local cache
+    with patch("huggingface_hub.constants.HF_HUB_CACHE", hf_cache):
+        tokenizer = download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)
+        assert tokenizer == str(hf_cache / "models--mistralai--Mistral-7B-v0.1/snapshots/main/tekken.json")
+
+    # Test without local cache
+    with patch("mistral_common.tokens.tokenizers.utils.list_local_hf_repo_files", return_value=[]):
+        with pytest.raises(ConnectionError):
+            download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=True, revision=None)


### PR DESCRIPTION
Add the possibility to load tokenizer without internet connection.

Add `mode` argument to allow different normalization of requests.