### PR TITLE
Improve from openai methods

### DIFF
--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -97,10 +97,11 @@ class ImageChunk(BaseContentChunk):
         image_url_dict = openai_chunk["image_url"]
         assert isinstance(image_url_dict, dict) and "url" in image_url_dict, image_url_dict
 
-        if re.match(r"^data:image/\w+;base64,", image_url_dict["url"]):  # Remove the prefix if it exists
-            image_url_dict["url"] = image_url_dict["url"].split(",")[1]
+        url = image_url_dict["url"]
+        if re.match(r"^data:image/\w+;base64,", url):  # Remove the prefix if it exists
+            url = url.split(",")[1]
 
-        return cls.model_validate({"image": image_url_dict["url"]})
+        return cls.model_validate({"image": url})
 
 
 class ImageURL(MistralBase):

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -180,7 +180,8 @@ class AssistantMessage(BaseMessage):
             case _, None:
                 thinking = reasoning_content
             case _, _:
-                assert reasoning_content == reasoning, "`reasoning_content` and `reasoning` should be equal."
+                if reasoning_content != reasoning:
+                    raise ValueError("`reasoning_content` and `reasoning` should be equal.")
                 thinking = reasoning
 
         if thinking is not None:

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -169,6 +169,16 @@ class AssistantMessage(BaseMessage):
         else:
             raise ValueError(f"Unknown content type: {type(openai_content)}")
 
+        reasoning_content = openai_message.get("reasoning", openai_message.get("reasoning_content", None))
+        if reasoning_content is not None:
+            reasoning_chunk = ThinkChunk(thinking=reasoning_content, closed=True)
+            if isinstance(content, str):
+                content = [reasoning_chunk, TextChunk(text=content)]
+            elif content is None:
+                content = [reasoning_chunk]
+            else:
+                content.insert(0, reasoning_chunk)
+
         return cls.model_validate(
             {
                 "role": openai_message["role"],

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -169,9 +169,22 @@ class AssistantMessage(BaseMessage):
         else:
             raise ValueError(f"Unknown content type: {type(openai_content)}")
 
-        reasoning_content = openai_message.get("reasoning", openai_message.get("reasoning_content", None))
-        if reasoning_content is not None:
-            reasoning_chunk = ThinkChunk(thinking=reasoning_content, closed=True)
+        reasoning_content: str | None = openai_message.get("reasoning_content")  # deprecated field
+        reasoning: str | None = openai_message.get("reasoning")
+
+        match reasoning_content, reasoning:
+            case None, None:
+                thinking = None
+            case None, _:
+                thinking = reasoning
+            case _, None:
+                thinking = reasoning_content
+            case _, _:
+                assert reasoning_content == reasoning, "`reasoning_content` and `reasoning` should be equal."
+                thinking = reasoning
+
+        if thinking is not None:
+            reasoning_chunk = ThinkChunk(thinking=thinking, closed=True)
             if isinstance(content, str):
                 content = [reasoning_chunk, TextChunk(text=content)]
             elif content is None:

--- a/src/mistral_common/protocol/instruct/tool_calls.py
+++ b/src/mistral_common/protocol/instruct/tool_calls.py
@@ -191,7 +191,7 @@ class FunctionCall(MistralBase):
         if isinstance(v, dict):
             return json.dumps(v)
         elif v is None:
-            return json.dumps({})
+            return "{}"
         return v
 
 

--- a/src/mistral_common/protocol/instruct/tool_calls.py
+++ b/src/mistral_common/protocol/instruct/tool_calls.py
@@ -142,7 +142,17 @@ class Tool(MistralBase):
 
     @classmethod
     def from_openai(cls, openai_tool: dict[str, Any]) -> "Tool":
+        r"""Convert an OpenAI tool definition to a Mistral `Tool`.
+
+        Args:
+            openai_tool: The OpenAI tool definition.
+
+        Returns:
+            The Mistral tool.
+        """
+        openai_tool = openai_tool.copy()
         if function := openai_tool.get("function"):
+            function = function.copy()
             if function.get("parameters") is None:
                 function["parameters"] = {}
             if function.get("description") is None:
@@ -169,7 +179,7 @@ class FunctionCall(MistralBase):
 
     @field_validator("arguments", mode="before")
     def validate_arguments(cls, v: str | dict[str, Any] | None) -> str:
-        """Convert arguments to a JSON string if they are a dictionary.
+        r"""Convert arguments to a JSON string if they are a dictionary.
 
         Args:
             v: The arguments to validate.

--- a/src/mistral_common/protocol/instruct/tool_calls.py
+++ b/src/mistral_common/protocol/instruct/tool_calls.py
@@ -142,6 +142,11 @@ class Tool(MistralBase):
 
     @classmethod
     def from_openai(cls, openai_tool: dict[str, Any]) -> "Tool":
+        if function := openai_tool.get("function"):
+            if function.get("parameters") is None:
+                function["parameters"] = {}
+            if function.get("description") is None:
+                function["description"] = ""
         return cls.model_validate_ignore_extra(openai_tool)
 
 
@@ -163,7 +168,7 @@ class FunctionCall(MistralBase):
     arguments: str
 
     @field_validator("arguments", mode="before")
-    def validate_arguments(cls, v: str | dict[str, Any]) -> str:
+    def validate_arguments(cls, v: str | dict[str, Any] | None) -> str:
         """Convert arguments to a JSON string if they are a dictionary.
 
         Args:
@@ -174,6 +179,8 @@ class FunctionCall(MistralBase):
         """
         if isinstance(v, dict):
             return json.dumps(v)
+        elif v is None:
+            return json.dumps({})
         return v
 
 

--- a/src/mistral_common/protocol/instruct/tool_calls.py
+++ b/src/mistral_common/protocol/instruct/tool_calls.py
@@ -152,11 +152,12 @@ class Tool(MistralBase):
         """
         openai_tool = openai_tool.copy()
         if function := openai_tool.get("function"):
-            function = function.copy()
+            function = Function._filter_cls_fields(function)
             if function.get("parameters") is None:
                 function["parameters"] = {}
             if function.get("description") is None:
                 function["description"] = ""
+            openai_tool["function"] = function
         return cls.model_validate_ignore_extra(openai_tool)
 
 

--- a/src/mistral_common/protocol/instruct/tool_calls.py
+++ b/src/mistral_common/protocol/instruct/tool_calls.py
@@ -51,6 +51,25 @@ class Function(FunctionName):
     parameters: dict[str, Any]
     strict: bool = False
 
+    @classmethod
+    def from_openai(cls, openai_function: dict[str, Any]) -> "Function":
+        r"""Convert an OpenAI function definition to a Mistral `Function`.
+
+        Filters out unknown fields and defaults missing `parameters` and `description`.
+
+        Args:
+            openai_function: The OpenAI function definition.
+
+        Returns:
+            The Mistral function.
+        """
+        filtered = cls._filter_cls_fields(openai_function)
+        if filtered.get("parameters") is None:
+            filtered["parameters"] = {}
+        if filtered.get("description") is None:
+            filtered["description"] = ""
+        return cls.model_validate(filtered)
+
 
 class ToolTypes(str, Enum):
     r"""Enum of tool types.
@@ -144,6 +163,8 @@ class Tool(MistralBase):
     def from_openai(cls, openai_tool: dict[str, Any]) -> "Tool":
         r"""Convert an OpenAI tool definition to a Mistral `Tool`.
 
+        Delegates function parsing to `Function.from_openai`.
+
         Args:
             openai_tool: The OpenAI tool definition.
 
@@ -152,12 +173,7 @@ class Tool(MistralBase):
         """
         openai_tool = openai_tool.copy()
         if function := openai_tool.get("function"):
-            function = Function._filter_cls_fields(function)
-            if function.get("parameters") is None:
-                function["parameters"] = {}
-            if function.get("description") is None:
-                function["description"] = ""
-            openai_tool["function"] = function
+            openai_tool["function"] = Function.from_openai(function)
         return cls.model_validate_ignore_extra(openai_tool)
 
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -257,6 +257,11 @@ def test_convert_audio_url_chunk(vllm_audio_url_chunk: dict, audio_url_chunk: Au
         assert AudioURLChunk.from_openai(vllm_audio_url_chunk) == audio_url_chunk
 
 
+def test_convert_function_from_openai_missing_parameters_and_description_and_unk_args() -> None:
+    openai_function: dict[str, Any] = {"name": "do_nothing", "unk_field": "1"}
+    assert Function.from_openai(openai_function) == Function(name="do_nothing", description="", parameters={})
+
+
 def test_convert_tool() -> None:
     tool = Tool(
         function=Function(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -497,7 +497,12 @@ def test_convert_openai_message_to_message_and_back(openai_message: dict, messag
             AssistantMessage(content=[ThinkChunk(thinking="Let me think...", closed=True), TextChunk(text="Hi")]),
         ),
         (
-            {"role": "assistant", "content": None, "reasoning": "Thinking aloud"},
+            {
+                "role": "assistant",
+                "content": None,
+                "reasoning": "Thinking aloud",
+                "reasoning_content": "Thinking aloud",
+            },
             AssistantMessage(content=[ThinkChunk(thinking="Thinking aloud", closed=True)]),
         ),
         (

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -463,6 +463,45 @@ def test_convert_openai_message_to_message_and_back(openai_message: dict, messag
 
 
 @pytest.mark.parametrize(
+    ["openai_message", "expected"],
+    [
+        (
+            {"role": "assistant", "content": "Hi", "reasoning_content": "Let me think..."},
+            AssistantMessage(content=[ThinkChunk(thinking="Let me think...", closed=True), TextChunk(text="Hi")]),
+        ),
+        (
+            {"role": "assistant", "content": None, "reasoning_content": "Thinking aloud"},
+            AssistantMessage(content=[ThinkChunk(thinking="Thinking aloud", closed=True)]),
+        ),
+        (
+            {"role": "assistant", "reasoning_content": "Thinking aloud"},
+            AssistantMessage(content=[ThinkChunk(thinking="Thinking aloud", closed=True)]),
+        ),
+        (
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Hello"}],
+                "reasoning_content": "Deep thought",
+            },
+            AssistantMessage(content=[ThinkChunk(thinking="Deep thought", closed=True), TextChunk(text="Hello")]),
+        ),
+        (
+            {"role": "assistant", "content": "Hi", "reasoning": "Primary", "reasoning_content": "Fallback"},
+            AssistantMessage(content=[ThinkChunk(thinking="Primary", closed=True), TextChunk(text="Hi")]),
+        ),
+        (
+            {"role": "assistant", "content": "Hi", "reasoning": "Only reasoning"},
+            AssistantMessage(content=[ThinkChunk(thinking="Only reasoning", closed=True), TextChunk(text="Hi")]),
+        ),
+    ],
+)
+def test_from_openai_reasoning_content_in_assistant_message(
+    openai_message: dict[str, Any], expected: AssistantMessage
+) -> None:
+    assert AssistantMessage.from_openai(openai_message) == expected
+
+
+@pytest.mark.parametrize(
     "reasoning_effort",
     [None, ReasoningEffort.none, ReasoningEffort.high],
 )

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -466,39 +466,39 @@ def test_convert_openai_message_to_message_and_back(openai_message: dict, messag
     ["openai_message", "expected"],
     [
         (
-            {"role": "assistant", "content": "Hi", "reasoning_content": "Let me think..."},
+            {"role": "assistant", "content": "Hi", "reasoning": "Let me think..."},
             AssistantMessage(content=[ThinkChunk(thinking="Let me think...", closed=True), TextChunk(text="Hi")]),
         ),
         (
-            {"role": "assistant", "content": None, "reasoning_content": "Thinking aloud"},
+            {"role": "assistant", "content": None, "reasoning": "Thinking aloud"},
             AssistantMessage(content=[ThinkChunk(thinking="Thinking aloud", closed=True)]),
         ),
         (
-            {"role": "assistant", "reasoning_content": "Thinking aloud"},
+            {"role": "assistant", "reasoning": "Thinking aloud"},
             AssistantMessage(content=[ThinkChunk(thinking="Thinking aloud", closed=True)]),
         ),
         (
             {
                 "role": "assistant",
                 "content": [{"type": "text", "text": "Hello"}],
-                "reasoning_content": "Deep thought",
+                "reasoning": "Deep thought",
             },
             AssistantMessage(content=[ThinkChunk(thinking="Deep thought", closed=True), TextChunk(text="Hello")]),
         ),
         (
-            {"role": "assistant", "content": "Hi", "reasoning": "Primary", "reasoning_content": "Fallback"},
-            AssistantMessage(content=[ThinkChunk(thinking="Primary", closed=True), TextChunk(text="Hi")]),
-        ),
-        (
-            {"role": "assistant", "content": "Hi", "reasoning": "Only reasoning"},
+            {"role": "assistant", "content": "Hi", "reasoning_content": "Only reasoning"},
             AssistantMessage(content=[ThinkChunk(thinking="Only reasoning", closed=True), TextChunk(text="Hi")]),
         ),
     ],
 )
-def test_from_openai_reasoning_content_in_assistant_message(
-    openai_message: dict[str, Any], expected: AssistantMessage
-) -> None:
+def test_from_openai_reasoning_in_assistant_message(openai_message: dict[str, Any], expected: AssistantMessage) -> None:
     assert AssistantMessage.from_openai(openai_message) == expected
+
+
+def test_from_openai_reasoning_differ_reasoning_content_in_assistant_message() -> None:
+    openai_message = {"role": "assistant", "content": "Hi", "reasoning": "Primary", "reasoning_content": "Fallback"}
+    with pytest.raises(AssertionError, match=r"`reasoning_content` and `reasoning` should be equal"):
+        AssistantMessage.from_openai(openai_message)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -497,7 +497,7 @@ def test_from_openai_reasoning_in_assistant_message(openai_message: dict[str, An
 
 def test_from_openai_reasoning_differ_reasoning_content_in_assistant_message() -> None:
     openai_message = {"role": "assistant", "content": "Hi", "reasoning": "Primary", "reasoning_content": "Fallback"}
-    with pytest.raises(AssertionError, match=r"`reasoning_content` and `reasoning` should be equal"):
+    with pytest.raises(ValueError, match=r"`reasoning_content` and `reasoning` should be equal"):
         AssistantMessage.from_openai(openai_message)
 
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,3 +1,4 @@
+import copy
 import io
 from pathlib import Path
 from typing import Any
@@ -125,6 +126,17 @@ def test_convert_image_chunk() -> None:
     typeddict_openai = OpenAIImageChunk(**openai_image)  # type: ignore[typeddict-item]
 
     assert isinstance(ImageChunk.from_openai(typeddict_openai), ImageChunk)
+
+
+def test_convert_image_chunk_from_openai_does_not_mutate_input() -> None:
+    image = Image.open(LOGO_PATH.as_posix())
+    original_chunk = ImageChunk(image=image)
+    openai_chunk = original_chunk.to_openai()
+    original_url = openai_chunk["image_url"]["url"]
+
+    ImageChunk.from_openai(openai_chunk)
+
+    assert openai_chunk["image_url"]["url"] == original_url
 
 
 def test_convert_text_chunk() -> None:
@@ -299,6 +311,21 @@ def test_convert_tool() -> None:
 
     typeddict_openai = OpenAITool(**tool.to_openai())  # type: ignore[typeddict-item]
     assert Tool.from_openai(typeddict_openai) == tool
+
+
+def test_convert_tool_from_openai_missing_parameters_description_and_unknown_field() -> None:
+    openai_tool: dict[str, Any] = {
+        "type": "function",
+        "function": {
+            "name": "do_nothing",
+            "unknown_field": "should be ignored",
+        },
+    }
+    original_openai_tool = copy.deepcopy(openai_tool)
+    tool = Tool.from_openai(openai_tool)
+
+    assert tool == Tool(function=Function(name="do_nothing", description="", parameters={}))
+    assert openai_tool == original_openai_tool
 
 
 def test_convert_tool_call() -> None:


### PR DESCRIPTION
This PR does:
- support to multi-turn thinking inside mistral-common from third-party complying with OpenAI API such as vLLM that put reasoning inside a `reasoning` field
- Convert tools with None fields
- Remove mutation of dicts inside from_openai methods.