### PR TITLE
Pin uv required-version and bump pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.8.4
+    rev: 0.11.14
     hooks:
       - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ docs = [
 
 
 [tool.uv]
-required-version = ">=0.11.14"
+required-version = "==0.11.14"
 
 [tool.ruff]
 lint.select = ["E", "F", "W", "Q", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ docs = [
 ]
 
 
+[tool.uv]
+required-version = ">=0.11.14"
+
 [tool.ruff]
 lint.select = ["E", "F", "W", "Q", "I"]
 lint.ignore = ["E203"]


### PR DESCRIPTION
## Summary

- Add `required-version = "==0.11.14"` under `[tool.uv]` in `pyproject.toml` so CI and local dev use a consistent uv version
- Bump `uv-pre-commit` hook from `0.8.4` to `0.11.14`