### PR TITLE
Add default validation mode

### DIFF
--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -2,7 +2,7 @@ import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import numpy as np
 from pydantic import ConfigDict, Field
@@ -17,12 +17,14 @@ from mistral_common.protocol.instruct.messages import (
 )
 from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import Tool
-from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.protocol.speech.request import SpeechRequest
 from mistral_common.protocol.transcription.request import TranscriptionRequest
 from mistral_common.tokens.tokenizers.audio import AudioEncoder
 from mistral_common.tokens.tokenizers.image import ImageEncoder
 from mistral_common.tokens.tokenizers.model_settings_builder import ModelSettingsBuilder
+
+if TYPE_CHECKING:
+    from mistral_common.protocol.instruct.validator import ValidationMode
 
 
 class UserMessagePosition(str, Enum):
@@ -239,7 +241,7 @@ class Tokenizer(ABC):
 
     @property
     @abstractmethod
-    def default_validation_mode(self) -> ValidationMode | None:
+    def default_validation_mode(self) -> "ValidationMode | None":
         r"""The default validation mode embedded in the tokenizer file."""
 
     @abstractmethod

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -17,6 +17,7 @@ from mistral_common.protocol.instruct.messages import (
 )
 from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import Tool
+from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.protocol.speech.request import SpeechRequest
 from mistral_common.protocol.transcription.request import TranscriptionRequest
 from mistral_common.tokens.tokenizers.audio import AudioEncoder
@@ -235,6 +236,11 @@ class Tokenizer(ABC):
     @abstractmethod
     def model_settings_builder(self) -> ModelSettingsBuilder | None:
         r"""The model settings builder, or None if unsupported by this version."""
+
+    @property
+    @abstractmethod
+    def default_validation_mode(self) -> ValidationMode | None:
+        r"""The default validation mode embedded in the tokenizer file."""
 
     @abstractmethod
     def vocab(self) -> list[str]:

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -162,14 +162,12 @@ class MistralTokenizer(
     @classmethod
     def v1(cls) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer v1."""
-        return cls.from_file(str(cls._data_path() / "tokenizer.model.v1"), mode=ValidationMode.test)
+        return cls.from_file(str(cls._data_path() / "tokenizer.model.v1"))
 
     @classmethod
     def v2(cls) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer v2."""
-        return cls.from_file(
-            str(cls._data_path() / "mistral_instruct_tokenizer_240216.model.v2"), mode=ValidationMode.test
-        )
+        return cls.from_file(str(cls._data_path() / "mistral_instruct_tokenizer_240216.model.v2"))
 
     @classmethod
     def v3(cls, is_tekken: bool = False, is_mm: bool = False) -> "MistralTokenizer":
@@ -192,7 +190,7 @@ class MistralTokenizer(
         else:
             tokenizer_name = "mistral_instruct_tokenizer_240323.model.v3"
 
-        return cls.from_file(str(cls._data_path() / tokenizer_name), mode=ValidationMode.test)
+        return cls.from_file(str(cls._data_path() / tokenizer_name))
 
     @classmethod
     def v7(cls, is_mm: bool = False) -> "MistralTokenizer":
@@ -205,13 +203,9 @@ class MistralTokenizer(
             The Mistral tokenizer v7.
         """
         if is_mm:
-            return cls.from_file(
-                str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7m1"), mode=ValidationMode.test
-            )
+            return cls.from_file(str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7m1"))
         else:
-            return cls.from_file(
-                str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7"), mode=ValidationMode.test
-            )
+            return cls.from_file(str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7"))
 
     @classmethod
     def from_model(cls, model: str, strict: bool = True) -> "MistralTokenizer":
@@ -240,7 +234,7 @@ class MistralTokenizer(
         revision: str | None = None,
         force_download: bool = False,
         local_files_only: bool = False,
-        mode: ValidationMode = ValidationMode.test,
+        mode: ValidationMode | None = None,
     ) -> "MistralTokenizer":
         r"""Download the Mistral tokenizer for a given Hugging Face repository ID.
 
@@ -250,7 +244,8 @@ class MistralTokenizer(
             repo_id: The Hugging Face repo ID.
             token: The Hugging Face token to use to download the tokenizer.
             revision: The revision of the model to use. If `None`, the latest revision will be used.
-            mode: The validation mode to use.
+            mode: The validation mode to use. If `None`, the mode is resolved
+                from the tokenizer file or defaults to `ValidationMode.test`.
             force_download: Whether to force the download of the tokenizer. If `True`, the tokenizer will be downloaded
                 even if it is already cached.
             local_files_only: Whether to only use local files. If `True`, the tokenizer will be downloaded only if it is
@@ -272,13 +267,19 @@ class MistralTokenizer(
     def from_file(
         cls,
         tokenizer_filename: str | Path,
-        mode: ValidationMode = ValidationMode.test,
+        mode: ValidationMode | None = None,
     ) -> "MistralTokenizer":
         r"""Loads a tokenizer from a file.
 
+        The validation mode is resolved with the following priority:
+        1. Explicit `mode` argument if provided.
+        2. `default_validation_mode` from the tokenizer file config.
+        3. Falls back to `ValidationMode.test`.
+
         Args:
             tokenizer_filename: The path to the tokenizer file.
-            mode: The validation mode to use.
+            mode: The validation mode to use. If `None`, the mode is resolved
+                from the tokenizer file or defaults to `ValidationMode.test`.
 
         Returns:
             The loaded tokenizer.
@@ -304,8 +305,10 @@ class MistralTokenizer(
             assert isinstance(tokenizer, Tekkenizer), "Audio is only supported for tekken tokenizers"
             audio_encoder = load_audio_encoder(audio_config, tokenizer)
 
+        resolved_mode = mode or tokenizer.default_validation_mode or ValidationMode.test
+
         request_normalizer = get_normalizer(tokenizer.version, tokenizer.model_settings_builder)
-        validator = get_validator(tokenizer.version, mode=mode)
+        validator = get_validator(tokenizer.version, mode=resolved_mode)
 
         if tokenizer.version == TokenizerVersion.v1:
             assert image_encoder is None, "Tokenizer version needs to be >= v3"

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -162,12 +162,14 @@ class MistralTokenizer(
     @classmethod
     def v1(cls) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer v1."""
-        return cls.from_file(str(cls._data_path() / "tokenizer.model.v1"))
+        return cls.from_file(str(cls._data_path() / "tokenizer.model.v1"), mode=ValidationMode.test)
 
     @classmethod
     def v2(cls) -> "MistralTokenizer":
         r"""Get the Mistral tokenizer v2."""
-        return cls.from_file(str(cls._data_path() / "mistral_instruct_tokenizer_240216.model.v2"))
+        return cls.from_file(
+            str(cls._data_path() / "mistral_instruct_tokenizer_240216.model.v2"), mode=ValidationMode.test
+        )
 
     @classmethod
     def v3(cls, is_tekken: bool = False, is_mm: bool = False) -> "MistralTokenizer":
@@ -190,7 +192,7 @@ class MistralTokenizer(
         else:
             tokenizer_name = "mistral_instruct_tokenizer_240323.model.v3"
 
-        return cls.from_file(str(cls._data_path() / tokenizer_name))
+        return cls.from_file(str(cls._data_path() / tokenizer_name), mode=ValidationMode.test)
 
     @classmethod
     def v7(cls, is_mm: bool = False) -> "MistralTokenizer":
@@ -203,9 +205,13 @@ class MistralTokenizer(
             The Mistral tokenizer v7.
         """
         if is_mm:
-            return cls.from_file(str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7m1"))
+            return cls.from_file(
+                str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7m1"), mode=ValidationMode.test
+            )
         else:
-            return cls.from_file(str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7"))
+            return cls.from_file(
+                str(cls._data_path() / "mistral_instruct_tokenizer_241114.model.v7"), mode=ValidationMode.test
+            )
 
     @classmethod
     def from_model(cls, model: str, strict: bool = True) -> "MistralTokenizer":

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from mistral_common.exceptions import TokenizerException
 from mistral_common.imports import assert_sentencepiece_installed, is_sentencepiece_installed
+from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import (
     SpecialTokenPolicy,
     Tokenizer,
@@ -124,6 +125,11 @@ class SentencePieceTokenizer(Tokenizer):
         r"""Always returns None as SentencePiece does not support `model_settings_builder`."""
         if self.version.supports_model_settings:
             raise ValueError(f"SentencePieceTokenizer does not support model settings for version {self.version}")
+        return None
+
+    @property
+    def default_validation_mode(self) -> ValidationMode | None:
+        r"""Always returns None as SentencePiece does not support `default_validation_mode`."""
         return None
 
     def get_special_token(self, s: str) -> int:

--- a/src/mistral_common/tokens/tokenizers/tekken.py
+++ b/src/mistral_common/tokens/tokenizers/tekken.py
@@ -9,7 +9,9 @@ from typing import TypedDict, TypeGuard
 
 import numpy as np
 import tiktoken
+from typing_extensions import NotRequired
 
+from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.audio import AudioConfig, AudioSpectrogramConfig
 from mistral_common.tokens.tokenizers.base import (
     SpecialTokenPolicy,
@@ -75,6 +77,7 @@ class TekkenConfig(TypedDict):
         default_vocab_size: The default vocabulary size.
         default_num_special_tokens: The default number of special tokens.
         version: The version of the tokenizer.
+        default_validation_mode: The default validation mode embedded in the tokenizer file.
     """
 
     pattern: str
@@ -82,6 +85,7 @@ class TekkenConfig(TypedDict):
     default_vocab_size: int
     default_num_special_tokens: int
     version: str
+    default_validation_mode: NotRequired[str | None]
 
 
 class ModelData(TypedDict):
@@ -152,6 +156,7 @@ class Tekkenizer(Tokenizer):
         image_config: ImageConfig | None = None,
         audio_config: AudioConfig | None = None,
         model_settings_builder: ModelSettingsBuilder | None = None,
+        default_validation_mode: ValidationMode | None = None,
     ):
         r"""Initialize the tekken tokenizer.
 
@@ -166,6 +171,7 @@ class Tekkenizer(Tokenizer):
             image_config: The image configuration of the tokenizer.
             audio_config: The audio configuration of the tokenizer.
             model_settings_builder: The builder for model settings, or None if unsupported.
+            default_validation_mode: The default validation mode embedded in the tokenizer file.
         """
         if not version.supports_model_settings and model_settings_builder is not None:
             raise ValueError(
@@ -226,6 +232,7 @@ class Tekkenizer(Tokenizer):
         self._special_token_policy = SpecialTokenPolicy.IGNORE
         self._file_path = Path(_path) if _path is not None else None
         self._model_settings_builder = model_settings_builder
+        self._default_validation_mode = default_validation_mode
 
     @property
     def file_path(self) -> Path:
@@ -238,6 +245,11 @@ class Tekkenizer(Tokenizer):
     def model_settings_builder(self) -> ModelSettingsBuilder | None:
         r"""The model settings builder, or None if unsupported by this version."""
         return self._model_settings_builder
+
+    @property
+    def default_validation_mode(self) -> ValidationMode | None:
+        r"""The default validation mode embedded in the tokenizer file."""
+        return self._default_validation_mode
 
     @classmethod
     def from_file(cls: type["Tekkenizer"], path: str | Path) -> "Tekkenizer":
@@ -305,6 +317,16 @@ class Tekkenizer(Tokenizer):
         elif model_settings_builder is not None:
             model_settings_builder = ModelSettingsBuilder.model_validate(model_settings_builder)
 
+        default_validation_mode: ValidationMode | None = None
+        if (dvm_str := untyped["config"].get("default_validation_mode")) is not None:
+            try:
+                default_validation_mode = ValidationMode(dvm_str)
+            except ValueError:
+                raise ValueError(
+                    f"Unknown default_validation_mode: {dvm_str!r} in {path}. "
+                    f"Valid values are: {[m.value for m in ValidationMode]}"
+                ) from None
+
         model_data: ModelData = untyped
 
         return cls(
@@ -318,6 +340,7 @@ class Tekkenizer(Tokenizer):
             image_config=model_data.get("image"),
             audio_config=model_data.get("audio"),
             model_settings_builder=model_settings_builder,
+            default_validation_mode=default_validation_mode,
             _path=path,
         )
 

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -1,9 +1,11 @@
 import multiprocessing
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from mistral_common.exceptions import TokenizerException
+from mistral_common.imports import is_sentencepiece_installed
 from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, TokenizerVersion
 from mistral_common.tokens.tokenizers.instruct import (
@@ -12,6 +14,8 @@ from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerV3,
 )
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
+from tests.test_tekken import write_tekken_json_with_config
 
 SPM_SPECIAL_WHITESPACE = "▁"
 SPM_WHITESPACE = "▁"
@@ -162,3 +166,40 @@ def test_mistral_tokenizer_mode_property() -> None:
     for mode in [ValidationMode.serving, ValidationMode.finetuning, ValidationMode.test]:
         tokenizer = MistralTokenizer.from_file(tokenizer_path, mode)
         assert tokenizer.mode == tokenizer._chat_completion_request_validator.mode == mode
+
+
+@pytest.mark.parametrize(
+    ["default_file_mode", "explicit_mode", "expected_mode"],
+    [
+        ("serving", None, ValidationMode.serving),
+        ("serving", ValidationMode.finetuning, ValidationMode.finetuning),
+        (None, None, ValidationMode.test),
+    ],
+)
+def test_from_file_mode_resolution(
+    tmp_path: Path,
+    default_file_mode: str | None,
+    explicit_mode: ValidationMode | None,
+    expected_mode: ValidationMode,
+) -> None:
+    tokpath = tmp_path / "tekken.json"
+    write_tekken_json_with_config(tokpath, default_validation_mode=default_file_mode)
+
+    tokenizer = MistralTokenizer.from_file(tokpath, mode=explicit_mode)
+
+    assert tokenizer.mode == expected_mode
+
+
+@pytest.mark.skipif(
+    not is_sentencepiece_installed(),
+    reason="sentencepiece not installed",
+)
+def test_sentencepiece_default_validation_mode_is_none() -> None:
+    spm_path = MistralTokenizer._data_path() / "tokenizer.model.v1"
+    spm_tokenizer = SentencePieceTokenizer(str(spm_path))
+
+    assert spm_tokenizer.default_validation_mode is None
+
+    tokenizer = MistralTokenizer.from_file(str(spm_path))
+
+    assert tokenizer.mode == ValidationMode.test

--- a/tests/test_tekken.py
+++ b/tests/test_tekken.py
@@ -399,3 +399,20 @@ def test_from_file_with_invalid_default_validation_mode(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Unknown default_validation_mode"):
         Tekkenizer.from_file(tokpath)
+
+
+@pytest.mark.parametrize("mode", [None, ValidationMode.serving])
+def test_init_default_validation_mode(mode: ValidationMode | None) -> None:
+    vocab = quick_vocab()
+    special_tokens = _get_deprecated_special_tokens()
+
+    tekkenizer = Tekkenizer(
+        vocab,
+        special_tokens=special_tokens,
+        pattern=".",
+        vocab_size=len(vocab) + len(special_tokens),
+        num_special_tokens=len(special_tokens),
+        version=TokenizerVersion.v3,
+        default_validation_mode=mode,
+    )
+    assert tekkenizer.default_validation_mode == mode

--- a/tests/test_tekken.py
+++ b/tests/test_tekken.py
@@ -7,6 +7,7 @@ from typing import Sequence
 import numpy as np
 import pytest
 
+from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, SpecialTokens, TokenizerVersion
 from mistral_common.tokens.tokenizers.tekken import (
     ModelData,
@@ -150,6 +151,36 @@ def _write_tekkenizer_model(
     )
     with open(tmp_path, "w") as f:
         json.dump(model, f)
+
+
+def write_tekken_json_with_config(
+    path: Path,
+    *,
+    default_validation_mode: str | None = None,
+    version: str = "v3",
+) -> None:
+    """Write a tekken JSON file with optional extra config fields."""
+    vocab = quick_vocab()
+    num_special_tokens = 100
+
+    config: dict[str, object] = {
+        "pattern": ".",
+        "default_num_special_tokens": num_special_tokens,
+        "default_vocab_size": len(vocab) + num_special_tokens,
+        "version": version,
+    }
+    if default_validation_mode is not None:
+        config["default_validation_mode"] = default_validation_mode
+
+    model: dict[str, object] = {
+        "vocab": vocab,
+        "config": config,
+        "special_tokens": None,
+        "version": 1,
+        "type": "Tekken",
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(model, f, ensure_ascii=False)
 
 
 def test_roundtrip() -> None:
@@ -349,3 +380,22 @@ def test_special_tokens_property(dummy_v3: Tekkenizer) -> None:
     num_special = dummy_v3.num_special_tokens
     assert isinstance(num_special, int)
     assert num_special == len(dummy_v3._all_special_tokens)
+
+
+@pytest.mark.parametrize("mode_name", [None, *ValidationMode.__members__])
+def test_from_file_default_validation_mode(tmp_path: Path, mode_name: str | None) -> None:
+    tokpath = tmp_path / "tekken.json"
+    write_tekken_json_with_config(tokpath, default_validation_mode=mode_name)
+
+    tekkenizer = Tekkenizer.from_file(tokpath)
+
+    expected = ValidationMode(mode_name) if mode_name is not None else None
+    assert tekkenizer.default_validation_mode == expected
+
+
+def test_from_file_with_invalid_default_validation_mode(tmp_path: Path) -> None:
+    tokpath = tmp_path / "tekken.json"
+    write_tekken_json_with_config(tokpath, default_validation_mode="invalid_mode")
+
+    with pytest.raises(ValueError, match="Unknown default_validation_mode"):
+        Tekkenizer.from_file(tokpath)


### PR DESCRIPTION
This PR brings the possibility to initialize a ValidationMode for MistralTokenizer from a default stored in tekken.json.