### PR TITLE
Fix the Python badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/mistral-common?label=release&logo=pypi&logoColor=white)](https://pypi.org/project/mistral-common/)
 [![Tests](https://img.shields.io/github/actions/workflow/status/mistralai/mistral-common/lint_build_test.yaml?label=tests&branch=main)](https://github.com/mistralai/mistral-common/actions/workflows/lint_build_test.yaml)
 [![Documentation](https://img.shields.io/website?url=https%3A%2F%2Fmistralai.github.io%2Fmistral-common%2F&up_message=online&down_message=offline&label=docs)](https://mistralai.github.io/mistral-common/)
-[![Python version](https://img.shields.io/pypi/pyversions/mistral-common?color=blue&logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![Python version](https://img.shields.io/badge/dynamic/json?query=info.requires_python&label=python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fmistral-common%2Fjson)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENCE)
 
 </div>


### PR DESCRIPTION
Currently the badge of Python versions shows like this [![Python version](https://img.shields.io/pypi/pyversions/mistral-common?color=blue&logo=python&logoColor=white)](https://www.python.org/downloads/). This is due to the fact that I didn't specify in the `pyproject.toml` file the classifiers but only `requires_python` and I missed that before the release.

As it's simpler to just maintain the requires python field, I propose to read directly the field to create the badge. 

so it would be now
[![Python version](https://img.shields.io/badge/dynamic/json?query=info.requires_python&label=python&url=https%3A%2F%2Fpypi.org%2Fpypi%2Fmistral-common%2Fjson)](https://www.python.org/downloads/)


