### PR TITLE
Make model field optional in TranscriptionRequest

### DIFF
--- a/src/mistral_common/protocol/transcription/request.py
+++ b/src/mistral_common/protocol/transcription/request.py
@@ -28,7 +28,7 @@ class TranscriptionRequest(BaseCompletionRequest):
     """
 
     id: Optional[str] = None
-    model: str
+    model: Optional[str] = None
     audio: RawAudio
     language: Optional[LanguageAlpha2] = Field(
         ...,


### PR DESCRIPTION
Let's make it optional to avoid having to enter the model field as for fim and instruct. Especially now we deprecated requests in instruct folder.