### PR TITLE
Remove the index field from assistant tool_calls.

### DIFF
--- a/src/mistral_common/protocol/instruct/tool_calls.py
+++ b/src/mistral_common/protocol/instruct/tool_calls.py
@@ -165,7 +165,10 @@ class ToolCall(MistralBase):
 
     @classmethod
     def from_openai(cls, tool_call: dict[str, Any]) -> "ToolCall":
-        return cls.model_validate(tool_call)
+        # OpenAI responses may include an "index" field; ignore it to stay compatible
+        openai_tool_call = dict(tool_call)
+        openai_tool_call.pop("index", None)
+        return cls.model_validate(openai_tool_call)
 
 
 ToolType = TypeVar("ToolType", bound=Tool)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -333,6 +333,18 @@ def test_convert_tool_call() -> None:
     assert ToolCall.from_openai(typeddict_openai) == tool_call
 
 
+def test_tool_call_from_openai_ignores_index() -> None:
+    openai_tool_call = {
+        "id": "call_123",
+        "index": 0,
+        "type": "function",
+        "function": {"name": "foo", "arguments": "{}"},
+    }
+    assert ToolCall.from_openai(openai_tool_call) == ToolCall(
+        id="call_123", function=FunctionCall(name="foo", arguments="{}")
+    )
+
+
 def test_convert_think_chunk() -> None:
     chunk = ThinkChunk(thinking="Hello", closed=False)
     text_openai = chunk.to_openai()


### PR DESCRIPTION
Remove the index field from assistant tool_calls before forwarding requests to the vLLM backend. This avoids Pydantic validation errors (extra_forbidden: index) in mistral_common when tools-aware clients replay OpenAI-style tool call messages. Dropping index looks like a safe change as it's not actually used inside the engine. 

# Context:

I was running mistral-vibe using ` ~/.vibe/config.toml`:

```toml
[[providers]]
name = "vllm"
api_base = "http://some-ip:8000/v1"
api_key_env_var = ""
api_style = "openai"
backend = "generic"

[[models]]
name = "Devstral-2-123B-Instruct-2512"
provider = "vllm"
alias = "vllm"
temperature = 0.2
input_price = 0.0
output_price = 0.0
```

vllm was throwing a 400 bad request, with following stack trace:

```
An error occurred in `mistral_common` while applying chat template
Traceback (most recent call last):
  File "/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1811, in apply_mistral_chat_template
    return tokenizer.apply_chat_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/vllm/tokenizers/mistral.py", line 436, in apply_chat_template
    return self.transformers_tokenizer.apply_chat_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/transformers/tokenization_mistral_common.py", line 1504, in apply_chat_template
    chat_request = ChatCompletionRequest.from_openai(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/request.py", line 185, in from_openai
    converted_messages: list[ChatMessage] = convert_openai_messages(messages)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/converters.py", line 31, in convert_openai_messages
    message = AssistantMessage.from_openai(openai_message)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/messages.py", line 226, in from_openai
    tools_calls.append(ToolCall.from_openai(openai_tool_call))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/tool_calls.py", line 168, in from_openai
    return cls.model_validate(tool_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm-env/lib/python3.12/site-packages/pydantic/main.py", line 716, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for ToolCall
index
  Extra inputs are not permitted [type=extra_forbidden, input_value=0, input_type=int]
    For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden
 Error in preprocessing prompt inputs
 Traceback (most recent call last):
   File "/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1811, in apply_mistral_chat_template
     return tokenizer.apply_chat_template(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/vllm/tokenizers/mistral.py", line 436, in apply_chat_template
     return self.transformers_tokenizer.apply_chat_template(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/transformers/tokenization_mistral_common.py", line 1504, in apply_chat_template
     chat_request = ChatCompletionRequest.from_openai(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/request.py", line 185, in from_openai
     converted_messages: list[ChatMessage] = convert_openai_messages(messages)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/converters.py", line 31, in convert_openai_messages
     message = AssistantMessage.from_openai(openai_message)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/messages.py", line 226, in from_openai
     tools_calls.append(ToolCall.from_openai(openai_tool_call))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/mistral_common/protocol/instruct/tool_calls.py", line 168, in from_openai
     return cls.model_validate(tool_call)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/pydantic/main.py", line 716, in model_validate
     return cls.__pydantic_validator__.validate_python(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 pydantic_core._pydantic_core.ValidationError: 1 validation error for ToolCall
 index
   Extra inputs are not permitted [type=extra_forbidden, input_value=0, input_type=int]
     For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden

 The above exception was the direct cause of the following exception:

 Traceback (most recent call last):
   File "/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/openai/serving_chat.py", line 241, in create_chat_completion
     ) = await self._preprocess_chat(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/openai/serving_engine.py", line 1193, in _preprocess_chat
     request_prompt = await self._apply_mistral_chat_template_async(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
     result = self.fn(*self.args, **self.kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/opt/vllm-env/lib/python3.12/site-packages/vllm/entrypoints/chat_utils.py", line 1831, in apply_mistral_chat_template
     raise ValueError(str(e)) from e
 ValueError: 1 validation error for ToolCall
 index
   Extra inputs are not permitted [type=extra_forbidden, input_value=0, input_type=int]
     For further information visit https://errors.pydantic.dev/2.12/v/extra_forbidden

"POST /v1/chat/completions HTTP/1.1" 400 Bad Request
```
