### PR TITLE
Fix error message instructions in transform_image()

### DIFF
--- a/src/mistral_common/tokens/tokenizers/multimodal.py
+++ b/src/mistral_common/tokens/tokenizers/multimodal.py
@@ -141,7 +141,9 @@ def transform_image(image: Image.Image, new_size: Tuple[int, int]) -> np.ndarray
         Transformed image with shape (C, H, W).
     """
     if not is_cv2_installed():
-        raise ImportError("OpenCV is required for this function. Install it with 'pip install mistral_common[opencv]'")
+        raise ImportError(
+            "OpenCV is required for this function. Install it with 'pip install mistral-common[opencv]'"
+        )
 
     np_image = cv2.resize(np.array(_convert_to_rgb(image), dtype=np.float32), new_size, interpolation=cv2.INTER_CUBIC)
     return normalize(np_image, DATASET_MEAN, DATASET_STD)

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -12,7 +12,7 @@ from mistral_common.protocol.instruct.messages import (
     ImageURLChunk,
     TextChunk,
 )
-from mistral_common.tokens.tokenizers.multimodal import ImageEncoder, MultimodalConfig, SpecialImageIDs
+from mistral_common.tokens.tokenizers.multimodal import ImageEncoder, MultimodalConfig, SpecialImageIDs, transform_image
 
 
 @pytest.fixture
@@ -187,3 +187,14 @@ def test_image_encoder_formats(spatial_merge_size: int, special_token_ids: Speci
     for output in outputs[1:]:
         assert (output.image == outputs[0].image).all()
         assert output.tokens == outputs[0].tokens
+
+
+def test_transform_image_missing_cv2(monkeypatch) -> None:
+    img = Image.new("RGB", (10, 10), "red")
+
+    monkeypatch.setattr("mistral_common.tokens.tokenizers.multimodal.is_cv2_installed", lambda: False)
+
+    with pytest.raises(ImportError) as exc_info:
+        transform_image(img, (16, 16))
+
+    assert "pip install mistral-common[opencv]" in str(exc_info.value)


### PR DESCRIPTION
The error message in `transform_image` indicates the user to install `mistral_common` instead of `mistral-common`