### PR TITLE
Add to_openai reasoning format for AssistantMessage

### DIFF
--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -187,7 +187,6 @@ class AssistantMessage(BaseMessage):
             if effective_format == OpenAIReasoningField.thinking:
                 out_dict["content"] = [chunk.to_openai() for chunk in self.content]
             else:
-                # Find the split point between leading ThinkChunks and remaining content.
                 split_idx = 0
                 for chunk in self.content:
                     if isinstance(chunk, ThinkChunk):

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -2,7 +2,7 @@ import warnings
 from enum import Enum
 from typing import Any, Literal, TypeVar
 
-from pydantic import Field, field_validator
+from pydantic import Field
 from typing_extensions import Annotated, TypeAlias
 
 from mistral_common.base import MistralBase
@@ -154,25 +154,6 @@ class AssistantMessage(BaseMessage):
     tool_calls: list[ToolCall] | None = None
     prefix: bool = False
 
-    @field_validator("content")
-    @classmethod
-    def _validate_thinking_chunks_are_leading(
-        cls, content: str | list[TextChunk | ThinkChunk] | None
-    ) -> str | list[TextChunk | ThinkChunk] | None:
-        """Validates that all ThinkChunks are contiguous and at the start of the content list."""
-        if not isinstance(content, list):
-            return content
-        seen_non_think = False
-        for chunk in content:
-            if isinstance(chunk, ThinkChunk):
-                if seen_non_think:
-                    raise InvalidAssistantMessageException(
-                        "ThinkChunks must be leading: all ThinkChunks must appear before any other content chunk."
-                    )
-            else:
-                seen_non_think = True
-        return content
-
     def to_openai(
         self,
         convert_thinking_format: OpenAIReasoningField | None = None,
@@ -192,6 +173,16 @@ class AssistantMessage(BaseMessage):
         elif isinstance(self.content, str):
             out_dict["content"] = self.content
         else:
+            seen_non_think = False
+            for chunk in self.content:
+                if isinstance(chunk, ThinkChunk):
+                    if seen_non_think:
+                        raise InvalidAssistantMessageException(
+                            "ThinkChunks must be leading: all ThinkChunks must appear before any other content chunk."
+                        )
+                else:
+                    seen_non_think = True
+
             if convert_thinking_format is None and any(isinstance(c, ThinkChunk) for c in self.content):
                 warnings.warn(
                     "`convert_thinking_format` defaults to 'thinking_chunks' but will change to 'reasoning' "

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -173,6 +173,7 @@ class AssistantMessage(BaseMessage):
         elif isinstance(self.content, str):
             out_dict["content"] = self.content
         else:
+            split_idx = 0
             seen_non_think = False
             for chunk in self.content:
                 if isinstance(chunk, ThinkChunk):
@@ -180,10 +181,11 @@ class AssistantMessage(BaseMessage):
                         raise InvalidAssistantMessageException(
                             "ThinkChunks must be leading: all ThinkChunks must appear before any other content chunk."
                         )
+                    split_idx += 1
                 else:
                     seen_non_think = True
 
-            if convert_thinking_format is None and any(isinstance(c, ThinkChunk) for c in self.content):
+            if convert_thinking_format is None and split_idx > 0:
                 warnings.warn(
                     "`convert_thinking_format` defaults to 'thinking_chunks' but will change to 'reasoning' "
                     "in 1.13.0. Pass `convert_thinking_format` explicitly to silence this warning.",
@@ -196,13 +198,6 @@ class AssistantMessage(BaseMessage):
             if effective_format == OpenAIReasoningField.thinking_chunks:
                 out_dict["content"] = [chunk.to_openai() for chunk in self.content]
             else:
-                split_idx = 0
-                for chunk in self.content:
-                    if isinstance(chunk, ThinkChunk):
-                        split_idx += 1
-                    else:
-                        break
-
                 leading_thinks = self.content[:split_idx]
                 remaining = self.content[split_idx:]
 

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -2,7 +2,7 @@ import warnings
 from enum import Enum
 from typing import Any, Literal, TypeVar
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from typing_extensions import Annotated, TypeAlias
 
 from mistral_common.base import MistralBase
@@ -19,7 +19,7 @@ from mistral_common.protocol.instruct.tool_calls import ToolCall
 warnings.filterwarnings(
     action="once",
     category=FutureWarning,
-    message=r".*`convert_thinking_format` defaults to.*",
+    message=r".*`convert_thinking_format` defaults to 'thinking_chunks'.*",
 )
 
 
@@ -27,12 +27,12 @@ class OpenAIReasoningField(str, Enum):
     r"""How to serialize leading `ThinkChunk` in `AssistantMessage.to_openai()`.
 
     Attributes:
-        thinking: Use think chunks (Mistral convention).
+        thinking_chunks: Use think chunks (Mistral convention).
         reasoning: Flat `reasoning` string (vLLM convention).
         reasoning_content: Flat `reasoning_content` string (SGLang convention).
     """
 
-    thinking = "thinking"
+    thinking_chunks = "thinking_chunks"
     reasoning = "reasoning"
     reasoning_content = "reasoning_content"
 
@@ -154,6 +154,25 @@ class AssistantMessage(BaseMessage):
     tool_calls: list[ToolCall] | None = None
     prefix: bool = False
 
+    @field_validator("content")
+    @classmethod
+    def _validate_thinking_chunks_are_leading(
+        cls, content: str | list[TextChunk | ThinkChunk] | None
+    ) -> str | list[TextChunk | ThinkChunk] | None:
+        """Validates that all ThinkChunks are contiguous and at the start of the content list."""
+        if not isinstance(content, list):
+            return content
+        seen_non_think = False
+        for chunk in content:
+            if isinstance(chunk, ThinkChunk):
+                if seen_non_think:
+                    raise InvalidAssistantMessageException(
+                        "ThinkChunks must be leading: all ThinkChunks must appear before any other content chunk."
+                    )
+            else:
+                seen_non_think = True
+        return content
+
     def to_openai(
         self,
         convert_thinking_format: OpenAIReasoningField | None = None,
@@ -162,9 +181,8 @@ class AssistantMessage(BaseMessage):
 
         Args:
             convert_thinking_format: Conversion strategy for think chunks. When ``None``, defaults to
-                `OpenAIReasoningField.thinking` (chunks kept inline) but emits a `FutureWarning` if the
-                content contains `ThinkChunk`. When not `thinking`, only leading think chunks are extracted;
-                remaining think chunks are kept inline.
+                `OpenAIReasoningField.thinking_chunks` (chunks kept inline) but emits a `FutureWarning` if
+                the content contains `ThinkChunk`.
         """
         out_dict: dict[str, Any] = {
             "role": self.role,
@@ -176,15 +194,15 @@ class AssistantMessage(BaseMessage):
         else:
             if convert_thinking_format is None and any(isinstance(c, ThinkChunk) for c in self.content):
                 warnings.warn(
-                    "`convert_thinking_format` defaults to 'thinking' but will change to 'reasoning' "
+                    "`convert_thinking_format` defaults to 'thinking_chunks' but will change to 'reasoning' "
                     "in 1.13.0. Pass `convert_thinking_format` explicitly to silence this warning.",
                     FutureWarning,
                     stacklevel=2,
                 )
 
-            effective_format = convert_thinking_format or OpenAIReasoningField.thinking
+            effective_format = convert_thinking_format or OpenAIReasoningField.thinking_chunks
 
-            if effective_format == OpenAIReasoningField.thinking:
+            if effective_format == OpenAIReasoningField.thinking_chunks:
                 out_dict["content"] = [chunk.to_openai() for chunk in self.content]
             else:
                 split_idx = 0
@@ -200,7 +218,6 @@ class AssistantMessage(BaseMessage):
                 if leading_thinks:
                     match effective_format:
                         case OpenAIReasoningField.reasoning | OpenAIReasoningField.reasoning_content:
-                            assert all(isinstance(tc, ThinkChunk) for tc in leading_thinks)
                             combined = "\n".join(tc.thinking for tc in leading_thinks if isinstance(tc, ThinkChunk))
                             out_dict[effective_format.value] = combined
                         case _:

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -1,6 +1,6 @@
 import warnings
 from enum import Enum
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeGuard, TypeVar
 
 from pydantic import Field
 from typing_extensions import Annotated, TypeAlias
@@ -23,7 +23,15 @@ warnings.filterwarnings(
 )
 
 
-class OpenAIReasoningField(str, Enum):
+def _are_think_chunks(think_chunks: list[ThinkChunk | TextChunk]) -> TypeGuard[list[ThinkChunk]]:
+    return all(isinstance(c, ThinkChunk) for c in think_chunks)
+
+
+def _are_text_chunks(think_chunks: list[ThinkChunk | TextChunk]) -> TypeGuard[list[TextChunk]]:
+    return all(isinstance(c, TextChunk) for c in think_chunks)
+
+
+class ReasoningFieldFormat(str, Enum):
     r"""How to serialize leading `ThinkChunk` in `AssistantMessage.to_openai()`.
 
     Attributes:
@@ -156,66 +164,61 @@ class AssistantMessage(BaseMessage):
 
     def to_openai(
         self,
-        convert_thinking_format: OpenAIReasoningField | None = None,
+        reasoning_field_format: ReasoningFieldFormat | None = None,
     ) -> dict[str, Any]:
         r"""Converts the message to the OpenAI format.
 
         Args:
-            convert_thinking_format: Conversion strategy for think chunks. When ``None``, defaults to
-                `OpenAIReasoningField.thinking_chunks` (chunks kept inline) but emits a `FutureWarning` if
+            reasoning_field_format: Format for converting thinking chunks. When `None`, defaults to
+                `ReasoningFieldFormat.thinking_chunks` (chunks kept inline) but emits a `FutureWarning` if
                 the content contains `ThinkChunk`.
         """
         out_dict: dict[str, Any] = {
             "role": self.role,
         }
-        if self.content is None:
-            pass
-        elif isinstance(self.content, str):
-            out_dict["content"] = self.content
-        else:
-            split_idx = 0
-            seen_non_think = False
-            for chunk in self.content:
-                if isinstance(chunk, ThinkChunk):
-                    if seen_non_think:
-                        raise InvalidAssistantMessageException(
-                            "ThinkChunks must be leading: all ThinkChunks must appear before any other content chunk."
-                        )
-                    split_idx += 1
-                else:
-                    seen_non_think = True
-
-            if convert_thinking_format is None and split_idx > 0:
-                warnings.warn(
-                    "`convert_thinking_format` defaults to 'thinking_chunks' but will change to 'reasoning' "
-                    "in 1.13.0. Pass `convert_thinking_format` explicitly to silence this warning.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
-
-            effective_format = convert_thinking_format or OpenAIReasoningField.thinking_chunks
-
-            if effective_format == OpenAIReasoningField.thinking_chunks:
-                out_dict["content"] = [chunk.to_openai() for chunk in self.content]
-            else:
-                leading_thinks = self.content[:split_idx]
-                remaining = self.content[split_idx:]
-
-                if leading_thinks:
-                    match effective_format:
-                        case OpenAIReasoningField.reasoning | OpenAIReasoningField.reasoning_content:
-                            combined = "\n".join(tc.thinking for tc in leading_thinks if isinstance(tc, ThinkChunk))
-                            out_dict[effective_format.value] = combined
-                        case _:
-                            raise ValueError(f"{effective_format=} is not supported.")
-
-                if len(remaining) == 1 and isinstance(remaining[0], TextChunk):
-                    out_dict["content"] = remaining[0].text
-                elif remaining:
-                    out_dict["content"] = [chunk.to_openai() for chunk in remaining]
-
         if self.tool_calls is not None:
             out_dict["tool_calls"] = [tool_call.to_openai() for tool_call in self.tool_calls]
+
+        if self.content is None:
+            return out_dict
+
+        if isinstance(self.content, str):
+            out_dict["content"] = self.content
+            return out_dict
+
+        last_think_idx: int = -1
+        for i, chunk in enumerate(self.content):
+            if isinstance(chunk, ThinkChunk):
+                if (i - last_think_idx) > 1:
+                    raise InvalidAssistantMessageException(
+                        "ThinkChunks must be leading: all ThinkChunks must appear before any other content chunk."
+                    )
+                last_think_idx = i
+
+        if reasoning_field_format is None and last_think_idx >= 0:
+            warnings.warn(
+                "`convert_thinking_format` defaults to 'thinking_chunks' but will change to 'reasoning' "
+                "in 1.13.0. Pass `reasoning_field_format` explicitly to silence this warning.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
+        match reasoning_field_format:
+            case None | ReasoningFieldFormat.thinking_chunks:
+                out_dict["content"] = [chunk.to_openai() for chunk in self.content]
+            case ReasoningFieldFormat.reasoning | ReasoningFieldFormat.reasoning_content:
+                think_chunks, content_chunks = self.content[: last_think_idx + 1], self.content[last_think_idx + 1 :]
+                if not _are_think_chunks(think_chunks) or not _are_text_chunks(content_chunks):
+                    raise RuntimeError("Impossible, only think or content chunks should have been present.")
+                if len(think_chunks) > 0:
+                    out_dict[reasoning_field_format.value] = "\n".join(tc.thinking for tc in think_chunks)
+
+                if len(content_chunks) == 1:
+                    out_dict["content"] = content_chunks[0].text
+                elif content_chunks:
+                    out_dict["content"] = [chunk.to_openai() for chunk in content_chunks]
+            case _:
+                raise ValueError(f"{reasoning_field_format=} is not supported.")
 
         return out_dict
 

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import Enum
 from typing import Any, Literal, TypeVar
 
@@ -14,6 +15,26 @@ from mistral_common.protocol.instruct.chunk import (
     _convert_openai_content_chunks,
 )
 from mistral_common.protocol.instruct.tool_calls import ToolCall
+
+warnings.filterwarnings(
+    action="once",
+    category=FutureWarning,
+    message=r".*`convert_thinking_format` defaults to.*",
+)
+
+
+class OpenAIReasoningField(str, Enum):
+    r"""How to serialize leading `ThinkChunk` in `AssistantMessage.to_openai()`.
+
+    Attributes:
+        thinking: Use think chunks (Mistral convention).
+        reasoning: Flat `reasoning` string (vLLM convention).
+        reasoning_content: Flat `reasoning_content` string (SGLang convention).
+    """
+
+    thinking = "thinking"
+    reasoning = "reasoning"
+    reasoning_content = "reasoning_content"
 
 
 class Roles(str, Enum):
@@ -133,9 +154,19 @@ class AssistantMessage(BaseMessage):
     tool_calls: list[ToolCall] | None = None
     prefix: bool = False
 
-    def to_openai(self) -> dict[str, Any]:
-        r"""Converts the message to the OpenAI format."""
-        out_dict: dict[str, str | list[dict[str, str | dict[str, Any]]]] = {
+    def to_openai(
+        self,
+        convert_thinking_format: OpenAIReasoningField | None = None,
+    ) -> dict[str, Any]:
+        r"""Converts the message to the OpenAI format.
+
+        Args:
+            convert_thinking_format: Conversion strategy for think chunks. When ``None``, defaults to
+                `OpenAIReasoningField.thinking` (chunks kept inline) but emits a `FutureWarning` if the
+                content contains `ThinkChunk`. When not `thinking`, only leading think chunks are extracted;
+                remaining think chunks are kept inline.
+        """
+        out_dict: dict[str, Any] = {
             "role": self.role,
         }
         if self.content is None:
@@ -143,7 +174,44 @@ class AssistantMessage(BaseMessage):
         elif isinstance(self.content, str):
             out_dict["content"] = self.content
         else:
-            out_dict["content"] = [chunk.to_openai() for chunk in self.content]
+            if convert_thinking_format is None and any(isinstance(c, ThinkChunk) for c in self.content):
+                warnings.warn(
+                    "`convert_thinking_format` defaults to 'thinking' but will change to 'reasoning' "
+                    "in 1.13.0. Pass `convert_thinking_format` explicitly to silence this warning.",
+                    FutureWarning,
+                    stacklevel=2,
+                )
+
+            effective_format = convert_thinking_format or OpenAIReasoningField.thinking
+
+            if effective_format == OpenAIReasoningField.thinking:
+                out_dict["content"] = [chunk.to_openai() for chunk in self.content]
+            else:
+                # Find the split point between leading ThinkChunks and remaining content.
+                split_idx = 0
+                for chunk in self.content:
+                    if isinstance(chunk, ThinkChunk):
+                        split_idx += 1
+                    else:
+                        break
+
+                leading_thinks = self.content[:split_idx]
+                remaining = self.content[split_idx:]
+
+                if leading_thinks:
+                    match effective_format:
+                        case OpenAIReasoningField.reasoning | OpenAIReasoningField.reasoning_content:
+                            assert all(isinstance(tc, ThinkChunk) for tc in leading_thinks)
+                            combined = "\n".join(tc.thinking for tc in leading_thinks if isinstance(tc, ThinkChunk))
+                            out_dict[effective_format.value] = combined
+                        case _:
+                            raise ValueError(f"{effective_format=} is not supported.")
+
+                if len(remaining) == 1 and isinstance(remaining[0], TextChunk):
+                    out_dict["content"] = remaining[0].text
+                elif remaining:
+                    out_dict["content"] = [chunk.to_openai() for chunk in remaining]
+
         if self.tool_calls is not None:
             out_dict["tool_calls"] = [tool_call.to_openai() for tool_call in self.tool_calls]
 

--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -13,7 +13,7 @@ from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
     ChatMessage,
     ChatMessageType,
-    OpenAIReasoningField,
+    ReasoningFieldFormat,
 )
 from mistral_common.protocol.instruct.tool_calls import Tool, ToolChoice, ToolChoiceEnum, ToolType
 
@@ -117,7 +117,7 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
 
     def to_openai(
         self,
-        convert_thinking_format: OpenAIReasoningField | None = None,
+        convert_thinking_format: ReasoningFieldFormat | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         r"""Convert the request messages and tools into the OpenAI format.
@@ -179,7 +179,7 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
         openai_messages = []
         for message in self.messages:
             if isinstance(message, AssistantMessage):
-                openai_messages.append(message.to_openai(convert_thinking_format=convert_thinking_format))
+                openai_messages.append(message.to_openai(reasoning_field_format=convert_thinking_format))
             else:
                 openai_messages.append(message.to_openai())
 
@@ -270,7 +270,7 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
 
     def to_openai(
         self,
-        convert_thinking_format: OpenAIReasoningField | None = None,
+        convert_thinking_format: ReasoningFieldFormat | None = None,
         **kwargs: Any,
     ) -> dict[str, list[dict[str, Any]]]:
         r"""Convert the request messages and tools into the OpenAI format.
@@ -329,7 +329,7 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
 
         for message in self.messages:
             if isinstance(message, AssistantMessage):
-                openai_messages.append(message.to_openai(convert_thinking_format=convert_thinking_format))
+                openai_messages.append(message.to_openai(reasoning_field_format=convert_thinking_format))
             else:
                 openai_messages.append(message.to_openai())
 

--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -117,13 +117,13 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
 
     def to_openai(
         self,
-        convert_thinking_format: ReasoningFieldFormat | None = None,
+        reasoning_field_format: ReasoningFieldFormat | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         r"""Convert the request messages and tools into the OpenAI format.
 
         Args:
-            convert_thinking_format: Conversion strategy for think chunks in assistant messages.
+            reasoning_field_format: Format for converting thinking chunks in assistant messages.
                 See `AssistantMessage.to_openai` for details.
             kwargs: Additional parameters to be added to the request.
 
@@ -179,7 +179,7 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
         openai_messages = []
         for message in self.messages:
             if isinstance(message, AssistantMessage):
-                openai_messages.append(message.to_openai(reasoning_field_format=convert_thinking_format))
+                openai_messages.append(message.to_openai(reasoning_field_format=reasoning_field_format))
             else:
                 openai_messages.append(message.to_openai())
 
@@ -270,13 +270,13 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
 
     def to_openai(
         self,
-        convert_thinking_format: ReasoningFieldFormat | None = None,
+        reasoning_field_format: ReasoningFieldFormat | None = None,
         **kwargs: Any,
     ) -> dict[str, list[dict[str, Any]]]:
         r"""Convert the request messages and tools into the OpenAI format.
 
         Args:
-            convert_thinking_format: Conversion strategy for think chunks in assistant messages.
+            reasoning_field_format: Format for converting thinking chunks in assistant messages.
                 See `AssistantMessage.to_openai` for details.
             kwargs: Additional parameters to be added to the request.
 
@@ -329,7 +329,7 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
 
         for message in self.messages:
             if isinstance(message, AssistantMessage):
-                openai_messages.append(message.to_openai(reasoning_field_format=convert_thinking_format))
+                openai_messages.append(message.to_openai(reasoning_field_format=reasoning_field_format))
             else:
                 openai_messages.append(message.to_openai())
 

--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -10,8 +10,10 @@ from mistral_common.protocol.instruct.converters import (
     convert_openai_tools,
 )
 from mistral_common.protocol.instruct.messages import (
+    AssistantMessage,
     ChatMessage,
     ChatMessageType,
+    OpenAIReasoningField,
 )
 from mistral_common.protocol.instruct.tool_calls import Tool, ToolChoice, ToolChoiceEnum, ToolType
 
@@ -113,10 +115,16 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
     continue_final_message: bool = False
     reasoning_effort: ReasoningEffort | None = None
 
-    def to_openai(self, **kwargs: Any) -> dict[str, Any]:
+    def to_openai(
+        self,
+        convert_thinking_format: OpenAIReasoningField | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         r"""Convert the request messages and tools into the OpenAI format.
 
         Args:
+            convert_thinking_format: Conversion strategy for think chunks in assistant messages.
+                See `AssistantMessage.to_openai` for details.
             kwargs: Additional parameters to be added to the request.
 
         Returns:
@@ -170,7 +178,10 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
 
         openai_messages = []
         for message in self.messages:
-            openai_messages.append(message.to_openai())
+            if isinstance(message, AssistantMessage):
+                openai_messages.append(message.to_openai(convert_thinking_format=convert_thinking_format))
+            else:
+                openai_messages.append(message.to_openai())
 
         openai_request["messages"] = openai_messages
         if self.tools is not None:
@@ -257,10 +268,16 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
     continue_final_message: bool = False
     settings: ModelSettings = Field(default_factory=ModelSettings.none)
 
-    def to_openai(self, **kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+    def to_openai(
+        self,
+        convert_thinking_format: OpenAIReasoningField | None = None,
+        **kwargs: Any,
+    ) -> dict[str, list[dict[str, Any]]]:
         r"""Convert the request messages and tools into the OpenAI format.
 
         Args:
+            convert_thinking_format: Conversion strategy for think chunks in assistant messages.
+                See `AssistantMessage.to_openai` for details.
             kwargs: Additional parameters to be added to the request.
 
         Returns:
@@ -311,7 +328,10 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
             openai_messages.append({"role": "system", "content": self.system_prompt})
 
         for message in self.messages:
-            openai_messages.append(message.to_openai())
+            if isinstance(message, AssistantMessage):
+                openai_messages.append(message.to_openai(convert_thinking_format=convert_thinking_format))
+            else:
+                openai_messages.append(message.to_openai())
 
         openai_request["messages"] = openai_messages
         if self.available_tools is not None:

--- a/tests/experimental/test_app.py
+++ b/tests/experimental/test_app.py
@@ -364,27 +364,21 @@ def test_detokenize_assistant_message(
         ),
         AssistantMessage(
             content=[
-                TextChunk(text="Hello, world!"),
                 ThinkChunk(thinking="Let me think about this..."),
-                TextChunk(text="This is a complex question."),
                 ThinkChunk(thinking="I need to consider all options."),
                 TextChunk(text="Here is my final answer."),
             ],
         ),
         AssistantMessage(
             content=[
-                TextChunk(text="Hello, world!"),
                 ThinkChunk(thinking="Let me think about this..."),
-                TextChunk(text="This is a complex question."),
                 ThinkChunk(thinking="I need to consider all options.", closed=False),
             ],
             prefix=True,
         ),
         AssistantMessage(
             content=[
-                TextChunk(text="Hello, world!"),
                 ThinkChunk(thinking="Let me think about this..."),
-                TextChunk(text="This is a complex question."),
                 ThinkChunk(thinking="I need to consider all options.", closed=False),
             ],
             prefix=True,
@@ -455,9 +449,7 @@ class MockResponse:
         ),
         AssistantMessage(
             content=[
-                TextChunk(text="Hello, world!"),
                 ThinkChunk(thinking="Let me think about this..."),
-                TextChunk(text="This is a complex question."),
                 ThinkChunk(thinking="I need to consider all options."),
                 TextChunk(text="Here is my final answer."),
             ],

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -738,7 +738,7 @@ def test_assistant_message_to_openai_none_no_warning_with_none_content() -> None
     "request_cls",
     [ChatCompletionRequest, InstructRequest],
 )
-def test_request_to_openai_forwards_convert_thinking_format(
+def test_request_to_openai_forwards_reasoning_field_format(
     request_cls: type[ChatCompletionRequest | InstructRequest],
 ) -> None:
     messages: list[ChatMessage] = [
@@ -751,7 +751,7 @@ def test_request_to_openai_forwards_convert_thinking_format(
     else:
         request = InstructRequest(messages=messages)
 
-    openai_request = request.to_openai(convert_thinking_format=ReasoningFieldFormat.reasoning)
+    openai_request = request.to_openai(reasoning_field_format=ReasoningFieldFormat.reasoning)
     assistant_msg = [m for m in openai_request["messages"] if m["role"] == "assistant"][0]
     assert assistant_msg == {"role": "assistant", "reasoning": "Let me think", "content": "Done"}
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -620,7 +620,6 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
                 ],
             },
         ),
-
         # reasoning: single leading ThinkChunk extracted as flat string
         (
             AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -421,16 +421,16 @@ def test_convert_think_chunk() -> None:
             {
                 "role": "assistant",
                 "content": [
-                    {"type": "text", "text": "Hi"},
                     {"type": "thinking", "thinking": "Hello", "closed": True},
                     {"type": "thinking", "thinking": "Hello", "closed": False},
+                    {"type": "text", "text": "Hi"},
                 ],
             },
             AssistantMessage(
                 content=[
-                    TextChunk(text="Hi"),
                     ThinkChunk(thinking="Hello", closed=True),
                     ThinkChunk(thinking="Hello", closed=False),
+                    TextChunk(text="Hi"),
                 ]
             ),
         ),
@@ -582,14 +582,13 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
                 ],
             },
         ),
-        # thinking: multiple chunks all inline
+        # thinking: multiple leading ThinkChunks stay as-is (no aggregation)
         (
             AssistantMessage(
                 content=[
                     ThinkChunk(thinking="First", closed=True),
                     ThinkChunk(thinking="Second", closed=False),
                     TextChunk(text="Reply"),
-                    ThinkChunk(thinking="Third", closed=False),
                 ]
             ),
             OpenAIReasoningField.thinking,
@@ -599,10 +598,29 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
                     {"type": "thinking", "thinking": "First", "closed": True},
                     {"type": "thinking", "thinking": "Second", "closed": False},
                     {"type": "text", "text": "Reply"},
+                ],
+            },
+        ),
+        # thinking: non-leading ThinkChunks stay inline (no error)
+        (
+            AssistantMessage(
+                content=[
+                    ThinkChunk(thinking="First", closed=True),
+                    TextChunk(text="Reply"),
+                    ThinkChunk(thinking="Third", closed=False),
+                ]
+            ),
+            OpenAIReasoningField.thinking,
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "First", "closed": True},
+                    {"type": "text", "text": "Reply"},
                     {"type": "thinking", "thinking": "Third", "closed": False},
                 ],
             },
         ),
+
         # reasoning: single leading ThinkChunk extracted as flat string
         (
             AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),
@@ -626,23 +644,6 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
             ),
             OpenAIReasoningField.reasoning,
             {"role": "assistant", "reasoning": "Part 1\nPart 2", "content": "Final"},
-        ),
-        # reasoning: non-leading ThinkChunks stay inline in content
-        (
-            AssistantMessage(
-                content=[
-                    TextChunk(text="Hi"),
-                    ThinkChunk(thinking="After text", closed=True),
-                ]
-            ),
-            OpenAIReasoningField.reasoning,
-            {
-                "role": "assistant",
-                "content": [
-                    {"type": "text", "text": "Hi"},
-                    {"type": "thinking", "thinking": "After text", "closed": True},
-                ],
-            },
         ),
         # thinking: ThinkChunk only, no remaining content
         (

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -737,6 +737,7 @@ def test_request_to_openai_forwards_convert_thinking_format(
         UserMessage(content="Hi"),
         AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),
     ]
+    request: ChatCompletionRequest | InstructRequest
     if request_cls == ChatCompletionRequest:
         request = ChatCompletionRequest(messages=messages)
     else:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,5 +1,6 @@
 import copy
 import io
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,7 @@ from mistral_common.protocol.instruct.chunk import (
 from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
     ChatMessage,
+    OpenAIReasoningField,
     SystemMessage,
     ToolMessage,
     UserMessage,
@@ -563,6 +565,186 @@ def test_from_openai_reasoning_differ_reasoning_content_in_assistant_message() -
 def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[str, Any]) -> None:
     with pytest.raises(InvalidAssistantMessageException):
         AssistantMessage.from_openai(openai_message)
+
+
+@pytest.mark.parametrize(
+    ["message", "convert_thinking_format", "expected"],
+    [
+        # thinking: chunks stay inline
+        (
+            AssistantMessage(content=[ThinkChunk(thinking="Deep thought", closed=True), TextChunk(text="Answer")]),
+            OpenAIReasoningField.thinking,
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "Deep thought", "closed": True},
+                    {"type": "text", "text": "Answer"},
+                ],
+            },
+        ),
+        # thinking: multiple chunks all inline
+        (
+            AssistantMessage(
+                content=[
+                    ThinkChunk(thinking="First", closed=True),
+                    ThinkChunk(thinking="Second", closed=False),
+                    TextChunk(text="Reply"),
+                    ThinkChunk(thinking="Third", closed=False),
+                ]
+            ),
+            OpenAIReasoningField.thinking,
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "First", "closed": True},
+                    {"type": "thinking", "thinking": "Second", "closed": False},
+                    {"type": "text", "text": "Reply"},
+                    {"type": "thinking", "thinking": "Third", "closed": False},
+                ],
+            },
+        ),
+        # reasoning: single leading ThinkChunk extracted as flat string
+        (
+            AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),
+            OpenAIReasoningField.reasoning,
+            {"role": "assistant", "reasoning": "Let me think", "content": "Done"},
+        ),
+        # reasoning_content: single leading ThinkChunk extracted as flat string
+        (
+            AssistantMessage(content=[ThinkChunk(thinking="Pondering", closed=True), TextChunk(text="Result")]),
+            OpenAIReasoningField.reasoning_content,
+            {"role": "assistant", "reasoning_content": "Pondering", "content": "Result"},
+        ),
+        # reasoning: multiple leading ThinkChunks concatenated with newline
+        (
+            AssistantMessage(
+                content=[
+                    ThinkChunk(thinking="Part 1", closed=True),
+                    ThinkChunk(thinking="Part 2", closed=True),
+                    TextChunk(text="Final"),
+                ]
+            ),
+            OpenAIReasoningField.reasoning,
+            {"role": "assistant", "reasoning": "Part 1\nPart 2", "content": "Final"},
+        ),
+        # reasoning: non-leading ThinkChunks stay inline in content
+        (
+            AssistantMessage(
+                content=[
+                    TextChunk(text="Hi"),
+                    ThinkChunk(thinking="After text", closed=True),
+                ]
+            ),
+            OpenAIReasoningField.reasoning,
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "Hi"},
+                    {"type": "thinking", "thinking": "After text", "closed": True},
+                ],
+            },
+        ),
+        # thinking: ThinkChunk only, no remaining content
+        (
+            AssistantMessage(content=[ThinkChunk(thinking="Just thinking", closed=True)]),
+            OpenAIReasoningField.thinking,
+            {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "Just thinking", "closed": True}],
+            },
+        ),
+        # reasoning: ThinkChunk only, no remaining content
+        (
+            AssistantMessage(content=[ThinkChunk(thinking="Only reasoning", closed=True)]),
+            OpenAIReasoningField.reasoning,
+            {"role": "assistant", "reasoning": "Only reasoning"},
+        ),
+        # reasoning: leading ThinkChunk with remaining list content (multiple chunks)
+        (
+            AssistantMessage(
+                content=[
+                    ThinkChunk(thinking="Think", closed=True),
+                    TextChunk(text="A"),
+                    TextChunk(text="B"),
+                ]
+            ),
+            OpenAIReasoningField.reasoning,
+            {
+                "role": "assistant",
+                "reasoning": "Think",
+                "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}],
+            },
+        ),
+        # String content unchanged regardless of convert_thinking_format
+        (
+            AssistantMessage(content="Simple text"),
+            OpenAIReasoningField.reasoning,
+            {"role": "assistant", "content": "Simple text"},
+        ),
+        # None content unchanged
+        (
+            AssistantMessage(content=None),
+            OpenAIReasoningField.thinking,
+            {"role": "assistant"},
+        ),
+    ],
+)
+def test_assistant_message_to_openai_convert_thinking_format(
+    message: AssistantMessage,
+    convert_thinking_format: OpenAIReasoningField,
+    expected: dict[str, Any],
+) -> None:
+    assert message.to_openai(convert_thinking_format=convert_thinking_format) == expected
+
+
+def test_assistant_message_to_openai_none_warns_with_think_chunks() -> None:
+    message = AssistantMessage(content=[ThinkChunk(thinking="Hmm", closed=True), TextChunk(text="Answer")])
+    with pytest.warns(FutureWarning, match=r"convert_thinking_format.*defaults to 'thinking'"):
+        result = message.to_openai()
+    assert result == {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "Hmm", "closed": True},
+            {"type": "text", "text": "Answer"},
+        ],
+    }
+
+
+def test_assistant_message_to_openai_none_no_warning_without_think_chunks() -> None:
+    message = AssistantMessage(content="Plain text")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = message.to_openai()
+    assert result == {"role": "assistant", "content": "Plain text"}
+
+
+def test_assistant_message_to_openai_none_no_warning_with_none_content() -> None:
+    message = AssistantMessage(content=None)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result = message.to_openai()
+    assert result == {"role": "assistant"}
+
+
+@pytest.mark.parametrize(
+    "request_cls",
+    [ChatCompletionRequest, InstructRequest],
+)
+def test_request_to_openai_forwards_convert_thinking_format(
+    request_cls: type[ChatCompletionRequest | InstructRequest],
+) -> None:
+    messages: list[ChatMessage] = [
+        UserMessage(content="Hi"),
+        AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),
+    ]
+    if request_cls == ChatCompletionRequest:
+        request = ChatCompletionRequest(messages=messages)
+    else:
+        request = InstructRequest(messages=messages)
+
+    openai_request = request.to_openai(convert_thinking_format=OpenAIReasoningField.reasoning)
+    assistant_msg = [m for m in openai_request["messages"] if m["role"] == "assistant"][0]
+    assert assistant_msg == {"role": "assistant", "reasoning": "Let me think", "content": "Done"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -567,15 +567,31 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
         AssistantMessage.from_openai(openai_message)
 
 
-def test_non_leading_think_chunks_raises() -> None:
+def test_non_leading_think_chunks_construction_ok() -> None:
+    """Non-leading ThinkChunks are allowed at construction time."""
+    msg = AssistantMessage(
+        content=[
+            ThinkChunk(thinking="First", closed=True),
+            TextChunk(text="Reply"),
+            ThinkChunk(thinking="Third", closed=False),
+        ]
+    )
+    assert msg.content is not None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        [ThinkChunk(thinking="First", closed=True), TextChunk(text="Reply"), ThinkChunk(thinking="Third")],
+        [TextChunk(text="Reply"), ThinkChunk(thinking="After", closed=True)],
+        [TextChunk(text="A"), TextChunk(text="B"), ThinkChunk(thinking="End", closed=True)],
+    ],
+)
+def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | ThinkChunk]) -> None:
+    """to_openai raises when ThinkChunks are not leading."""
+    msg = AssistantMessage(content=content)
     with pytest.raises(InvalidAssistantMessageException, match="ThinkChunks must be leading"):
-        AssistantMessage(
-            content=[
-                ThinkChunk(thinking="First", closed=True),
-                TextChunk(text="Reply"),
-                ThinkChunk(thinking="Third", closed=False),
-            ]
-        )
+        msg.to_openai()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -47,7 +47,7 @@ from mistral_common.protocol.instruct.chunk import (
 from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
     ChatMessage,
-    OpenAIReasoningField,
+    ReasoningFieldFormat,
     SystemMessage,
     ToolMessage,
     UserMessage,
@@ -600,7 +600,7 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
         # thinking: chunks stay inline
         (
             AssistantMessage(content=[ThinkChunk(thinking="Deep thought", closed=True), TextChunk(text="Answer")]),
-            OpenAIReasoningField.thinking_chunks,
+            ReasoningFieldFormat.thinking_chunks,
             {
                 "role": "assistant",
                 "content": [
@@ -618,7 +618,7 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
                     TextChunk(text="Reply"),
                 ]
             ),
-            OpenAIReasoningField.thinking_chunks,
+            ReasoningFieldFormat.thinking_chunks,
             {
                 "role": "assistant",
                 "content": [
@@ -631,13 +631,13 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
         # reasoning: single leading ThinkChunk extracted as flat string
         (
             AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),
-            OpenAIReasoningField.reasoning,
+            ReasoningFieldFormat.reasoning,
             {"role": "assistant", "reasoning": "Let me think", "content": "Done"},
         ),
         # reasoning_content: single leading ThinkChunk extracted as flat string
         (
             AssistantMessage(content=[ThinkChunk(thinking="Pondering", closed=True), TextChunk(text="Result")]),
-            OpenAIReasoningField.reasoning_content,
+            ReasoningFieldFormat.reasoning_content,
             {"role": "assistant", "reasoning_content": "Pondering", "content": "Result"},
         ),
         # reasoning: multiple leading ThinkChunks concatenated with newline
@@ -649,13 +649,13 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
                     TextChunk(text="Final"),
                 ]
             ),
-            OpenAIReasoningField.reasoning,
+            ReasoningFieldFormat.reasoning,
             {"role": "assistant", "reasoning": "Part 1\nPart 2", "content": "Final"},
         ),
         # thinking: ThinkChunk only, no remaining content
         (
             AssistantMessage(content=[ThinkChunk(thinking="Just thinking", closed=True)]),
-            OpenAIReasoningField.thinking_chunks,
+            ReasoningFieldFormat.thinking_chunks,
             {
                 "role": "assistant",
                 "content": [{"type": "thinking", "thinking": "Just thinking", "closed": True}],
@@ -664,7 +664,7 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
         # reasoning: ThinkChunk only, no remaining content
         (
             AssistantMessage(content=[ThinkChunk(thinking="Only reasoning", closed=True)]),
-            OpenAIReasoningField.reasoning,
+            ReasoningFieldFormat.reasoning,
             {"role": "assistant", "reasoning": "Only reasoning"},
         ),
         # reasoning: leading ThinkChunk with remaining list content (multiple chunks)
@@ -676,7 +676,7 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
                     TextChunk(text="B"),
                 ]
             ),
-            OpenAIReasoningField.reasoning,
+            ReasoningFieldFormat.reasoning,
             {
                 "role": "assistant",
                 "reasoning": "Think",
@@ -686,23 +686,23 @@ def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | Thi
         # String content unchanged regardless of convert_thinking_format
         (
             AssistantMessage(content="Simple text"),
-            OpenAIReasoningField.reasoning,
+            ReasoningFieldFormat.reasoning,
             {"role": "assistant", "content": "Simple text"},
         ),
         # None content unchanged
         (
             AssistantMessage(content=None),
-            OpenAIReasoningField.thinking_chunks,
+            ReasoningFieldFormat.thinking_chunks,
             {"role": "assistant"},
         ),
     ],
 )
 def test_assistant_message_to_openai_convert_thinking_format(
     message: AssistantMessage,
-    convert_thinking_format: OpenAIReasoningField,
+    convert_thinking_format: ReasoningFieldFormat,
     expected: dict[str, Any],
 ) -> None:
-    assert message.to_openai(convert_thinking_format=convert_thinking_format) == expected
+    assert message.to_openai(reasoning_field_format=convert_thinking_format) == expected
 
 
 def test_assistant_message_to_openai_none_warns_with_think_chunks() -> None:
@@ -751,7 +751,7 @@ def test_request_to_openai_forwards_convert_thinking_format(
     else:
         request = InstructRequest(messages=messages)
 
-    openai_request = request.to_openai(convert_thinking_format=OpenAIReasoningField.reasoning)
+    openai_request = request.to_openai(convert_thinking_format=ReasoningFieldFormat.reasoning)
     assistant_msg = [m for m in openai_request["messages"] if m["role"] == "assistant"][0]
     assert assistant_msg == {"role": "assistant", "reasoning": "Let me think", "content": "Done"}
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -567,13 +567,24 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
         AssistantMessage.from_openai(openai_message)
 
 
+def test_non_leading_think_chunks_raises() -> None:
+    with pytest.raises(InvalidAssistantMessageException, match="ThinkChunks must be leading"):
+        AssistantMessage(
+            content=[
+                ThinkChunk(thinking="First", closed=True),
+                TextChunk(text="Reply"),
+                ThinkChunk(thinking="Third", closed=False),
+            ]
+        )
+
+
 @pytest.mark.parametrize(
     ["message", "convert_thinking_format", "expected"],
     [
         # thinking: chunks stay inline
         (
             AssistantMessage(content=[ThinkChunk(thinking="Deep thought", closed=True), TextChunk(text="Answer")]),
-            OpenAIReasoningField.thinking,
+            OpenAIReasoningField.thinking_chunks,
             {
                 "role": "assistant",
                 "content": [
@@ -591,32 +602,13 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
                     TextChunk(text="Reply"),
                 ]
             ),
-            OpenAIReasoningField.thinking,
+            OpenAIReasoningField.thinking_chunks,
             {
                 "role": "assistant",
                 "content": [
                     {"type": "thinking", "thinking": "First", "closed": True},
                     {"type": "thinking", "thinking": "Second", "closed": False},
                     {"type": "text", "text": "Reply"},
-                ],
-            },
-        ),
-        # thinking: non-leading ThinkChunks stay inline (no error)
-        (
-            AssistantMessage(
-                content=[
-                    ThinkChunk(thinking="First", closed=True),
-                    TextChunk(text="Reply"),
-                    ThinkChunk(thinking="Third", closed=False),
-                ]
-            ),
-            OpenAIReasoningField.thinking,
-            {
-                "role": "assistant",
-                "content": [
-                    {"type": "thinking", "thinking": "First", "closed": True},
-                    {"type": "text", "text": "Reply"},
-                    {"type": "thinking", "thinking": "Third", "closed": False},
                 ],
             },
         ),
@@ -647,7 +639,7 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
         # thinking: ThinkChunk only, no remaining content
         (
             AssistantMessage(content=[ThinkChunk(thinking="Just thinking", closed=True)]),
-            OpenAIReasoningField.thinking,
+            OpenAIReasoningField.thinking_chunks,
             {
                 "role": "assistant",
                 "content": [{"type": "thinking", "thinking": "Just thinking", "closed": True}],
@@ -684,7 +676,7 @@ def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[s
         # None content unchanged
         (
             AssistantMessage(content=None),
-            OpenAIReasoningField.thinking,
+            OpenAIReasoningField.thinking_chunks,
             {"role": "assistant"},
         ),
     ],
@@ -699,7 +691,7 @@ def test_assistant_message_to_openai_convert_thinking_format(
 
 def test_assistant_message_to_openai_none_warns_with_think_chunks() -> None:
     message = AssistantMessage(content=[ThinkChunk(thinking="Hmm", closed=True), TextChunk(text="Answer")])
-    with pytest.warns(FutureWarning, match=r"convert_thinking_format.*defaults to 'thinking'"):
+    with pytest.warns(FutureWarning, match=r"convert_thinking_format.*defaults to 'thinking_chunks'"):
         result = message.to_openai()
     assert result == {
         "role": "assistant",

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -174,10 +174,10 @@ class TestChatCompletionRequestNormalization:
             "a": AssistantMessage(content="a"),
             "a2": AssistantMessage(
                 content=[
-                    TextChunk(text="a1"),
-                    TextChunk(text="a2"),
                     ThinkChunk(thinking="t1"),
                     ThinkChunk(thinking="t2"),
+                    TextChunk(text="a1"),
+                    TextChunk(text="a2"),
                     TextChunk(text="a3"),
                 ]
             ),
@@ -221,10 +221,9 @@ class TestChatCompletionRequestNormalization:
             [
                 "u",
                 [
-                    TextChunk(text="a1\n\na2"),
                     ThinkChunk(thinking="t1"),
                     ThinkChunk(thinking="t2"),
-                    TextChunk(text="a3"),
+                    TextChunk(text="a1\n\na2\n\na3"),
                 ],
                 "u",
             ],

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -106,7 +106,7 @@ EXPECTED_TEXT_V13: str = (
     r'"Math expression."}}}}}][/AVAILABLE_TOOLS][INST]U1[/INST]A1'
     r"[TOOL_CALLS]F1[ARGS]{}[TOOL_CALLS]F2[ARGS]{}</s>"
     r"[TOOL_RESULTS]R1[/TOOL_RESULTS][TOOL_RESULTS]R2"
-    r"[/TOOL_RESULTS]A2[THINK]T1[/THINK]</s>[INST]U2[/INST]"
+    r"[/TOOL_RESULTS][THINK]T1[/THINK]A2</s>[INST]U2[/INST]"
 )
 
 
@@ -158,7 +158,7 @@ def messages() -> list[BaseMessage]:
         ),
         ToolMessage(content="R1", tool_call_id="123456789"),
         ToolMessage(content="R2", tool_call_id="999999999"),
-        AssistantMessage(content=[TextChunk(text="A2"), ThinkChunk(thinking="T1")]),
+        AssistantMessage(content=[ThinkChunk(thinking="T1"), TextChunk(text="A2")]),
         UserMessage(content="U2"),
     ]
 
@@ -278,15 +278,15 @@ def test_encode_think_chunk(v13_tekkenizer_think: InstructTokenizerV13) -> None:
             "A1",
         ),
         (
-            AssistantMessage(content=[TextChunk(text="A1"), ThinkChunk(thinking="T1")]),
-            "A1[THINK]T1[/THINK]",
+            AssistantMessage(content=[ThinkChunk(thinking="T1"), TextChunk(text="A1")]),
+            "[THINK]T1[/THINK]A1",
         ),
         (
             AssistantMessage(
-                content=[TextChunk(text="A1"), ThinkChunk(thinking="R1", closed=False)],
+                content=[ThinkChunk(thinking="R1", closed=False), TextChunk(text="A1")],
                 tool_calls=[ToolCall(id="123456789", function=FunctionCall(name="F1", arguments="{'a': 1}"))],
             ),
-            "A1[THINK]R1[TOOL_CALLS]F1[ARGS]\"{'a': 1}\"",
+            "[THINK]R1A1[TOOL_CALLS]F1[ARGS]\"{'a': 1}\"",
         ),
     ],
 )


### PR DESCRIPTION
This PR introduces the support of multiple conversion of thinking chunks to various format in order to be compliant with inference backends.

For now, our format is the default but it will be changed to vLLM in the future (reasoning field).