### PR TITLE
Make sentencepiece optional and refactor optional imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requires-python = ">=3.9.0,<3.14"
 dependencies = [
     "pydantic>=2.7,<3.0",
     "jsonschema>=4.21.1",
-    "sentencepiece>=0.2.0",
     "typing-extensions>=4.11.0",
     "tiktoken>=0.7.0",
     "pillow>=10.3.0",
@@ -26,6 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 opencv = ["opencv-python-headless>=4.0.0"]
+sentencepiece = ["sentencepiece>=0.2.0"]
 soundfile = ["soundfile>=0.12.1"]
 soxr = ["soxr>=0.5.0"]
 audio = ["mistral_common[soundfile]", "mistral_common[soxr]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ image = ["mistral_common[opencv]"]
 hf-hub = ["huggingface-hub>=0.32.4"]
 server = ["fastapi[standard]>=0.115.12", "pydantic-settings >= 2.9.1", "click>=8.1.0"]
 
+all = ["mistral_common[image]", "mistral_common[audio]", "mistral_common[sentencepiece]", "mistral_common[hf-hub]", "mistral_common[server]"]
+
 [project.scripts]
 mistral_common = "mistral_common.experimental.app.main:cli"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ image = ["mistral_common[opencv]"]
 hf-hub = ["huggingface-hub>=0.32.4"]
 server = ["fastapi[standard]>=0.115.12", "pydantic-settings >= 2.9.1", "click>=8.1.0"]
 
-all = ["mistral_common[image]", "mistral_common[audio]", "mistral_common[sentencepiece]", "mistral_common[hf-hub]", "mistral_common[server]"]
-
 [project.scripts]
 mistral_common = "mistral_common.experimental.app.main:cli"
 

--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -6,6 +6,10 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+def _get_dependency_error_message(package_name: str, dependency_group: str) -> str:
+    return f"`{package_name}` is not installed. Please install it with `pip install mistral-common[{dependency_group}]`"
+
+
 def is_package_installed(package_name: str) -> bool:
     return importlib.util.find_spec(package_name) is not None
 
@@ -57,32 +61,20 @@ def is_soxr_installed() -> bool:
 
 
 def assert_hf_hub_installed() -> None:
-    assert_package_installed(
-        "huggingface_hub",
-        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf-hub]`",
-    )
+    assert_package_installed("huggingface_hub", _get_dependency_error_message("huggingface_hub", "hf-hub"))
 
 
 def assert_opencv_installed() -> None:
-    assert_package_installed(
-        "cv2", "`opencv` is not installed. Please install it with `pip install mistral-common[opencv]`"
-    )
+    assert_package_installed("cv2", _get_dependency_error_message("opencv", "opencv"))
 
 
 def assert_sentencepiece_installed() -> None:
-    assert_package_installed(
-        "sentencepiece",
-        "`sentencepiece` is not installed. Please install it with `pip install mistral-common[sentencepiece]`",
-    )
+    assert_package_installed("sentencepiece", _get_dependency_error_message("sentencepiece", "sentencepiece"))
 
 
 def assert_soundfile_installed() -> None:
-    assert_package_installed(
-        "soundfile", "`soundfile` is not installed. Please install it with `pip install mistral-common[soundfile]`"
-    )
+    assert_package_installed("soundfile", _get_dependency_error_message("soundfile", "soundfile"))
 
 
 def assert_soxr_installed() -> None:
-    assert_package_installed(
-        "soxr", "`soxr` is not installed. Please install it with `pip install mistral-common[soxr]`"
-    )
+    assert_package_installed("soxr", _get_dependency_error_message("soxr", "soxr"))

--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -25,9 +25,10 @@ def is_hf_hub_installed() -> bool:
 def is_opencv_installed() -> bool:
     try:
         import cv2  # noqa: IOO1,F401
+
         cv2 = cv2
     except ImportError as e:
-        raise e # Should not happen, as we check for the package before importing
+        raise e  # Should not happen, as we check for the package before importing
     except Exception as e:
         # cv2 has lots of import problems: https://github.com/opencv/opencv-python/issues/884
         # for better UX, let's simply skip all errors that might arise from import for now

--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -27,8 +27,8 @@ def is_opencv_installed() -> bool:
         import cv2  # noqa: IOO1,F401
 
         cv2 = cv2
-    except ImportError as e:
-        raise e  # Should not happen, as we check for the package before importing
+    except ImportError:
+        _cv2_available = False
     except Exception as e:
         # cv2 has lots of import problems: https://github.com/opencv/opencv-python/issues/884
         # for better UX, let's simply skip all errors that might arise from import for now

--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -24,9 +24,7 @@ def is_hf_hub_installed() -> bool:
 @lru_cache()
 def is_opencv_installed() -> bool:
     try:
-        import cv2  # noqa: IOO1,F401
-
-        cv2 = cv2
+        import cv2  # noqa: F401
     except ImportError:
         _cv2_available = False
     except Exception as e:

--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -60,13 +60,13 @@ def is_soxr_installed() -> bool:
 def assert_hf_hub_installed() -> None:
     assert_package_installed(
         "huggingface_hub",
-        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf_hub]`",
+        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf-hub]`",
     )
 
 
 def assert_opencv_installed() -> None:
     assert_package_installed(
-        "cv2", "`opencv` is not installed. Please install it with `pip install mistral-common[image]`"
+        "cv2", "`opencv` is not installed. Please install it with `pip install mistral-common[opencv]`"
     )
 
 
@@ -79,11 +79,11 @@ def assert_sentencepiece_installed() -> None:
 
 def assert_soundfile_installed() -> None:
     assert_package_installed(
-        "soundfile", "`soundfile` is not installed. Please install it with `pip install mistral-common[audio]`"
+        "soundfile", "`soundfile` is not installed. Please install it with `pip install mistral-common[soundfile]`"
     )
 
 
 def assert_soxr_installed() -> None:
     assert_package_installed(
-        "soxr", "`soxr` is not installed. Please install it with `pip install mistral-common[audio]`"
+        "soxr", "`soxr` is not installed. Please install it with `pip install mistral-common[soxr]`"
     )

--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -1,0 +1,89 @@
+import importlib.util
+import logging
+from functools import lru_cache
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def is_package_installed(package_name: str) -> bool:
+    return importlib.util.find_spec(package_name) is not None
+
+
+def assert_package_installed(package_name: str, error_message: Optional[str] = None) -> None:
+    if not is_package_installed(package_name):
+        error_message = error_message or f"Package '{package_name}' is required but not installed."
+        raise ImportError(error_message)
+
+
+@lru_cache()
+def is_hf_hub_installed() -> bool:
+    return is_package_installed("huggingface_hub")
+
+
+@lru_cache()
+def is_opencv_installed() -> bool:
+    try:
+        import cv2  # noqa: IOO1,F401
+        cv2 = cv2
+    except ImportError as e:
+        raise e # Should not happen, as we check for the package before importing
+    except Exception as e:
+        # cv2 has lots of import problems: https://github.com/opencv/opencv-python/issues/884
+        # for better UX, let's simply skip all errors that might arise from import for now
+        _cv2_available = False
+        logger.warning(
+            f"Warning: Your installation of OpenCV appears to be broken: {e}."
+            "Please follow the instructions at https://github.com/opencv/opencv-python/issues/884 "
+            "to correct your environment. The import of cv2 has been skipped."
+        )
+    else:
+        _cv2_available = True
+    return _cv2_available
+
+
+@lru_cache()
+def is_sentencepiece_installed() -> bool:
+    return is_package_installed("sentencepiece")
+
+
+@lru_cache()
+def is_soundfile_installed() -> bool:
+    return is_package_installed("soundfile")
+
+
+@lru_cache()
+def is_soxr_installed() -> bool:
+    return is_package_installed("soxr")
+
+
+def assert_hf_hub_installed() -> None:
+    assert_package_installed(
+        "huggingface_hub",
+        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf_hub]`",
+    )
+
+
+def assert_opencv_installed() -> None:
+    assert_package_installed(
+        "cv2", "`opencv` is not installed. Please install it with `pip install mistral-common[image]`"
+    )
+
+
+def assert_sentencepiece_installed() -> None:
+    assert_package_installed(
+        "sentencepiece",
+        "`sentencepiece` is not installed. Please install it with `pip install mistral-common[sentencepiece]`",
+    )
+
+
+def assert_soundfile_installed() -> None:
+    assert_package_installed(
+        "soundfile", "`soundfile` is not installed. Please install it with `pip install mistral-common[audio]`"
+    )
+
+
+def assert_soxr_installed() -> None:
+    assert_package_installed(
+        "soxr", "`soxr` is not installed. Please install it with `pip install mistral-common[audio]`"
+    )

--- a/src/mistral_common/protocol/transcription/request.py
+++ b/src/mistral_common/protocol/transcription/request.py
@@ -4,9 +4,13 @@ from typing import Any, Dict, List, Optional
 from pydantic import Field
 from pydantic_extra_types.language_code import LanguageAlpha2
 
-from mistral_common.audio import Audio, is_soundfile_installed
+from mistral_common.audio import Audio
+from mistral_common.imports import assert_soundfile_installed, is_soundfile_installed
 from mistral_common.protocol.base import BaseCompletionRequest
 from mistral_common.protocol.instruct.messages import RawAudio
+
+if is_soundfile_installed():
+    import soundfile as sf
 
 
 class TranscriptionRequest(BaseCompletionRequest):
@@ -53,12 +57,7 @@ class TranscriptionRequest(BaseCompletionRequest):
         """
         openai_request: Dict[str, Any] = self.model_dump(exclude={"audio"})
 
-        if not is_soundfile_installed():
-            raise ImportError(
-                "soundfile is required for this function. Install it with 'pip install mistral-common[soundfile]'"
-            )
-
-        import soundfile as sf
+        assert_soundfile_installed()
 
         if isinstance(self.audio.data, bytes):
             buffer = io.BytesIO(self.audio.data)

--- a/src/mistral_common/tokens/tokenizers/image.py
+++ b/src/mistral_common/tokens/tokenizers/image.py
@@ -9,31 +9,14 @@ import numpy as np
 from PIL import Image
 
 from mistral_common.image import SerializableImage, download_image
+from mistral_common.imports import assert_opencv_installed, is_opencv_installed
 from mistral_common.protocol.instruct.messages import ImageChunk, ImageURLChunk
 
 logger = logging.getLogger(__name__)
 
 
-_cv2_installed: bool
-try:
+if is_opencv_installed():
     import cv2
-
-    _cv2_installed = True
-except ImportError:
-    _cv2_installed = False
-except Exception as e:
-    # cv2 has lots of import problems: https://github.com/opencv/opencv-python/issues/884
-    # for better UX, let's simply skip all errors that might arise from import for now
-    logger.warning(
-        f"Warning: Your installation of OpenCV appears to be broken: {e}."
-        "Please follow the instructions at https://github.com/opencv/opencv-python/issues/884 "
-        "to correct your environment. The import of cv2 has been skipped."
-    )
-
-
-def is_cv2_installed() -> bool:
-    r"""Check if OpenCV is installed."""
-    return _cv2_installed
 
 
 @dataclass
@@ -170,8 +153,7 @@ def transform_image(image: Image.Image, new_size: Tuple[int, int]) -> np.ndarray
     Returns:
         Transformed image with shape (C, H, W).
     """
-    if not is_cv2_installed():
-        raise ImportError("OpenCV is required for this function. Install it with 'pip install mistral-common[opencv]'")
+    assert_opencv_installed()
 
     np_image = cv2.resize(np.array(_convert_to_rgb(image), dtype=np.float32), new_size, interpolation=cv2.INTER_CUBIC)
     return normalize(np_image, DATASET_MEAN, DATASET_STD)

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -18,7 +18,6 @@ if is_sentencepiece_installed():
     from sentencepiece import SentencePieceProcessor
 
 
-
 def is_sentencepiece(path: Union[str, Path]) -> bool:
     r"""Check if the given path is a SentencePiece model."""
     if isinstance(path, str):

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -5,15 +5,18 @@ from functools import cached_property
 from pathlib import Path
 from typing import List, Optional, Set, Union
 
-from sentencepiece import SentencePieceProcessor
-
 from mistral_common.exceptions import TokenizerException
+from mistral_common.imports import assert_sentencepiece_installed, is_sentencepiece_installed
 from mistral_common.tokens.tokenizers.base import (
     SpecialTokenPolicy,
     Tokenizer,
     TokenizerVersion,
 )
 from mistral_common.tokens.tokenizers.image import ImageConfig, MultiModalVersion
+
+if is_sentencepiece_installed():
+    from sentencepiece import SentencePieceProcessor
+
 
 
 def is_sentencepiece(path: Union[str, Path]) -> bool:
@@ -75,6 +78,8 @@ class SentencePieceTokenizer(Tokenizer):
             model_path: The path to the `SentencePiece` model.
             tokenizer_version: The version of the tokenizer. If not provided, it will be inferred from the model path.
         """
+        assert_sentencepiece_installed()
+
         self._logger = logging.getLogger(self.__class__.__name__)
         # reload tokenizer
         assert os.path.isfile(model_path), model_path

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -30,12 +30,12 @@ _ASSERT_TO_TESTS = {
     (
         is_hf_hub_installed,
         assert_hf_hub_installed,
-        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf_hub]`",
+        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf-hub]`",
     ),
     (
         is_opencv_installed,
         assert_opencv_installed,
-        "`opencv` is not installed. Please install it with `pip install mistral-common[image]`",
+        "`opencv` is not installed. Please install it with `pip install mistral-common[opencv]`",
     ),
     (
         is_sentencepiece_installed,
@@ -45,12 +45,12 @@ _ASSERT_TO_TESTS = {
     (
         is_soundfile_installed,
         assert_soundfile_installed,
-        "`soundfile` is not installed. Please install it with `pip install mistral-common[audio]`",
+        "`soundfile` is not installed. Please install it with `pip install mistral-common[soundfile]`",
     ),
     (
         is_soxr_installed,
         assert_soxr_installed,
-        "`soxr` is not installed. Please install it with `pip install mistral-common[audio]`",
+        "`soxr` is not installed. Please install it with `pip install mistral-common[soxr]`",
     ),
 }
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -83,8 +83,6 @@ def test_is_opencv_installed() -> None:
     # TODO(Julien): Find a way to mock import for testing wrong import
 
 
-
-
 @patch("mistral_common.imports.is_package_installed")
 @pytest.mark.parametrize("is_installed_fn", _IS_INSTALLED_TO_TESTS)
 def test_is_installed(mock_is_package_installed: MagicMock, is_installed_fn: _lru_cache_wrapper) -> None:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,119 @@
+from functools import _lru_cache_wrapper
+from typing import Callable
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from mistral_common.imports import (
+    assert_hf_hub_installed,
+    assert_opencv_installed,
+    assert_package_installed,
+    assert_sentencepiece_installed,
+    assert_soundfile_installed,
+    assert_soxr_installed,
+    is_hf_hub_installed,
+    is_opencv_installed,
+    is_package_installed,
+    is_sentencepiece_installed,
+    is_soundfile_installed,
+    is_soxr_installed,
+)
+
+_IS_INSTALLED_TO_TESTS = [
+    is_hf_hub_installed,
+    is_sentencepiece_installed,
+    is_soundfile_installed,
+    is_soxr_installed,
+]
+
+_ASSERT_TO_TESTS = {
+    (
+        is_hf_hub_installed,
+        assert_hf_hub_installed,
+        "`huggingface_hub` is not installed. Please install it with `pip install mistral-common[hf_hub]`",
+    ),
+    (
+        is_opencv_installed,
+        assert_opencv_installed,
+        "`opencv` is not installed. Please install it with `pip install mistral-common[image]`",
+    ),
+    (
+        is_sentencepiece_installed,
+        assert_sentencepiece_installed,
+        "`sentencepiece` is not installed. Please install it with `pip install mistral-common[sentencepiece]`",
+    ),
+    (
+        is_soundfile_installed,
+        assert_soundfile_installed,
+        "`soundfile` is not installed. Please install it with `pip install mistral-common[audio]`",
+    ),
+    (
+        is_soxr_installed,
+        assert_soxr_installed,
+        "`soxr` is not installed. Please install it with `pip install mistral-common[audio]`",
+    ),
+}
+
+
+@patch("importlib.util.find_spec")
+def test_is_package_installed(mock_find_spec: MagicMock) -> None:
+    mock_find_spec.return_value = True
+    assert is_package_installed("package_name") is True
+
+    mock_find_spec.return_value = None
+    assert is_package_installed("package_name") is False
+
+
+@patch("mistral_common.imports.is_package_installed")
+def test_assert_package_installed(mock_is_package_installed: MagicMock) -> None:
+    mock_is_package_installed.return_value = True
+    assert_package_installed("package_name")
+
+    mock_is_package_installed.return_value = False
+    with pytest.raises(ImportError):
+        assert_package_installed("package_name")
+
+
+def test_is_opencv_installed() -> None:
+    is_opencv_installed.cache_clear()
+
+    with patch.dict("sys.modules", {"cv2": Mock()}):
+        assert is_opencv_installed() is True
+    is_opencv_installed.cache_clear()
+    # TODO(Julien): Find a way to mock import for testing wrong import
+
+
+
+
+@patch("mistral_common.imports.is_package_installed")
+@pytest.mark.parametrize("is_installed_fn", _IS_INSTALLED_TO_TESTS)
+def test_is_installed(mock_is_package_installed: MagicMock, is_installed_fn: _lru_cache_wrapper) -> None:
+    is_installed_fn.cache_clear()
+
+    mock_is_package_installed.return_value = True
+    assert is_installed_fn() is True
+    is_installed_fn.cache_clear()
+
+    mock_is_package_installed.return_value = False
+    assert is_installed_fn() is False
+    is_installed_fn.cache_clear()
+
+
+@patch("mistral_common.imports.is_package_installed")
+@pytest.mark.parametrize("is_installed_fn, assert_fn, error_message", _ASSERT_TO_TESTS)
+def test_assert_installed(
+    mock_is_package_installed: MagicMock,
+    is_installed_fn: _lru_cache_wrapper,
+    assert_fn: Callable[[], None],
+    error_message: str,
+) -> None:
+    is_installed_fn.cache_clear()
+    mock_is_package_installed.return_value = True
+    assert_fn()
+    is_installed_fn.cache_clear()
+
+    mock_is_package_installed.return_value = False
+    with pytest.raises(ImportError) as exc_info:
+        assert_fn()
+    assert str(exc_info.value) == error_message
+    is_installed_fn.cache_clear()

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,6 +1,6 @@
 import base64
 from io import BytesIO
-from typing import Any, Tuple
+from typing import Tuple
 
 import numpy as np
 import pytest
@@ -12,7 +12,7 @@ from mistral_common.protocol.instruct.messages import (
     ImageURLChunk,
     TextChunk,
 )
-from mistral_common.tokens.tokenizers.image import ImageConfig, ImageEncoder, SpecialImageIDs, transform_image
+from mistral_common.tokens.tokenizers.image import ImageConfig, ImageEncoder, SpecialImageIDs
 
 
 @pytest.fixture
@@ -187,14 +187,3 @@ def test_image_encoder_formats(spatial_merge_size: int, special_token_ids: Speci
     for output in outputs[1:]:
         assert (output.image == outputs[0].image).all()
         assert output.tokens == outputs[0].tokens
-
-
-def test_transform_image_missing_cv2(monkeypatch: Any) -> None:
-    img = Image.new("RGB", (10, 10), "red")
-
-    monkeypatch.setattr("mistral_common.tokens.tokenizers.image.is_cv2_installed", lambda: False)
-
-    with pytest.raises(ImportError) as exc_info:
-        transform_image(img, (16, 16))
-
-    assert "pip install mistral-common[opencv]" in str(exc_info.value)

--- a/uv.lock
+++ b/uv.lock
@@ -904,6 +904,17 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "huggingface-hub" },
+    { name = "opencv-python-headless" },
+    { name = "pydantic-settings" },
+    { name = "sentencepiece" },
+    { name = "soundfile" },
+    { name = "soxr" },
+]
 audio = [
     { name = "soundfile" },
     { name = "soxr" },
@@ -963,7 +974,12 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.115.12" },
     { name = "huggingface-hub", marker = "extra == 'hf-hub'", specifier = ">=0.32.4" },
     { name = "jsonschema", specifier = ">=4.21.1" },
+    { name = "mistral-common", extras = ["audio"], marker = "extra == 'all'" },
+    { name = "mistral-common", extras = ["hf-hub"], marker = "extra == 'all'" },
+    { name = "mistral-common", extras = ["image"], marker = "extra == 'all'" },
     { name = "mistral-common", extras = ["opencv"], marker = "extra == 'image'" },
+    { name = "mistral-common", extras = ["sentencepiece"], marker = "extra == 'all'" },
+    { name = "mistral-common", extras = ["server"], marker = "extra == 'all'" },
     { name = "mistral-common", extras = ["soundfile"], marker = "extra == 'audio'" },
     { name = "mistral-common", extras = ["soxr"], marker = "extra == 'audio'" },
     { name = "numpy", specifier = ">=1.25" },
@@ -979,7 +995,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
-provides-extras = ["opencv", "sentencepiece", "soundfile", "soxr", "audio", "image", "hf-hub", "server"]
+provides-extras = ["opencv", "sentencepiece", "soundfile", "soxr", "audio", "image", "hf-hub", "server", "all"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -899,7 +899,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-extra-types", extra = ["pycountry"] },
     { name = "requests" },
-    { name = "sentencepiece" },
     { name = "tiktoken" },
     { name = "typing-extensions" },
 ]
@@ -917,6 +916,9 @@ image = [
 ]
 opencv = [
     { name = "opencv-python-headless" },
+]
+sentencepiece = [
+    { name = "sentencepiece" },
 ]
 server = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -971,13 +973,13 @@ requires-dist = [
     { name = "pydantic-extra-types", extras = ["pycountry"], specifier = ">=2.10.5" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.9.1" },
     { name = "requests", specifier = ">=2.0.0" },
-    { name = "sentencepiece", specifier = ">=0.2.0" },
+    { name = "sentencepiece", marker = "extra == 'sentencepiece'", specifier = ">=0.2.0" },
     { name = "soundfile", marker = "extra == 'soundfile'", specifier = ">=0.12.1" },
     { name = "soxr", marker = "extra == 'soxr'", specifier = ">=0.5.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
-provides-extras = ["opencv", "soundfile", "soxr", "audio", "image", "hf-hub", "server"]
+provides-extras = ["opencv", "sentencepiece", "soundfile", "soxr", "audio", "image", "hf-hub", "server"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -904,17 +904,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-all = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "huggingface-hub" },
-    { name = "opencv-python-headless" },
-    { name = "pydantic-settings" },
-    { name = "sentencepiece" },
-    { name = "soundfile" },
-    { name = "soxr" },
-]
 audio = [
     { name = "soundfile" },
     { name = "soxr" },
@@ -974,12 +963,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.115.12" },
     { name = "huggingface-hub", marker = "extra == 'hf-hub'", specifier = ">=0.32.4" },
     { name = "jsonschema", specifier = ">=4.21.1" },
-    { name = "mistral-common", extras = ["audio"], marker = "extra == 'all'" },
-    { name = "mistral-common", extras = ["hf-hub"], marker = "extra == 'all'" },
-    { name = "mistral-common", extras = ["image"], marker = "extra == 'all'" },
     { name = "mistral-common", extras = ["opencv"], marker = "extra == 'image'" },
-    { name = "mistral-common", extras = ["sentencepiece"], marker = "extra == 'all'" },
-    { name = "mistral-common", extras = ["server"], marker = "extra == 'all'" },
     { name = "mistral-common", extras = ["soundfile"], marker = "extra == 'audio'" },
     { name = "mistral-common", extras = ["soxr"], marker = "extra == 'audio'" },
     { name = "numpy", specifier = ">=1.25" },
@@ -995,7 +979,7 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "typing-extensions", specifier = ">=4.11.0" },
 ]
-provides-extras = ["opencv", "sentencepiece", "soundfile", "soxr", "audio", "image", "hf-hub", "server", "all"]
+provides-extras = ["opencv", "sentencepiece", "soundfile", "soxr", "audio", "image", "hf-hub", "server"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This PR makes `sentencepiece` optional to fix issues rising: #125 #75 
This is ok as our recent models are only released as `Tekkenizer`s.

It also refactors optional import to add the functions:
- `in_package_installed`
- `assert_package_installed`

and avoid duplicating code across the codebase.