### PR TITLE
Raise multiple format of reasoning for from_openai

### DIFF
--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -5,6 +5,7 @@ from pydantic import Field
 from typing_extensions import Annotated, TypeAlias
 
 from mistral_common.base import MistralBase
+from mistral_common.exceptions import InvalidAssistantMessageException
 from mistral_common.protocol.instruct.chunk import (
     ContentChunk,
     TextChunk,
@@ -169,23 +170,30 @@ class AssistantMessage(BaseMessage):
         else:
             raise ValueError(f"Unknown content type: {type(openai_content)}")
 
-        reasoning_content: str | None = openai_message.get("reasoning_content")  # deprecated field
+        reasoning_content: str | None = openai_message.get("reasoning_content")
         reasoning: str | None = openai_message.get("reasoning")
 
         match reasoning_content, reasoning:
             case None, None:
-                thinking = None
+                openai_thinking = None
             case None, _:
-                thinking = reasoning
+                openai_thinking = reasoning
             case _, None:
-                thinking = reasoning_content
+                openai_thinking = reasoning_content
             case _, _:
                 if reasoning_content != reasoning:
                     raise ValueError("`reasoning_content` and `reasoning` should be equal.")
-                thinking = reasoning
+                openai_thinking = reasoning
 
-        if thinking is not None:
-            reasoning_chunk = ThinkChunk(thinking=thinking, closed=True)
+        if openai_thinking is not None:
+            has_thinking_chunks = isinstance(content, list) and any(isinstance(chunk, ThinkChunk) for chunk in content)
+            if has_thinking_chunks:
+                raise InvalidAssistantMessageException(
+                    "Message cannot have both thinking chunks in content and a top-level"
+                    " `reasoning` or `reasoning_content` field."
+                )
+
+            reasoning_chunk = ThinkChunk(thinking=openai_thinking, closed=True)
             if isinstance(content, str):
                 content = [reasoning_chunk, TextChunk(text=content)]
             elif content is None:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -31,6 +31,7 @@ from PIL import Image
 from pydantic_extra_types.language_code import LanguageAlpha2
 
 from mistral_common.audio import Audio
+from mistral_common.exceptions import InvalidAssistantMessageException
 from mistral_common.protocol.instruct.chunk import (
     AudioChunk,
     AudioURL,
@@ -535,6 +536,32 @@ def test_from_openai_reasoning_in_assistant_message(openai_message: dict[str, An
 def test_from_openai_reasoning_differ_reasoning_content_in_assistant_message() -> None:
     openai_message = {"role": "assistant", "content": "Hi", "reasoning": "Primary", "reasoning_content": "Fallback"}
     with pytest.raises(ValueError, match=r"`reasoning_content` and `reasoning` should be equal"):
+        AssistantMessage.from_openai(openai_message)
+
+
+@pytest.mark.parametrize(
+    "openai_message",
+    [
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "hmm", "closed": True}, {"type": "text", "text": "Hi"}],
+            "reasoning": "also thinking",
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "hmm", "closed": True}],
+            "reasoning_content": "also thinking",
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "hmm", "closed": True}],
+            "reasoning": "also thinking",
+            "reasoning_content": "also thinking",
+        },
+    ],
+)
+def test_from_openai_thinking_chunks_and_reasoning_raises(openai_message: dict[str, Any]) -> None:
+    with pytest.raises(InvalidAssistantMessageException):
         AssistantMessage.from_openai(openai_message)
 
 


### PR DESCRIPTION
Before reasoning and thinking chunks in the same message were supported.

This change will prevent that. This is to avoid duplication that is not easy to deduplicate.