### PR TITLE
Opening tekkenizer file with utf-8 and remove deprecation warning

### DIFF
--- a/src/mistral_common/tokens/tokenizers/tekken.py
+++ b/src/mistral_common/tokens/tokenizers/tekken.py
@@ -231,7 +231,7 @@ class Tekkenizer(Tokenizer):
             # Tokenizer > v7 should find special tokens in the tokenizer file
             if version > TokenizerVersion("v7"):
                 raise ValueError(
-                    f"Special tokens not found in {path} and default to {Tekkenizer.DEPRECATED_SPECIAL_TOKENS}. "
+                    f"Special tokens not found in {path}. "
                     "Please update your tokenizer file and include all special tokens you need."
                 )
             else:

--- a/src/mistral_common/tokens/tokenizers/tekken.py
+++ b/src/mistral_common/tokens/tokenizers/tekken.py
@@ -213,7 +213,7 @@ class Tekkenizer(Tokenizer):
         if isinstance(path, str):
             path = Path(path)
         assert path.exists(), path
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             untyped = json.load(f)
 
         _version_str = untyped["config"].get("version")
@@ -228,19 +228,13 @@ class Tekkenizer(Tokenizer):
 
         special_tokens_dicts: Optional[List[SpecialTokenInfo]] = untyped.get("special_tokens", None)
         if special_tokens_dicts is None:
-            err_msg = (
-                f"Special tokens not found in {path} and default to {Tekkenizer.DEPRECATED_SPECIAL_TOKENS}. "
-                "This behavior will be deprecated going forward. "
-                "Please update your tokenizer file and include all special tokens you need."
-            )
             # Tokenizer > v7 should find special tokens in the tokenizer file
             if version > TokenizerVersion("v7"):
-                raise ValueError(err_msg)
-            else:
-                warnings.warn(
-                    err_msg,
-                    FutureWarning,
+                raise ValueError(
+                    f"Special tokens not found in {path} and default to {Tekkenizer.DEPRECATED_SPECIAL_TOKENS}. "
+                    "Please update your tokenizer file and include all special tokens you need."
                 )
+            else:
                 special_tokens = list(Tekkenizer.DEPRECATED_SPECIAL_TOKENS)
         else:
             special_tokens = [token for token in special_tokens_dicts]


### PR DESCRIPTION
Fix #105 as an alternative of https://github.com/mistralai/mistral-common/pull/100

This makes the opening of tekkenizer files with the utf-8 encoder

Also remove the deprecation warning for special tokens because:
- Users mainly take our files
- We released tekkenizer > v7 with special tokens