### PR TITLE
Preserve zero OpenAI seed in chat request conversion

### DIFF
--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -215,7 +215,9 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
         if "seed" in kwargs and "random_seed" in kwargs:
             raise ValueError("Cannot specify both `seed` and `random_seed`.")
 
-        random_seed = kwargs.pop("seed", None) or kwargs.pop("random_seed", None)
+        random_seed = kwargs.pop("seed", None)
+        if random_seed is None:
+            random_seed = kwargs.pop("random_seed", None)
 
         filtered_kwargs = cls._filter_cls_fields(kwargs)
 

--- a/tests/validation/test_request.py
+++ b/tests/validation/test_request.py
@@ -13,3 +13,11 @@ class TestValidateRequest:
     def test_request_random_seed_negative(self, chat_request_raw: dict) -> None:
         with pytest.raises(ValidationError):
             ChatCompletionRequest(**chat_request_raw, random_seed=-1)
+
+    def test_from_openai_preserves_zero_seed(self) -> None:
+        request = ChatCompletionRequest.from_openai(
+            messages=[{"role": "user", "content": "hello"}],
+            seed=0,
+        )
+
+        assert request.random_seed == 0


### PR DESCRIPTION
## Root cause

`ChatCompletionRequest.from_openai()` translated OpenAI's `seed` argument with `kwargs.pop("seed", None) or kwargs.pop("random_seed", None)`. Because `0` is falsey, a valid `seed=0` was discarded and converted to `random_seed=None`.

## Change

Preserve `seed=0` by checking explicitly for `None` before falling back to `random_seed`.

## Validation

- `uv run pytest tests/validation/test_request.py`
- `uv run ruff check src/mistral_common/protocol/instruct/request.py tests/validation/test_request.py`
