### PR TITLE
Add v13 tokenizer

### DIFF
--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -213,7 +213,7 @@ class InstructRequestNormalizer(
         else:  # System messages are ignored
             return []
 
-    def _aggregate_messages(self, request: ChatCompletionRequest[UATS]) -> List[UATS]:  # type: ignore
+    def _aggregate_messages(self, request: ChatCompletionRequest[UATS]) -> List[UATS]:
         aggregated_messages: List[UATS] = []
         messages_to_aggregate: List[UATS] = []
         current_role: Optional[Roles] = None
@@ -328,7 +328,7 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
     def _aggregate_system_prompts(self, request: ChatCompletionRequest[UATS]) -> Optional[str]:
         raise NotImplementedError("We should not aggregate system prompts")
 
-    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:  # type: ignore[type-var]
+    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:
         r"""Converts a chat completion request to an instruct request.
 
         Args:
@@ -349,7 +349,7 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
             >>> instruct_request = normalizer.from_chat_completion_request(request)
         """
         messages = self._aggregate_messages(request)
-        return self._instruct_request_class(messages=messages, system_prompt=None, available_tools=request.tools)  # type: ignore[no-any-return]
+        return self._instruct_request_class(messages=messages, system_prompt=None, available_tools=request.tools)
 
 
 class InstructRequestNormalizerV13(InstructRequestNormalizerV7):

--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -328,7 +328,7 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
     def _aggregate_system_prompts(self, request: ChatCompletionRequest[UATS]) -> Optional[str]:
         raise NotImplementedError("We should not aggregate system prompts")
 
-    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:
+    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:  # type: ignore
         r"""Converts a chat completion request to an instruct request.
 
         Args:
@@ -349,7 +349,11 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
             >>> instruct_request = normalizer.from_chat_completion_request(request)
         """
         messages = self._aggregate_messages(request)
-        return self._instruct_request_class(messages=messages, system_prompt=None, available_tools=request.tools)
+        return self._instruct_request_class(  # type: ignore
+            messages=messages,
+            system_prompt=None,
+            available_tools=request.tools,
+        )
 
 
 class InstructRequestNormalizerV13(InstructRequestNormalizerV7):

--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -106,10 +106,11 @@ class InstructRequestNormalizer(
 
         return "\n\n".join(system_prompt) if len(system_prompt) else None
 
-    def _aggregate_tool_messages(self, messages: List[UATS]) -> List[ToolMessageType]:
+    def _aggregate_tool_messages(self, messages: List[UATS], latest_call_ids: List[str]) -> List[ToolMessageType]:
         """
         We currently do not do any aggregation for tool messages, but we normalize the json content
         """
+        # latest_call_ids is not used here
         tool_messages: List[ToolMessageType] = []
         for message in messages:
             assert isinstance(message, self._tool_message_class), "Expected tool message"
@@ -200,9 +201,11 @@ class InstructRequestNormalizer(
 
         return self._user_message_class(content=all_content)
 
-    def _aggregate_role(self, messages: List[UATS], role: Optional[Roles]) -> Sequence[UATS]:
+    def _aggregate_role(
+        self, messages: List[UATS], role: Optional[Roles], latest_call_ids: List[str]
+    ) -> Sequence[UATS]:
         if role == Roles.tool:
-            return self._aggregate_tool_messages(messages)
+            return self._aggregate_tool_messages(messages, latest_call_ids)
         elif role == Roles.assistant:
             return [self._aggregate_assistant_messages(messages)]
         elif role == Roles.user:
@@ -210,24 +213,37 @@ class InstructRequestNormalizer(
         else:  # System messages are ignored
             return []
 
-    def _aggregate_messages(self, request: ChatCompletionRequest[UATS]) -> List[UATS]:
+    def _aggregate_messages(self, request: ChatCompletionRequest[UATS]) -> List[UATS]:  # type: ignore
         aggregated_messages: List[UATS] = []
         messages_to_aggregate: List[UATS] = []
         current_role: Optional[Roles] = None
         current_weight: Optional[float] = None
+        latest_call_ids: List[str] = []
 
         # Collect consecutive lists of messages with the same role and weight
         for message in request.messages:
             new_weight = getattr(message, "weight", None)
             if current_role != message.role or (new_weight != current_weight):
-                aggregated_messages.extend(self._aggregate_role(messages_to_aggregate, current_role))
+                aggregated_messages.extend(self._aggregate_role(messages_to_aggregate, current_role, latest_call_ids))
+
+                if current_role == Roles.assistant:
+                    assistant_message = aggregated_messages[-1]
+                    assert isinstance(aggregated_messages[-1], AssistantMessage)
+                    if assistant_message.tool_calls is not None:
+                        for tool_call in assistant_message.tool_calls:
+                            latest_call_ids.append(tool_call.id)
+
+                elif current_role == Roles.tool:
+                    # reordering only depends on the latest aggregated assistant message
+                    latest_call_ids.clear()
+
                 messages_to_aggregate.clear()
             current_weight = new_weight
             current_role = message.role
             messages_to_aggregate.append(message)
 
         # Add the last set of messages
-        aggregated_messages.extend(self._aggregate_role(messages_to_aggregate, current_role))
+        aggregated_messages.extend(self._aggregate_role(messages_to_aggregate, current_role, latest_call_ids))
 
         # If the first message is not a user message, or we didn't aggregate
         # anything (all system messages) for example, add an empty user message
@@ -294,9 +310,11 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
             InstructRequest[UATS, Tool],
         )
 
-    def _aggregate_role(self, messages: List[UATS], role: Optional[Roles]) -> Sequence[UATS]:
+    def _aggregate_role(
+        self, messages: List[UATS], role: Optional[Roles], latest_call_ids: List[str]
+    ) -> Sequence[UATS]:
         if role == Roles.tool:
-            return self._aggregate_tool_messages(messages)
+            return self._aggregate_tool_messages(messages, latest_call_ids)
         elif role == Roles.assistant:
             return [self._aggregate_assistant_messages(messages)]
         elif role == Roles.user:
@@ -334,6 +352,31 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
         return self._instruct_request_class(messages=messages, system_prompt=None, available_tools=request.tools)  # type: ignore[no-any-return]
 
 
+class InstructRequestNormalizerV13(InstructRequestNormalizerV7):
+    @staticmethod
+    def normalizer() -> "InstructRequestNormalizerV13":
+        return InstructRequestNormalizerV13(
+            UserMessage,
+            AssistantMessage,
+            ToolMessage,
+            SystemMessage,
+            InstructRequest[UATS, Tool],
+        )
+
+    def _aggregate_tool_messages(self, messages: List[UATS], latest_call_ids: List[str]) -> List[ToolMessage]:
+        tool_messages: List[ToolMessage] = super()._aggregate_tool_messages(messages, latest_call_ids)
+        id_to_tool_call_idx = {call_id: idx for idx, call_id in enumerate(latest_call_ids)}
+        id_to_tool_result_idx = {message.tool_call_id: idx for idx, message in enumerate(tool_messages)}
+        # First order by tool call idx and then by tool result idx
+        tool_messages.sort(
+            key=lambda msg: (
+                id_to_tool_call_idx.get(msg.tool_call_id or "null", float("inf")),
+                id_to_tool_result_idx[msg.tool_call_id],
+            ),
+        )
+        return tool_messages
+
+
 def normalizer_for_tokenizer_version(version: TokenizerVersion) -> InstructRequestNormalizer:
     """Gets the appropriate normalizer for the given tokenizer version.
 
@@ -350,4 +393,6 @@ def normalizer_for_tokenizer_version(version: TokenizerVersion) -> InstructReque
         return InstructRequestNormalizer.normalizer()
     elif version in {TokenizerVersion.v7, TokenizerVersion.v11}:
         return InstructRequestNormalizerV7.normalizer()
+    elif version == TokenizerVersion.v13:
+        return InstructRequestNormalizerV13.normalizer()
     raise ValueError(f"Unknown tokenizer version {version}")

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -102,7 +102,8 @@ class TokenizerVersion(str, Enum):
         v2: The second version of the tokenizer that includes special control tokens [INST], [\INST].
         v3: The third version of the tokenizer that includes improved function calling.
         v7: The seventh version of the tokenizer that includes improved system prompt and function calling.
-        v11: The elevnth version of the tokenizer that has improved function calling
+        v11: The eleventh version of the tokenizer that includes improved function calling.
+        v13: The thirteenth version of the tokenizer that includes no call id tokenization and better prompt caching.
 
     Examples:
         >>> version = TokenizerVersion.v1
@@ -141,10 +142,10 @@ class TokenizerVersion(str, Enum):
 
     v1 = "v1"  # vocab_size = 32000
     v2 = "v2"  # vocab_size = 32768 with special control tokens [INST], [\INST]
-    v3 = "v3"  # vocab_size = 32768 (spm) OR 128000 (tekken) with improved function calling
-    v7 = "v7"  # vocab_size = 32768 (spm) or 128000 (tekken) with improved system prompt and function calling
-    v11 = "v11"  # vocab_size = 32768 (spm) or 128000 (tekken) with improved function calling
-    v13 = "v13"  # vocab_size = 32768 (spm) or 128000 (tekken) with no call id and better prompt caching
+    v3 = "v3"  # vocab_size = 32768 (spm) OR 131072 (tekken) with improved function calling
+    v7 = "v7"  # vocab_size = 32768 (spm) or 131072 (tekken) with improved system prompt and function calling
+    v11 = "v11"  # 131072 (tekken) with improved function calling
+    v13 = "v13"  # 131072 (tekken) with no call id and better prompt caching
 
 
 class Tokenized(MistralBase):

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -18,6 +18,13 @@ from mistral_common.tokens.instruct.request import FIMRequest, InstructRequest
 from mistral_common.tokens.tokenizers.image import ImageEncoder
 
 
+class UserMessagePosition(str, Enum):
+    """Where to encode available tools"""
+
+    first = "first"
+    last = "last"
+
+
 class SpecialTokens(str, Enum):
     r"""[DEPRECATED] Enum of special tokens used in the tokenizer.
 
@@ -137,6 +144,7 @@ class TokenizerVersion(str, Enum):
     v3 = "v3"  # vocab_size = 32768 (spm) OR 128000 (tekken) with improved function calling
     v7 = "v7"  # vocab_size = 32768 (spm) or 128000 (tekken) with improved system prompt and function calling
     v11 = "v11"  # vocab_size = 32768 (spm) or 128000 (tekken) with improved function calling
+    v13 = "v13"  # vocab_size = 32768 (spm) or 128000 (tekken) with no call id and better prompt caching
 
 
 class Tokenized(MistralBase):

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -29,6 +29,7 @@ from mistral_common.tokens.tokenizers.base import (
     Tokenized,
     TokenizedType,
     Tokenizer,
+    UserMessagePosition,
 )
 from mistral_common.tokens.tokenizers.image import ImageEncoder
 
@@ -80,7 +81,9 @@ class InstructTokenizerBase(
         return first_user_idx, last_user_idx
 
     @abstractmethod
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> List[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> Tuple[List[int], List[np.ndarray]]:
         r"""Encode a tool message.
 
         Raises:
@@ -148,7 +151,8 @@ class InstructTokenizerBase(
                 )
                 images.extend(new_images)
             elif isinstance(msg, ToolMessage):
-                new_tokens = self.encode_tool_message(msg, msg_idx < last_user_idx)
+                new_tokens, new_images = self.encode_tool_message(msg, msg_idx < last_user_idx)
+                images.extend(new_images)
             elif isinstance(msg, AssistantMessage):
                 continue_message = request.continue_final_message and (msg_idx == len(request.messages) - 1)
 
@@ -273,7 +277,9 @@ class InstructTokenizerV1(
         tokens = self.tokenizer.encode(content, bos=False, eos=False)
         return tokens, []
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> List[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> Tuple[List[int], List[np.ndarray]]:
         r"""Encode a tool message.
 
         Raises:
@@ -328,6 +334,8 @@ class InstructTokenizerV2(
     This tokenizer adds supports to images, tools and FIM requests.
     """
 
+    _message_position_to_encode_tools = UserMessagePosition.last
+
     def __init__(self, tokenizer: Tokenizer, image_encoder: Optional[ImageEncoder] = None):
         r"""Initialize the tokenizer.
 
@@ -370,8 +378,12 @@ class InstructTokenizerV2(
             The encoded tokens and the list of images.
         """
         assert message.content is not None
+        do_encode_tools = False
+        do_encode_tools |= is_first and (self._message_position_to_encode_tools == UserMessagePosition.first)
+        do_encode_tools |= is_last and (self._message_position_to_encode_tools == UserMessagePosition.last)
         tools_tokens: List[int] = []
-        if is_last and available_tools:
+
+        if do_encode_tools and available_tools:
             tools = [tool.model_dump() for tool in available_tools]
             tools_json_tokens = self.tokenizer.encode(json.dumps(tools, ensure_ascii=False), bos=False, eos=False)
             tools_tokens = [
@@ -408,7 +420,9 @@ class InstructTokenizerV2(
             "content": self._parse_json_content(tool_message.content),
         }
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> List[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> Tuple[List[int], List[np.ndarray]]:
         r"""Encode a tool message.
 
         Args:
@@ -421,7 +435,7 @@ class InstructTokenizerV2(
         """
         if is_before_last_user_message:
             # don't tokenize last tool response before last user msg
-            return []
+            return [], []
 
         # Currently only supports single tool results
         tool_result_str = json.dumps([self._prepare_tool_result(message)], ensure_ascii=False)
@@ -430,7 +444,7 @@ class InstructTokenizerV2(
             *self.tokenizer.encode(tool_result_str, bos=False, eos=False),
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, []
 
     def _prepare_function_call(self, tool_call: ToolCall) -> Dict[str, Any]:
         r"""Bit of a hack due to the way function calls are tokenized."""
@@ -553,7 +567,9 @@ class InstructTokenizerV3(
             "call_id": tool_message.tool_call_id,
         }
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> List[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> Tuple[List[int], List[np.ndarray]]:
         r"""Encode a tool message.
 
         Note:
@@ -574,7 +590,7 @@ class InstructTokenizerV3(
             *self.tokenizer.encode(tool_result_str, bos=False, eos=False),
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, []
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
@@ -763,7 +779,9 @@ class InstructTokenizerV7(InstructTokenizerV3):
             force_img_first=force_img_first,
         )
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> List[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> Tuple[List[int], List[np.ndarray]]:
         r"""Encode a tool message.
 
         Note:
@@ -791,7 +809,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
             *tokens,
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, []
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
@@ -865,3 +883,42 @@ class InstructTokenizerV11(InstructTokenizerV7):
                 *self.tokenizer.encode(json.dumps(prepared["arguments"], ensure_ascii=False), bos=False, eos=False),
             ]
         return curr_tokens
+
+
+class InstructTokenizerV13(InstructTokenizerV11):
+    """
+    V13 updates
+        - available tools are tokenized at the first user message
+        - call id is no longer tokenized for tool calls or results
+    """
+
+    _msg_pos_to_enc_tools = UserMessagePosition.first
+
+    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessageType) -> List[int]:
+        assert message.tool_calls, f"Assistant message must have tool calls. Got {message}"
+        curr_tokens = []
+        for tool_call in message.tool_calls:
+            assert tool_call.id and tool_call.id != "null"
+            prepared = self._prepare_function_call(tool_call)
+
+            curr_tokens += [
+                self.TOOL_CALLS,
+                *self.tokenizer.encode(prepared["name"], bos=False, eos=False),
+                self.ARGS,
+                *self.tokenizer.encode(json.dumps(prepared["arguments"], ensure_ascii=False), bos=False, eos=False),
+            ]
+        return curr_tokens
+
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> Tuple[List[int], List[np.ndarray]]:
+        assert message.tool_call_id is not None
+        tokens, images = self.encode_user_content(
+            message.content, is_last=False, system_prompt=None, force_img_first=None
+        )
+        curr_tokens = [
+            self.BEGIN_TOOL_RESULTS,
+            *tokens,
+            self.END_TOOL_RESULTS,
+        ]
+        return curr_tokens, images

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -913,9 +913,7 @@ class InstructTokenizerV13(InstructTokenizerV11):
         self, message: ToolMessage, is_before_last_user_message: bool
     ) -> Tuple[List[int], List[np.ndarray]]:
         assert message.tool_call_id is not None
-        tokens, images = self.encode_user_content(
-            message.content, is_last=False, system_prompt=None, force_img_first=None
-        )
+        tokens, images = self.encode_user_content(message.content, is_last=False)
         curr_tokens = [
             self.BEGIN_TOOL_RESULTS,
             *tokens,

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -889,10 +889,11 @@ class InstructTokenizerV11(InstructTokenizerV7):
 
 
 class InstructTokenizerV13(InstructTokenizerV11):
-    """
-    V13 updates
-        - available tools are tokenized at the first user message
-        - call id is no longer tokenized for tool calls or results
+    r"""Instruct tokenizer V13.
+
+    The difference with V11 tokenizer is that it encodes tool calls differently:
+        - available tools are tokenized at the first user message.
+        - call id is no longer tokenized for tool calls or results.
     """
 
     _msg_pos_to_enc_tools = UserMessagePosition.first
@@ -915,6 +916,14 @@ class InstructTokenizerV13(InstructTokenizerV11):
     def encode_tool_message(
         self, message: ToolMessage, is_before_last_user_message: bool
     ) -> Tuple[List[int], List[np.ndarray]]:
+        r"""Encode a tool message.
+
+        Args:
+            message: The message to encode.
+            is_before_last_user_message: Not used.
+        Returns:
+            The encoded tokens.
+        """
         assert message.tool_call_id is not None
         tokens, images = self.encode_user_content(message.content, is_last=False)
         curr_tokens = [

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -415,6 +415,7 @@ class InstructTokenizerV2(
     def _prepare_tool_result(self, tool_message: ToolMessage) -> Dict[str, Any]:
         r"""Bit of a hack due to the way tool results are tokenized."""
         assert tool_message.content is not None, "Tool message content cannot be None"
+        assert isinstance(tool_message.content, str), "Tool message content must be string"
         return {
             "name": tool_message.name,
             "content": self._parse_json_content(tool_message.content),
@@ -560,6 +561,7 @@ class InstructTokenizerV3(
 
     def _prepare_tool_result(self, tool_message: ToolMessage) -> Dict[str, Any]:
         assert tool_message.content is not None, "Tool message content cannot be None"
+        assert isinstance(tool_message.content, str), "Tool message content must be string"
         assert tool_message.tool_call_id is not None, "Tool message has to have the tool call id defined in v3"
 
         return {
@@ -796,6 +798,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
             The encoded tokens.
         """
         assert message.tool_call_id is not None
+        assert isinstance(message.content, str), "Tool message content must be string"
         tool_call_id_tokens = self.tokenizer.encode(message.tool_call_id, bos=False, eos=False)
         tokens = self.tokenizer.encode(message.content, bos=False, eos=False)
 

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -18,6 +18,7 @@ from mistral_common.protocol.instruct.validator import (
     MistralRequestValidator,
     MistralRequestValidatorV3,
     MistralRequestValidatorV5,
+    MistralRequestValidatorV13,
     ValidationMode,
 )
 from mistral_common.tokens.instruct.request import FIMRequest
@@ -41,6 +42,7 @@ from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerV3,
     InstructTokenizerV7,
     InstructTokenizerV11,
+    InstructTokenizerV13,
 )
 from mistral_common.tokens.tokenizers.sentencepiece import (
     SentencePieceTokenizer,
@@ -304,6 +306,12 @@ class MistralTokenizer(
             return MistralTokenizer(
                 InstructTokenizerV11(tokenizer, image_encoder=image_encoder),
                 validator=MistralRequestValidatorV5(mode=mode),
+                request_normalizer=request_normalizer,
+            )
+        elif tokenizer.version == TokenizerVersion.v13:
+            return MistralTokenizer(
+                InstructTokenizerV13(tokenizer, mm_encoder=mm_encoder),
+                validator=MistralRequestValidatorV13(mode=mode),
                 request_normalizer=request_normalizer,
             )
 

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -310,7 +310,7 @@ class MistralTokenizer(
             )
         elif tokenizer.version == TokenizerVersion.v13:
             return MistralTokenizer(
-                InstructTokenizerV13(tokenizer, mm_encoder=mm_encoder),
+                InstructTokenizerV13(tokenizer, image_encoder=image_encoder),
                 validator=MistralRequestValidatorV13(mode=mode),
                 request_normalizer=request_normalizer,
             )

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -285,6 +285,68 @@ def test_convert_tool_call() -> None:
                 ],
             ),
         ),
+        # Here we test converting image-chunk for assistant. This is not supported by OpenAI,
+        # but we relax it for more flexibility.
+        (
+            OpenAIAssistantMessage(
+                role="assistant",
+                content=[
+                    {"type": "text", "text": "Hi"},
+                    {  # type: ignore[list-item]
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg",
+                            "detail": "auto",
+                        },
+                    },
+                ],
+            ),
+            AssistantMessage(
+                content=[
+                    TextChunk(text="Hi"),
+                    ImageURLChunk(
+                        image_url=ImageURL(
+                            url="https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg",
+                            detail="auto",
+                        )
+                    ),
+                ]
+            ),
+        ),
+        (
+            OpenAIToolMessage(role="tool", content="22", tool_call_id="VvvODy9mT"),
+            ToolMessage(tool_call_id="VvvODy9mT", content="22"),
+        ),
+        # Here we test converting image-chunk for tools. This is not supported by OpenAI,
+        # but we relax it for more flexibility.
+        (
+            OpenAIToolMessage(
+                role="tool",
+                content=[
+                    {"type": "text", "text": "22"},
+                    {  # type: ignore[typeddict-item]
+                        "type": "image_url",  # type: ignore[typeddict-item]
+                        "image_url": {
+                            "url": "https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg",
+                            "detail": "auto",
+                        },
+                    },
+                ],
+                tool_call_id="VvvODy9mT",
+            ),
+            ToolMessage(
+                tool_call_id="VvvODy9mT",
+                content=[
+                    TextChunk(text="22"),
+                    ImageURLChunk(
+                        image_url=ImageURL(
+                            url="https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg",
+                            detail="auto",
+                        )
+                    ),
+                ],
+            ),
+        ),
         (
             OpenAISystemMessage(role="system", content="You are a helpful assistant."),
             SystemMessage(content="You are a helpful assistant."),

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -657,3 +657,18 @@ class TestChatCompletionRequestNormalizationV13:
             ToolMessage(content="D", tool_call_id="2"),
             ToolMessage(content="C", tool_call_id="1"),
         ]
+
+    def test_normalize_tool_messages(self, normalizer_v13: InstructRequestNormalizerV13) -> None:
+        chat_completion_request: ChatCompletionRequest = self._mock_chat_completion(
+            messages=[
+                ToolMessage(content=[TextChunk(text="Chunk1"), TextChunk(text="Chunk2")], tool_call_id="1"),
+                ToolMessage(content="D", tool_call_id="2"),
+            ]
+        )
+        parsed_request: InstructRequest[ChatMessage, Tool] = normalizer_v13.from_chat_completion_request(
+            chat_completion_request
+        )
+        assert parsed_request.messages == [
+            ToolMessage(content="Chunk1\n\nChunk2", tool_call_id="1"),
+            ToolMessage(content="D", tool_call_id="2"),
+        ]

--- a/tests/test_tokenizer_v11.py
+++ b/tests/test_tokenizer_v11.py
@@ -32,7 +32,7 @@ def test_special_tokens(tekkenizer: InstructTokenizerV11) -> None:
 
 
 def test_tokenize_assistant_message(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, _ = tekkenizer.encode_assistant_message(
         AssistantMessage(
             tool_calls=[ToolCall(function=FunctionCall(name="a_a_a", arguments="blabla"))],
         ),
@@ -61,7 +61,7 @@ def test_tokenize_assistant_message(tekkenizer: InstructTokenizerV11) -> None:
 
 
 def test_tokenize_assistant_message_continue_message(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, _ = tekkenizer.encode_assistant_message(
         AssistantMessage(
             content='"blabla"',
         ),
@@ -95,7 +95,7 @@ def test_tokenize_assistant_message_continue_message(tekkenizer: InstructTokeniz
 
 
 def test_tokenize_assistant_messages(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, _ = tekkenizer.encode_assistant_message(
         AssistantMessage(
             tool_calls=[
                 ToolCall(function=FunctionCall(name="a_a_a", arguments="blabla")),
@@ -135,7 +135,7 @@ def test_tokenize_assistant_messages(tekkenizer: InstructTokenizerV11) -> None:
 
 
 def test_tokenize_assistant_message_train(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, _ = tekkenizer.encode_assistant_message(
         AssistantMessage(
             tool_calls=[ToolCall(function=FunctionCall(name="a_a_a", arguments="blabla"), id="ABC")],
         ),

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -1,8 +1,10 @@
 import pytest
+from PIL import Image
 
 from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
     BaseMessage,
+    ImageChunk,
     SystemMessage,
     TextChunk,
     ToolMessage,
@@ -13,6 +15,7 @@ from mistral_common.protocol.instruct.request import ChatCompletionRequest
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.protocol.instruct.validator import MistralRequestValidatorV13
 from mistral_common.tokens.tokenizers.base import InstructTokenizer, Tokenized, TokenizerVersion
+from mistral_common.tokens.tokenizers.image import ImageConfig, ImageEncoder, SpecialImageIDs
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV13
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
@@ -33,6 +36,35 @@ def v13_tekkenizer() -> InstructTokenizerV13:
     return InstructTokenizerV13(tokenizer)
 
 
+@pytest.fixture(scope="session")
+def v13_tekkenizer_with_image_encoder() -> InstructTokenizerV13:
+    special_tokens = get_special_tokens(TokenizerVersion.v13)
+    tokenizer = Tekkenizer(
+        _quick_vocab([b"a", b"b", b"c", b"f", b"de"]),
+        special_tokens=special_tokens,
+        pattern=r".+",  # single token, whole string
+        vocab_size=256 + 100,
+        num_special_tokens=100,
+        version=TokenizerVersion.v13,
+        image_config=ImageConfig(
+            image_patch_size=2,
+            max_image_size=4,
+        ),
+    )
+    encoder = ImageEncoder(
+        image_config=ImageConfig(
+            image_patch_size=2,
+            max_image_size=4,
+        ),
+        special_ids=SpecialImageIDs(
+            img=tokenizer.get_control_token("[IMG]"),
+            img_end=tokenizer.get_control_token("[IMG_END]"),
+            img_break=tokenizer.get_control_token("[IMG_BREAK]"),
+        ),
+    )
+    return InstructTokenizerV13(tokenizer, encoder)
+
+
 EXPECTED_TEXT_V13: str = (
     r"<s>[SYSTEM_PROMPT]S[/SYSTEM_PROMPT][AVAILABLE_TOOLS][{"
     r'"type": "function", "function": {"name": "math_interpreter", '
@@ -43,6 +75,14 @@ EXPECTED_TEXT_V13: str = (
     r"[TOOL_CALLS]F1[ARGS]{}[TOOL_CALLS]F2[ARGS]{}</s>"
     r"[TOOL_RESULTS]R1[/TOOL_RESULTS][TOOL_RESULTS]R2"
     r"[/TOOL_RESULTS]A2</s>[INST]U2[/INST]"
+)
+
+EXPECTED_TEXT_V13_ASSISTANT_AND_TOOLS_WITH_IMAGES: str = (
+    r'<s>[SYSTEM_PROMPT]S[/SYSTEM_PROMPT][AVAILABLE_TOOLS][{"type": "function", "function": {"name": "math_interpreter"'
+    r', "description": "Get the value of an arithmetic expression.", "parameters": {"type": "object", "properties": '
+    r'{"expression": {"type": "string", "description": "Math expression."}}}}}][/AVAILABLE_TOOLS][INST]U1[/INST][IMG]'
+    r"[IMG][IMG_BREAK][IMG][IMG][IMG_END]A1[TOOL_CALLS]F1[ARGS]{}[TOOL_CALLS]F2[ARGS]{}</s>[TOOL_RESULTS]R1"
+    r"[/TOOL_RESULTS][TOOL_RESULTS][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]R2[/TOOL_RESULTS]A2</s>[INST]U2[/INST]"
 )
 
 
@@ -107,6 +147,30 @@ def messages_wrong_order_results() -> list[BaseMessage]:
     ]
 
 
+@pytest.fixture
+def messages_with_images() -> list[BaseMessage]:
+    return [
+        SystemMessage(content="S"),
+        UserMessage(content="U1"),
+        AssistantMessage(
+            content=[
+                TextChunk(text="A1"),
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+            ],
+            tool_calls=[
+                ToolCall(id="123456789", function=FunctionCall(name="F1", arguments="{}")),
+                ToolCall(id="999999999", function=FunctionCall(name="F2", arguments="{}")),
+            ],
+        ),
+        ToolMessage(content="R1", tool_call_id="123456789"),
+        ToolMessage(
+            content=[ImageChunk(image=Image.new("RGB", (4, 4), "red")), TextChunk(text="R2")], tool_call_id="999999999"
+        ),
+        AssistantMessage(content="A2"),
+        UserMessage(content="U2"),
+    ]
+
+
 def test_end_to_end_v13(
     v13_tekkenizer: InstructTokenizer,
     available_tools: list[Tool],
@@ -130,6 +194,31 @@ def test_end_to_end_v13(
     tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
     assert isinstance(tokenized_v13, Tokenized)
     assert tokenized_v13.text == EXPECTED_TEXT_V13, tokenized_v13.text
+
+
+def test_end_to_end_v13_assistant_and_tools_with_images(
+    v13_tekkenizer_with_image_encoder: InstructTokenizer,
+    available_tools: list[Tool],
+    messages_with_images: list[BaseMessage],
+) -> None:
+    """
+    Tests normalization (including reordering) and validation
+    """
+    request_normalizer = InstructRequestNormalizerV13.normalizer()
+    validator = MistralRequestValidatorV13()
+    mistral_tokenizer_v13 = MistralTokenizer(
+        instruct_tokenizer=v13_tekkenizer_with_image_encoder, validator=validator, request_normalizer=request_normalizer
+    )
+    chat_completion_request: ChatCompletionRequest = ChatCompletionRequest(
+        messages=messages_with_images,
+        tools=available_tools,
+    )
+
+    assert isinstance(mistral_tokenizer_v13, MistralTokenizer), type(mistral_tokenizer_v13)
+    # This does validation, normalization and encoding
+    tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
+    assert isinstance(tokenized_v13, Tokenized)
+    assert tokenized_v13.text == EXPECTED_TEXT_V13_ASSISTANT_AND_TOOLS_WITH_IMAGES, tokenized_v13.text
 
 
 def test_encode_tool_message(v13_tekkenizer: InstructTokenizer) -> None:

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -12,30 +12,16 @@ from mistral_common.protocol.instruct.normalize import InstructRequestNormalizer
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.protocol.instruct.validator import MistralRequestValidatorV13
-from mistral_common.tokens.tokenizers.base import InstructRequest, InstructTokenizer, Tokenized, TokenizerVersion
-from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV11, InstructTokenizerV13
+from mistral_common.tokens.tokenizers.base import InstructTokenizer, Tokenized, TokenizerVersion
+from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV13
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 from tests.test_tekken import _quick_vocab, get_special_tokens
 
 
 @pytest.fixture(scope="session")
-def v11_tekkenizer() -> InstructTokenizerV11:
-    special_tokens = get_special_tokens(TokenizerVersion.v11)
-    tokenizer = Tekkenizer(
-        _quick_vocab([b"a", b"b", b"c", b"f", b"de"]),
-        special_tokens=special_tokens,
-        pattern=r".+",  # single token, whole string
-        vocab_size=256 + 100,
-        num_special_tokens=100,
-        version=TokenizerVersion.v11,
-    )
-    return InstructTokenizerV11(tokenizer)
-
-
-@pytest.fixture(scope="session")
-def v13_tekkenizer() -> InstructTokenizerV11:
-    special_tokens = get_special_tokens(TokenizerVersion.v11)
+def v13_tekkenizer() -> InstructTokenizerV13:
+    special_tokens = get_special_tokens(TokenizerVersion.v13)
     tokenizer = Tekkenizer(
         _quick_vocab([b"a", b"b", b"c", b"f", b"de"]),
         special_tokens=special_tokens,
@@ -46,19 +32,6 @@ def v13_tekkenizer() -> InstructTokenizerV11:
     )
     return InstructTokenizerV13(tokenizer)
 
-
-EXPECTED_TEXT_V11: str = (
-    r"<s>[SYSTEM_PROMPT]S[/SYSTEM_PROMPT][INST]U1[/INST]A1"
-    r"[TOOL_CALLS]F1[CALL_ID]123456789[ARGS]{}[TOOL_CALLS]"
-    r"F2[CALL_ID]999999999[ARGS]{}</s>[TOOL_RESULTS]123456789"
-    r"[TOOL_CONTENT]R1[/TOOL_RESULTS][TOOL_RESULTS]999999999"
-    r"[TOOL_CONTENT]R2[/TOOL_RESULTS]A2</s>[AVAILABLE_TOOLS][{"
-    r'"type": "function", "function": {"name": "math_interpreter", '
-    r'"description": "Get the value of an arithmetic expression.", '
-    r'"parameters": {"type": "object", "properties": {'
-    r'"expression": {"type": "string", "description": '
-    r'"Math expression."}}}}}][/AVAILABLE_TOOLS][INST]U2[/INST]'
-)
 
 EXPECTED_TEXT_V13: str = (
     r"<s>[SYSTEM_PROMPT]S[/SYSTEM_PROMPT][AVAILABLE_TOOLS][{"
@@ -132,34 +105,6 @@ def messages_wrong_order_results() -> list[BaseMessage]:
         AssistantMessage(content="A2"),
         UserMessage(content="U2"),
     ]
-
-
-def test_function_calling_v11_vs_v13(
-    v11_tekkenizer: InstructTokenizer,
-    v13_tekkenizer: InstructTokenizer,
-    available_tools: list[Tool],
-    messages: list[BaseMessage],
-) -> None:
-    assert isinstance(v11_tekkenizer, InstructTokenizerV11), type(v11_tekkenizer)
-    assert isinstance(v13_tekkenizer, InstructTokenizerV13), type(v13_tekkenizer)
-
-    tokenized_v11 = v11_tekkenizer.encode_instruct(
-        InstructRequest(
-            messages=messages,
-            available_tools=available_tools,
-        )
-    )
-
-    assert tokenized_v11.text == EXPECTED_TEXT_V11, tokenized_v11.text
-
-    tokenized_v13 = v13_tekkenizer.encode_instruct(
-        InstructRequest(
-            messages=messages,
-            available_tools=available_tools,
-        )
-    )
-
-    assert tokenized_v13.text == EXPECTED_TEXT_V13, tokenized_v13.text
 
 
 def test_end_to_end_v13(

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 from mistral_common.protocol.instruct.messages import (
@@ -138,7 +136,7 @@ def messages_wrong_order_results() -> list[BaseMessage]:
 def test_function_calling_v11_vs_v13(
     v11_tekkenizer: InstructTokenizer,
     v13_tekkenizer: InstructTokenizer,
-    available_tools: list[dict[str, Any]],
+    available_tools: list[Tool],
     messages: list[BaseMessage],
 ) -> None:
     assert isinstance(v11_tekkenizer, InstructTokenizerV11), type(v11_tekkenizer)
@@ -165,7 +163,7 @@ def test_function_calling_v11_vs_v13(
 
 def test_end_to_end_v13(
     v13_tekkenizer: InstructTokenizer,
-    available_tools: list[dict[str, Any]],
+    available_tools: list[Tool],
     messages_wrong_order_results: list[BaseMessage],
 ) -> None:
     """

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -4,6 +4,7 @@ from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
     BaseMessage,
     SystemMessage,
+    TextChunk,
     ToolMessage,
     UserMessage,
 )
@@ -184,3 +185,10 @@ def test_end_to_end_v13(
     tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
     assert isinstance(tokenized_v13, Tokenized)
     assert tokenized_v13.text == EXPECTED_TEXT_V13, tokenized_v13.text
+
+
+def test_encode_tool_message(v13_tekkenizer: InstructTokenizer) -> None:
+    tool_message = ToolMessage(content=[TextChunk(text="R1")], tool_call_id="123456789")
+    assert isinstance(v13_tekkenizer, InstructTokenizerV13)
+    encoded = v13_tekkenizer.encode_tool_message(tool_message, is_before_last_user_message=False)
+    assert encoded[0] == [7, 182, 149, 8]

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -11,7 +11,7 @@ from mistral_common.protocol.instruct.messages import (
 )
 from mistral_common.protocol.instruct.normalize import InstructRequestNormalizerV13
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
-from mistral_common.protocol.instruct.tool_calls import FunctionCall, ToolCall
+from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.protocol.instruct.validator import MistralRequestValidatorV13
 from mistral_common.tokens.tokenizers.base import InstructRequest, InstructTokenizer, Tokenized, TokenizerVersion
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV11, InstructTokenizerV13
@@ -75,14 +75,13 @@ EXPECTED_TEXT_V13: str = (
 
 
 @pytest.fixture
-def available_tools() -> list[dict[str, Any]]:
+def available_tools() -> list[Tool]:
     return [
-        {
-            "type": "function",
-            "function": {
-                "name": "math_interpreter",
-                "description": "Get the value of an arithmetic expression.",
-                "parameters": {
+        Tool(
+            function=Function(
+                name="math_interpreter",
+                description="Get the value of an arithmetic expression.",
+                parameters={
                     "type": "object",
                     "properties": {
                         "expression": {
@@ -91,8 +90,8 @@ def available_tools() -> list[dict[str, Any]]:
                         }
                     },
                 },
-            },
-        }
+            )
+        )
     ]
 
 

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -97,6 +97,47 @@ def test_tokenize_assistant_message(spm_tokenizer: InstructTokenizerV7) -> None:
     )
 
 
+def test_tokenize_assistant_message_with_image(spm_tokenizer: InstructTokenizerV7) -> None:
+    tokenized = spm_tokenizer.encode_instruct(
+        InstructRequest(
+            messages=[
+                UserMessage(
+                    content=[
+                        TextChunk(
+                            text="a",
+                        ),
+                        ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        TextChunk(text="b"),
+                        ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                    ]
+                ),
+            ],
+        )
+    )
+    _im = 10
+    _im_break = 14
+    _im_end = 15
+    img_tokens = [_im, _im, _im_break, _im, _im, _im_end]
+    assert tokenized.tokens == [
+        1,  # bos
+        3,  # begin_inst
+        *img_tokens,
+        1032,  # a
+        4,  # end_inst
+        *img_tokens,
+        1055,  # b
+        2,  # eos
+    ]
+    assert (
+        tokenized.text
+        == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁b</s>"  # noqa
+    )
+
+
 def test_tokenize_assistant_message_continue_final_message(spm_tokenizer: InstructTokenizerV7) -> None:
     tokenized = spm_tokenizer.encode_instruct(
         InstructRequest(


### PR DESCRIPTION
Add v13 tokenizer:
- no longer tokenize call ids
- reorder tool messages

Also now all types of messages accept chunks.