### PR TITLE
fix: correct typos 'occurence' and 'recieved'

### DIFF
--- a/src/mistral_common/experimental/tools.py
+++ b/src/mistral_common/experimental/tools.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 from mistral_common.experimental.utils import (
     _split_integer_list_by_value,
-    _split_tokens_by_one_occurence_control_token,
+    _split_tokens_by_one_occurrence_control_token,
 )
 from mistral_common.protocol.instruct.tool_calls import FunctionCall, ToolCall
 from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, Tokenizer, TokenizerVersion
@@ -92,9 +92,9 @@ def _decode_tool_call_v11_with_call_id(tool_call_tokens: list[int], tokenizer: T
         `[TOOL_CALLS]name[CALL_ID]call_id[ARGS]{"arg1": "value1", "arg2": "value2"}`
 
     """
-    name, call_id_and_args = _split_tokens_by_one_occurence_control_token(tool_call_tokens, tokenizer, "[CALL_ID]")
+    name, call_id_and_args = _split_tokens_by_one_occurrence_control_token(tool_call_tokens, tokenizer, "[CALL_ID]")
 
-    call_id, args = _split_tokens_by_one_occurence_control_token(call_id_and_args, tokenizer, "[ARGS]")
+    call_id, args = _split_tokens_by_one_occurrence_control_token(call_id_and_args, tokenizer, "[ARGS]")
 
     try:
         tool_call = ToolCall(
@@ -117,7 +117,7 @@ def _decode_tool_call_v11(tool_call_tokens: list[int], tokenizer: Tokenizer) -> 
 
         `[TOOL_CALLS]name[ARGS]{"arg1": "value1", "arg2": "value2"}`
     """
-    name, args = _split_tokens_by_one_occurence_control_token(tool_call_tokens, tokenizer, "[ARGS]")
+    name, args = _split_tokens_by_one_occurrence_control_token(tool_call_tokens, tokenizer, "[ARGS]")
     try:
         tool_call = ToolCall(
             function=FunctionCall(

--- a/src/mistral_common/experimental/utils.py
+++ b/src/mistral_common/experimental/utils.py
@@ -29,7 +29,7 @@ def _split_integer_list_by_value(list_: list[int], value: int) -> tuple[list[int
     return (result,)
 
 
-def _split_tokens_by_one_occurence_control_token(
+def _split_tokens_by_one_occurrence_control_token(
     list_: list[int], tokenizer: Tokenizer, control_token: str
 ) -> tuple[list[int], list[int]]:
     r"""Split a list of integers by a given control token.

--- a/src/mistral_common/protocol/instruct/validator.py
+++ b/src/mistral_common/protocol/instruct/validator.py
@@ -434,7 +434,7 @@ class MistralRequestValidatorV13(MistralRequestValidatorV5):
                 observed_tool_ids.add(tool_call_id)
 
             elif message.role == Roles.assistant:
-                # if we have an assistant message and we have not recieved all the function calls
+                # if we have an assistant message and we have not received all the function calls
                 # we need to raise an exception
                 if len(expected_tool_ids) != len(observed_tool_ids):
                     raise InvalidMessageStructureException("Not the same number of function calls and responses")


### PR DESCRIPTION
Fixes typos in experimental tokenizer utilities and validator:
- `_split_tokens_by_one_occurence_control_token` → `_split_tokens_by_one_occurrence_control_token`
- `recieved` → `received`