### PR TITLE
fix(tokenizer): point users at from_hf_hub on unknown model (#229)

### DIFF
--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -216,10 +216,7 @@ class MistralTokenizer(
 
     @classmethod
     def from_model(cls, model: str, strict: bool = True) -> "MistralTokenizer":
-        r"""Deprecated in favor of `from_hf_hub` or `from_file`, will be removed in 1.12.0.
-
-        The static `MODEL_NAME_TO_TOKENIZER_CLS` mapping is no longer kept in sync
-        with new model releases. Load tokenizers by repo or file instead.
+        r"""Deprecated in favor of `from_hf_hub` or `from_file`, will be removed in 1.13.0.
 
         Args:
             model: The model name.
@@ -229,7 +226,7 @@ class MistralTokenizer(
             The Mistral tokenizer for the given model.
         """
         warnings.warn(
-            "`MistralTokenizer.from_model` is deprecated and will be removed in 1.12.0. "
+            "`MistralTokenizer.from_model` is deprecated and will be removed in 1.13.0. "
             "Use `MistralTokenizer.from_hf_hub(...)` or `MistralTokenizer.from_file(...)` instead.",
             FutureWarning,
         )

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Any, Callable, Generic
 
@@ -215,7 +216,10 @@ class MistralTokenizer(
 
     @classmethod
     def from_model(cls, model: str, strict: bool = True) -> "MistralTokenizer":
-        r"""Get the Mistral tokenizer for a given model.
+        r"""Deprecated in favor of `from_hf_hub` or `from_file`, will be removed in 1.12.0.
+
+        The static `MODEL_NAME_TO_TOKENIZER_CLS` mapping is no longer kept in sync
+        with new model releases. Load tokenizers by repo or file instead.
 
         Args:
             model: The model name.
@@ -224,17 +228,19 @@ class MistralTokenizer(
         Returns:
             The Mistral tokenizer for the given model.
         """
+        warnings.warn(
+            "`MistralTokenizer.from_model` is deprecated and will be removed in 1.12.0. "
+            "Use `MistralTokenizer.from_hf_hub(...)` or `MistralTokenizer.from_file(...)` instead.",
+            FutureWarning,
+        )
 
         if not strict:
             raise ValueError("strict has to be `True` since v1.10.0.")
 
         if model not in MODEL_NAME_TO_TOKENIZER_CLS:
-            known = ", ".join(sorted(MODEL_NAME_TO_TOKENIZER_CLS))
             raise TokenizerException(
-                f"Unrecognized model: {model!r}. The static mapping in MistralTokenizer.from_model "
-                f"only covers older model snapshots; newer or custom models should be loaded with "
-                f"MistralTokenizer.from_hf_hub(repo_id=...) or MistralTokenizer.from_file(...). "
-                f"Known names: {known}."
+                f"Unrecognized model: {model}. Use `MistralTokenizer.from_hf_hub(...)` "
+                f"or `MistralTokenizer.from_file(...)` to load newer or custom models."
             )
 
         return MODEL_NAME_TO_TOKENIZER_CLS[model]()

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -229,7 +229,13 @@ class MistralTokenizer(
             raise ValueError("strict has to be `True` since v1.10.0.")
 
         if model not in MODEL_NAME_TO_TOKENIZER_CLS:
-            raise TokenizerException(f"Unrecognized model: {model}")
+            known = ", ".join(sorted(MODEL_NAME_TO_TOKENIZER_CLS))
+            raise TokenizerException(
+                f"Unrecognized model: {model!r}. The static mapping in MistralTokenizer.from_model "
+                f"only covers older model snapshots; newer or custom models should be loaded with "
+                f"MistralTokenizer.from_hf_hub(repo_id=...) or MistralTokenizer.from_file(...). "
+                f"Known names: {known}."
+            )
 
         return MODEL_NAME_TO_TOKENIZER_CLS[model]()
 

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -19,21 +19,24 @@ SPM_WHITESPACE = "▁"
 
 class TestMistralToknizer:
     def test_from_model(self) -> None:
-        assert isinstance(MistralTokenizer.from_model("mistral-medium-2312").instruct_tokenizer, InstructTokenizerV1)
-        assert isinstance(MistralTokenizer.from_model("mistral-tiny-2312").instruct_tokenizer, InstructTokenizerV2)
-        assert isinstance(MistralTokenizer.from_model("mistral-large-2402").instruct_tokenizer, InstructTokenizerV2)
-        assert isinstance(
-            MistralTokenizer.from_model("open-mixtral-8x22b-2404").instruct_tokenizer, InstructTokenizerV3
-        )
+        with pytest.warns(FutureWarning, match="from_model.*deprecated"):
+            assert isinstance(
+                MistralTokenizer.from_model("mistral-medium-2312").instruct_tokenizer, InstructTokenizerV1
+            )
+        with pytest.warns(FutureWarning):
+            assert isinstance(MistralTokenizer.from_model("mistral-tiny-2312").instruct_tokenizer, InstructTokenizerV2)
+        with pytest.warns(FutureWarning):
+            assert isinstance(MistralTokenizer.from_model("mistral-large-2402").instruct_tokenizer, InstructTokenizerV2)
+        with pytest.warns(FutureWarning):
+            assert isinstance(
+                MistralTokenizer.from_model("open-mixtral-8x22b-2404").instruct_tokenizer, InstructTokenizerV3
+            )
 
-        with pytest.raises(TokenizerException) as exc_info:
+        with pytest.warns(FutureWarning), pytest.raises(TokenizerException) as exc_info:
             MistralTokenizer.from_model("unknown-model")
 
-        # The error should point users at from_hf_hub / from_file so they can
-        # handle model snapshots that aren't in the static mapping, and echo
-        # the bad name so typos are obvious.
         msg = str(exc_info.value)
-        assert "'unknown-model'" in msg
+        assert "unknown-model" in msg
         assert "from_hf_hub" in msg
         assert "from_file" in msg
 
@@ -147,7 +150,7 @@ def test_tokenizer_is_pickleable_with_multiprocessing(
 
 
 def test_mistral_tokenizer_version_property() -> None:
-    tokenizer_v1 = MistralTokenizer.from_model("mistral-medium-2312")
+    tokenizer_v1 = MistralTokenizer.v1()
     assert (
         tokenizer_v1.version
         == tokenizer_v1.instruct_tokenizer.version
@@ -155,7 +158,7 @@ def test_mistral_tokenizer_version_property() -> None:
         == TokenizerVersion.v1
     )
 
-    tokenizer_v3 = MistralTokenizer.from_model("open-mixtral-8x22b-2404")
+    tokenizer_v3 = MistralTokenizer.v3()
     assert (
         tokenizer_v3.version
         == tokenizer_v3.instruct_tokenizer.version

--- a/tests/test_mistral_tokenizer.py
+++ b/tests/test_mistral_tokenizer.py
@@ -26,8 +26,16 @@ class TestMistralToknizer:
             MistralTokenizer.from_model("open-mixtral-8x22b-2404").instruct_tokenizer, InstructTokenizerV3
         )
 
-        with pytest.raises(TokenizerException):
+        with pytest.raises(TokenizerException) as exc_info:
             MistralTokenizer.from_model("unknown-model")
+
+        # The error should point users at from_hf_hub / from_file so they can
+        # handle model snapshots that aren't in the static mapping, and echo
+        # the bad name so typos are obvious.
+        msg = str(exc_info.value)
+        assert "'unknown-model'" in msg
+        assert "from_hf_hub" in msg
+        assert "from_file" in msg
 
     @pytest.mark.parametrize(
         ["special_token_policy", "is_tekken"],

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -446,31 +446,32 @@ def test_truncation_failed(request: pytest.FixtureRequest, tekkenizer: str, mess
 
 
 def test_from_model() -> None:
-    tokenizer = MistralTokenizer.from_model("ministral-8b-2410")
-    assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v3
-    assert tokenizer.instruct_tokenizer.image_encoder is None
+    with pytest.warns(FutureWarning, match="from_model.*deprecated"):
+        tokenizer = MistralTokenizer.from_model("ministral-8b-2410")
+        assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v3
+        assert tokenizer.instruct_tokenizer.image_encoder is None
 
-    tokenizer = MistralTokenizer.from_model("mistral-small-2402")
-    assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v2
-    assert tokenizer.instruct_tokenizer.image_encoder is None
+        tokenizer = MistralTokenizer.from_model("mistral-small-2402")
+        assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v2
+        assert tokenizer.instruct_tokenizer.image_encoder is None
 
-    tokenizer = MistralTokenizer.from_model("mistral-small-2409")
-    assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v3
-    assert tokenizer.instruct_tokenizer.image_encoder is None
+        tokenizer = MistralTokenizer.from_model("mistral-small-2409")
+        assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v3
+        assert tokenizer.instruct_tokenizer.image_encoder is None
 
-    tokenizer = MistralTokenizer.from_model("mistral-large-2411")
-    assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v7
-    assert tokenizer.instruct_tokenizer.image_encoder is None
+        tokenizer = MistralTokenizer.from_model("mistral-large-2411")
+        assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v7
+        assert tokenizer.instruct_tokenizer.image_encoder is None
 
-    tokenizer = MistralTokenizer.from_model("pixtral-large-2411")
-    assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v7
-    assert tokenizer.instruct_tokenizer.image_encoder is not None
+        tokenizer = MistralTokenizer.from_model("pixtral-large-2411")
+        assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v7
+        assert tokenizer.instruct_tokenizer.image_encoder is not None
 
-    tokenizer = MistralTokenizer.from_model("pixtral-12b-2409")
-    assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v3
-    assert tokenizer.instruct_tokenizer.image_encoder is not None
+        tokenizer = MistralTokenizer.from_model("pixtral-12b-2409")
+        assert tokenizer.instruct_tokenizer.tokenizer.version == TokenizerVersion.v3
+        assert tokenizer.instruct_tokenizer.image_encoder is not None
 
-    with pytest.raises(TokenizerException):
+    with pytest.warns(FutureWarning), pytest.raises(TokenizerException):
         MistralTokenizer.from_model("unknown-model")
 
 


### PR DESCRIPTION
\`MistralTokenizer.from_model\` raises \`TokenizerException(\"Unrecognized model: X\")\` whenever the model name isn't in \`MODEL_NAME_TO_TOKENIZER_CLS\`. That mapping only covers older snapshots (latest entry is \`2411\`), so anything new — \`mistral-small-3\`, \`mistral-medium-3\`, \`magistral-medium\`, \`saba\`, ...  — hits this branch and the caller has no idea what to do next.

This swaps the bare message for one that points at the existing escape hatches and echoes the failing name so typos are obvious:

\`\`\`text
Unrecognized model: 'mistral-small-3-2501'. The static mapping in
MistralTokenizer.from_model only covers older model snapshots; newer or
custom models should be loaded with MistralTokenizer.from_hf_hub(repo_id=...)
or MistralTokenizer.from_file(...). Known names: codestral-2405, codestral-mamba-2407, ...
\`\`\`

I considered also adding new entries to \`MODEL_NAME_TO_TOKENIZER_CLS\` for the recent models, but I don't want to guess at the right tokenizer version (v3-tekken vs v7 vs v11 with image config) for each model — that decision really has to come from your side. Happy to send a follow-up once the mapping for the newer snapshots is published.

Refs #229.

## Tests

Existing \`tests/test_mistral_tokenizer.py::test_from_model\` already asserts \`TokenizerException\` for \`\"unknown-model\"\`. Extended it to also assert the message includes the offending name and the two escape hatches:

\`\`\`
$ pytest tests/test_mistral_tokenizer.py::TestMistralToknizer::test_from_model
1 passed in 0.40s
\`\`\`