### PR TITLE
Add agentic validation mode

### DIFF
--- a/src/mistral_common/protocol/instruct/validator.py
+++ b/src/mistral_common/protocol/instruct/validator.py
@@ -45,6 +45,8 @@ class ValidationMode(str, Enum):
         serving: The serving mode.
         finetuning: The finetuning mode.
         test: The test mode.
+        agentic: The agentic mode. Allows user messages after tool messages, enabling
+            agentic loops where the user can interrupt tool executions.
 
     Examples:
         >>> mode = ValidationMode.serving
@@ -53,6 +55,7 @@ class ValidationMode(str, Enum):
     serving = "serving"
     finetuning = "finetuning"
     test = "test"
+    agentic = "agentic"
 
 
 class MistralRequestValidator(Generic[UserMessageType, AssistantMessageType, ToolMessageType, SystemMessageType]):
@@ -247,6 +250,9 @@ class MistralRequestValidator(Generic[UserMessageType, AssistantMessageType, Too
                 if message.tool_calls is not None:
                     # Validate that the number of function calls and responses are the same
                     expected_tool_messages = len(message.tool_calls)
+            elif message.role == Roles.user and self._mode == ValidationMode.agentic:
+                # In agentic mode, a user message resets pending tool call expectations
+                expected_tool_messages = 0
 
             prev_role = message.role
 
@@ -272,6 +278,10 @@ class MistralRequestValidator(Generic[UserMessageType, AssistantMessageType, Too
                     expected_roles = {Roles.assistant, Roles.user, Roles.tool}
                 elif previous_role == Roles.tool:
                     expected_roles = {Roles.assistant, Roles.tool}
+                    if self._mode == ValidationMode.agentic:
+                        expected_roles.add(Roles.user)
+                else:
+                    assert_never(previous_role)
 
                 if current_role not in expected_roles:
                     raise InvalidMessageStructureException(
@@ -497,6 +507,10 @@ class MistralRequestValidatorV13(MistralRequestValidatorV5):
                                 f"Duplicate tool call id {tool_call.id} in assistant message"
                             )
                         expected_tool_ids.add(tool_call.id)
+            elif message.role == Roles.user and self._mode == ValidationMode.agentic:
+                # In agentic mode, a user message resets pending tool call expectations
+                expected_tool_ids.clear()
+                observed_tool_ids.clear()
 
             prev_role = message.role
 
@@ -516,6 +530,15 @@ class MistralRequestValidatorV15(MistralRequestValidatorV13):
 
 
 def get_validator(version: TokenizerVersion, mode: ValidationMode) -> MistralRequestValidator:
+    r"""Get the appropriate validator for a given tokenizer version and validation mode.
+
+    Args:
+        version: The tokenizer version.
+        mode: The validation mode.
+
+    Returns:
+        The validator instance.
+    """
     validator: MistralRequestValidator
     match version:
         case TokenizerVersion.v1 | TokenizerVersion.v2:

--- a/tests/validation/test_chat_validation.py
+++ b/tests/validation/test_chat_validation.py
@@ -72,6 +72,40 @@ def validator_v15(request: pytest.FixtureRequest) -> MistralRequestValidator:
     return request.param  # type: ignore
 
 
+@pytest.fixture(
+    params=[
+        MistralRequestValidator(ValidationMode.agentic),
+        MistralRequestValidatorV3(ValidationMode.agentic),
+        MistralRequestValidatorV13(ValidationMode.agentic),
+    ]
+)
+def agentic_validator(request: pytest.FixtureRequest) -> MistralRequestValidator:
+    return request.param  # type: ignore
+
+
+@pytest.fixture(
+    params=[
+        MistralRequestValidatorV13(ValidationMode.agentic),
+    ]
+)
+def agentic_validator_v13(request: pytest.FixtureRequest) -> MistralRequestValidator:
+    return request.param  # type: ignore
+
+
+@pytest.fixture(
+    params=[
+        MistralRequestValidator(ValidationMode.serving),
+        MistralRequestValidatorV3(ValidationMode.serving),
+        MistralRequestValidatorV13(ValidationMode.serving),
+        MistralRequestValidator(ValidationMode.agentic),
+        MistralRequestValidatorV3(ValidationMode.agentic),
+        MistralRequestValidatorV13(ValidationMode.agentic),
+    ]
+)
+def serving_or_agentic_validator(request: pytest.FixtureRequest) -> MistralRequestValidator:
+    return request.param  # type: ignore
+
+
 class TestChatValidation:
     def test_multiple_system_messages_OK(self, validator: MistralRequestValidator) -> None:
         validator.validate_messages(
@@ -131,7 +165,7 @@ class TestChatValidation:
             continue_final_message=False,
         )
 
-    def test_ends_with_assistant(self, validator: MistralRequestValidator) -> None:
+    def test_ends_with_assistant(self, serving_or_agentic_validator: MistralRequestValidator) -> None:
         with pytest.raises(
             InvalidMessageStructureException,
             match=(
@@ -139,7 +173,7 @@ class TestChatValidation:
                 r"True\) for serving but got assistant"
             ),
         ):
-            validator.validate_messages(
+            serving_or_agentic_validator.validate_messages(
                 messages=[
                     UserMessage(content="foo"),
                     AssistantMessage(content="foo"),
@@ -147,8 +181,8 @@ class TestChatValidation:
                 continue_final_message=False,
             )
 
-    def test_assistant_prefix(self, validator: MistralRequestValidator) -> None:
-        validator.validate_messages(
+    def test_assistant_prefix(self, serving_or_agentic_validator: MistralRequestValidator) -> None:
+        serving_or_agentic_validator.validate_messages(
             messages=[
                 UserMessage(content="foo"),
                 AssistantMessage(content="foo", prefix=True),
@@ -159,7 +193,7 @@ class TestChatValidation:
             InvalidAssistantMessageException,
             match=r"Assistant message with prefix True must be last message",
         ):
-            validator.validate_messages(
+            serving_or_agentic_validator.validate_messages(
                 messages=[
                     UserMessage(content="foo"),
                     AssistantMessage(content="foo", prefix=True),
@@ -168,8 +202,8 @@ class TestChatValidation:
                 continue_final_message=False,
             )
 
-    def test_continue_final_message(self, validator: MistralRequestValidator) -> None:
-        validator.validate_messages(
+    def test_continue_final_message(self, serving_or_agentic_validator: MistralRequestValidator) -> None:
+        serving_or_agentic_validator.validate_messages(
             messages=[
                 UserMessage(content="foo"),
                 AssistantMessage(content="foo"),
@@ -183,7 +217,7 @@ class TestChatValidation:
                 r"but got user"
             ),
         ):
-            validator.validate_messages(
+            serving_or_agentic_validator.validate_messages(
                 messages=[
                     UserMessage(content="foo"),
                     AssistantMessage(content="foo", prefix=True),
@@ -198,7 +232,7 @@ class TestChatValidation:
                 r" for serving but got assistant"
             ),
         ):
-            validator.validate_messages(
+            serving_or_agentic_validator.validate_messages(
                 messages=[
                     UserMessage(content="foo"),
                     AssistantMessage(content="foo"),
@@ -212,7 +246,7 @@ class TestChatValidation:
                 r"but got assistant"
             ),
         ):
-            validator.validate_messages(
+            serving_or_agentic_validator.validate_messages(
                 messages=[
                     UserMessage(content="foo"),
                     AssistantMessage(content="foo", prefix=True),
@@ -297,6 +331,41 @@ class TestChatValidation:
 
         with pytest.raises(InvalidRequestException, match="reasoning_effort='none' is not supported for this model"):
             validator._validate_model_settings(request)
+
+    def test_agentic_tool_then_user_ok(self, agentic_validator: MistralRequestValidator) -> None:
+        agentic_validator.validate_messages(
+            messages=[
+                UserMessage(content="foo"),
+                AssistantMessage(
+                    tool_calls=[ToolCall(id="123456789", function=FunctionCall(name="foo", arguments="{}"))]
+                ),
+                ToolMessage(name="foo", content="bar", tool_call_id="123456789"),
+                UserMessage(content="continue with this context"),
+            ],
+            continue_final_message=False,
+        )
+
+    def test_agentic_full_loop(self, agentic_validator: MistralRequestValidator) -> None:
+        agentic_validator.validate_messages(
+            messages=[
+                UserMessage(content="search for info"),
+                AssistantMessage(
+                    tool_calls=[
+                        ToolCall(id="aaaaaaaaa", function=FunctionCall(name="search", arguments="{}")),
+                        ToolCall(id="ccccccccc", function=FunctionCall(name="search", arguments="{}")),
+                    ]
+                ),
+                ToolMessage(name="search", content="result1", tool_call_id="aaaaaaaaa"),
+                UserMessage(content="now refine the search"),
+                AssistantMessage(
+                    tool_calls=[ToolCall(id="bbbbbbbbb", function=FunctionCall(name="search", arguments="{}"))]
+                ),
+                ToolMessage(name="search", content="result2", tool_call_id="bbbbbbbbb"),
+                AssistantMessage(content="here is the final answer"),
+                UserMessage(content="thanks"),
+            ],
+            continue_final_message=False,
+        )
 
 
 class TestChatValidationV5:
@@ -498,6 +567,46 @@ class TestChatValidationV13:
             messages=[
                 SystemMessage(content="This is a system prompt"),
                 UserMessage(content=[audio_chunk]),
+            ],
+            continue_final_message=False,
+        )
+
+    def test_agentic_partial_tool_results_then_user_ok(self, agentic_validator_v13: MistralRequestValidator) -> None:
+        agentic_validator_v13.validate_messages(
+            messages=[
+                UserMessage(content="foo"),
+                AssistantMessage(
+                    tool_calls=[
+                        ToolCall(id="aaaaaaaaa", function=FunctionCall(name="foo", arguments="{}")),
+                        ToolCall(id="bbbbbbbbb", function=FunctionCall(name="bar", arguments="{}")),
+                        ToolCall(id="ccccccccc", function=FunctionCall(name="baz", arguments="{}")),
+                    ]
+                ),
+                ToolMessage(name="foo", content="result1", tool_call_id="aaaaaaaaa"),
+                UserMessage(content="stop, only need the first result"),
+            ],
+            continue_final_message=False,
+        )
+
+    def test_agentic_user_after_partial_results_then_new_tool_calls(
+        self, agentic_validator_v13: MistralRequestValidator
+    ) -> None:
+        agentic_validator_v13.validate_messages(
+            messages=[
+                UserMessage(content="foo"),
+                AssistantMessage(
+                    tool_calls=[
+                        ToolCall(id="aaaaaaaaa", function=FunctionCall(name="foo", arguments="{}")),
+                        ToolCall(id="bbbbbbbbb", function=FunctionCall(name="bar", arguments="{}")),
+                    ]
+                ),
+                ToolMessage(name="foo", content="result1", tool_call_id="aaaaaaaaa"),
+                UserMessage(content="skip bar, try something else"),
+                AssistantMessage(
+                    tool_calls=[ToolCall(id="ccccccccc", function=FunctionCall(name="baz", arguments="{}"))]
+                ),
+                ToolMessage(name="baz", content="result3", tool_call_id="ccccccccc"),
+                UserMessage(content="done"),
             ],
             continue_final_message=False,
         )

--- a/tests/validation/test_validation.py
+++ b/tests/validation/test_validation.py
@@ -10,6 +10,7 @@ from mistral_common.protocol.instruct.validator import (
     MistralRequestValidatorV3,
     MistralRequestValidatorV5,
     MistralRequestValidatorV13,
+    MistralRequestValidatorV15,
     ValidationMode,
     get_validator,
 )
@@ -55,6 +56,7 @@ class TestValidateTools:
         (TokenizerVersion.v3, MistralRequestValidatorV3),
         (TokenizerVersion.v7, MistralRequestValidatorV5),
         (TokenizerVersion.v13, MistralRequestValidatorV13),
+        (TokenizerVersion.v15, MistralRequestValidatorV15),
     ],
 )
 def test_get_validator_version_mapping(version: TokenizerVersion, expected_class: type) -> None:
@@ -63,7 +65,7 @@ def test_get_validator_version_mapping(version: TokenizerVersion, expected_class
     assert validator._mode == ValidationMode.test
 
 
-@pytest.mark.parametrize("mode", [ValidationMode.serving, ValidationMode.finetuning, ValidationMode.test])
+@pytest.mark.parametrize("mode", list(ValidationMode))
 def test_get_validator_mode_passed_correctly(mode: ValidationMode) -> None:
     validator = get_validator(TokenizerVersion.v2, mode)
     assert validator._mode == validator.mode == mode


### PR DESCRIPTION
This PR adds agentic validation mode that allows tool interruption followed by user message. This allows usage of coding agents through vLLM serving for example as soon as we add this behavior to vLLM.