### PR TITLE
Fix: forward continue_final_message in tekken normalizers (V7/V15)

### DIFF
--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -450,7 +450,11 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
         if settings != ModelSettings.none():
             raise InvalidRequestException(f"Model settings are not supported for {type(self).__name__}, got {settings}")
         return self._instruct_request_class(  # type: ignore[no-any-return]
-            messages=messages, system_prompt=None, available_tools=request.tools, settings=settings
+            messages=messages,
+            system_prompt=None,
+            available_tools=request.tools,
+            continue_final_message=request.continue_final_message,
+            settings=settings,
         )
 
 
@@ -554,7 +558,11 @@ class InstructRequestNormalizerV15(InstructRequestNormalizerV13):
         messages = self._aggregate_messages(request.messages)
         settings = self.build_settings(request)
         return self._instruct_request_class(  # type: ignore[no-any-return]
-            messages=messages, system_prompt=None, available_tools=request.tools, settings=settings
+            messages=messages,
+            system_prompt=None,
+            available_tools=request.tools,
+            continue_final_message=request.continue_final_message,
+            settings=settings,
         )
 
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -386,6 +386,14 @@ class TestChatCompletionRequestNormalization:
         )
         assert parsed_request.settings == ModelSettings.none()
 
+    def test_continue_final_message_forwarded(self, normalizer: InstructRequestNormalizer) -> None:
+        request = ChatCompletionRequest[ChatMessage](
+            messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+            continue_final_message=True,
+        )
+        result: InstructRequest[ChatMessage, Tool] = normalizer.from_chat_completion_request(request)
+        assert result.continue_final_message is True
+
 
 class TestChatCompletionRequestNormalizationV7:
     @pytest.fixture(autouse=True)
@@ -503,6 +511,14 @@ class TestChatCompletionRequestNormalizationV7:
             chat_completion_request
         )
         assert parsed_request.settings == ModelSettings.none()
+
+    def test_continue_final_message_forwarded(self, normalizer_v7: InstructRequestNormalizerV7) -> None:
+        request = ChatCompletionRequest[ChatMessage](
+            messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+            continue_final_message=True,
+        )
+        result: InstructRequest[ChatMessage, Tool] = normalizer_v7.from_chat_completion_request(request)
+        assert result.continue_final_message is True
 
 
 class TestFineTuningNormalizer:
@@ -804,6 +820,14 @@ class TestChatCompletionRequestNormalizationV13:
         )
         assert parsed_request.settings == ModelSettings.none()
 
+    def test_continue_final_message_forwarded(self, normalizer_v13: InstructRequestNormalizerV13) -> None:
+        request = ChatCompletionRequest[ChatMessage](
+            messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+            continue_final_message=True,
+        )
+        result: InstructRequest[ChatMessage, Tool] = normalizer_v13.from_chat_completion_request(request)
+        assert result.continue_final_message is True
+
 
 class TestChatCompletionRequestNormalizationV15:
     @pytest.fixture(autouse=True)
@@ -832,6 +856,15 @@ class TestChatCompletionRequestNormalizationV15:
             chat_completion_request
         )
         assert parsed_request.settings == ModelSettings(reasoning_effort=reasoning_effort)
+
+    def test_continue_final_message_forwarded(self, normalizer_v15: InstructRequestNormalizerV15) -> None:
+        request = ChatCompletionRequest[ChatMessage](
+            messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+            continue_final_message=True,
+            reasoning_effort=ReasoningEffort.high,
+        )
+        result: InstructRequest[ChatMessage, Tool] = normalizer_v15.from_chat_completion_request(request)
+        assert result.continue_final_message is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -392,3 +392,19 @@ def test_encode_chat_completion_request_with_sp_and_audio(
     encoded = mistral_tokenizer_v13.encode_chat_completion(ChatCompletionRequest(messages=messages))
     assert encoded.text == "<s>[SYSTEM_PROMPT]hello[/SYSTEM_PROMPT][INST][BEGIN_AUDIO][AUDIO][AUDIO][/INST]"
     assert len(encoded.audios) == 1
+
+
+def test_encode_chat_completion_continue_final_message(v13_tekkenizer: InstructTokenizerV13) -> None:
+    request_normalizer = InstructRequestNormalizerV13.normalizer()
+    validator = MistralRequestValidatorV13()
+    mistral_tokenizer = MistralTokenizer(
+        instruct_tokenizer=v13_tekkenizer, validator=validator, request_normalizer=request_normalizer
+    )
+    request: ChatCompletionRequest = ChatCompletionRequest(
+        messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+        continue_final_message=True,
+    )
+    encoded = mistral_tokenizer.encode_chat_completion(request)
+
+    eos_id = v13_tekkenizer.tokenizer.eos_id
+    assert encoded.tokens[-1] != eos_id

--- a/tests/test_tokenizer_v15.py
+++ b/tests/test_tokenizer_v15.py
@@ -281,3 +281,16 @@ def test_end_to_end_no_default(messages: list[ChatMessage], reasoning_effort: Re
     else:
         # None with no default -> no model settings encoded
         assert "[MODEL_SETTINGS]" not in text
+
+
+def test_encode_chat_completion_continue_final_message() -> None:
+    builder = _build_model_settings_builder(("none", "high"))
+    tokenizer_v15 = get_v15_mistral_tokenizer(builder)
+    request: ChatCompletionRequest = ChatCompletionRequest(
+        messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+        continue_final_message=True,
+    )
+    encoded = tokenizer_v15.encode_chat_completion(request)
+
+    eos_id = tokenizer_v15.instruct_tokenizer.tokenizer.eos_id
+    assert encoded.tokens[-1] != eos_id

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -518,3 +518,22 @@ def test_assistant_tool_call_and_content(request: pytest.FixtureRequest, tekkeni
     tokens_2 = mistral_tokenizer.encode_chat_completion(chat_completion_request)
 
     assert tokens == tokens_2.tokens
+
+
+def test_encode_chat_completion_continue_final_message() -> None:
+    # Regression: the tekken normalizers (V7/V15) dropped continue_final_message
+    # when converting ChatCompletionRequest -> InstructRequest, so the full
+    # encode_chat_completion path appended EOS. encode_instruct was unaffected,
+    # which is why the existing test missed it. See #232.
+    tokenizer = MistralTokenizer.v7(is_mm=True)
+    eos_id = tokenizer.instruct_tokenizer.tokenizer.eos_id
+
+    request: ChatCompletionRequest = ChatCompletionRequest(
+        messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+        continue_final_message=True,
+    )
+    encoded = tokenizer.encode_chat_completion(request)
+
+    assert encoded.tokens == [1, 3, 1032, 4, 1055]
+    assert encoded.tokens[-1] != eos_id
+    assert eos_id not in encoded.prefix_ids

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -521,10 +521,6 @@ def test_assistant_tool_call_and_content(request: pytest.FixtureRequest, tekkeni
 
 
 def test_encode_chat_completion_continue_final_message() -> None:
-    # Regression: the tekken normalizers (V7/V15) dropped continue_final_message
-    # when converting ChatCompletionRequest -> InstructRequest, so the full
-    # encode_chat_completion path appended EOS. encode_instruct was unaffected,
-    # which is why the existing test missed it. See #232.
     tokenizer = MistralTokenizer.v7(is_mm=True)
     eos_id = tokenizer.instruct_tokenizer.tokenizer.eos_id
 

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -518,3 +518,18 @@ def test_assistant_tool_call_and_content(request: pytest.FixtureRequest, tekkeni
     tokens_2 = mistral_tokenizer.encode_chat_completion(chat_completion_request)
 
     assert tokens == tokens_2.tokens
+
+
+def test_encode_chat_completion_continue_final_message() -> None:
+    tokenizer = MistralTokenizer.v7(is_mm=True)
+    eos_id = tokenizer.instruct_tokenizer.tokenizer.eos_id
+
+    request: ChatCompletionRequest = ChatCompletionRequest(
+        messages=[UserMessage(content="a"), AssistantMessage(content="b")],
+        continue_final_message=True,
+    )
+    encoded = tokenizer.encode_chat_completion(request)
+
+    assert encoded.tokens == [1, 3, 1032, 4, 1055]
+    assert encoded.tokens[-1] != eos_id
+    assert eos_id not in encoded.prefix_ids


### PR DESCRIPTION
## What

`continue_final_message` is dropped on the tekken path. `InstructRequestNormalizerV7.from_chat_completion_request` and `InstructRequestNormalizerV15.from_chat_completion_request` build the `InstructRequest` without forwarding the flag, so it defaults to `False`. `continue_message` is then `False` in `encode_instruct`, and EOS is appended at `instruct.py` L1145 even when `continue_final_message=True`.

The base `InstructRequestNormalizer.from_chat_completion_request` forwards it correctly, so SentencePiece tokenizers (v1–v3) are unaffected; only tekken tokenizers (v7/v11/v13/v15) hit this — including Mistral-Small-3.2-24B.

## Repro

```python
from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
from mistral_common.protocol.instruct.request import ChatCompletionRequest

tok = MistralTokenizer.v7(is_mm=True)
req = ChatCompletionRequest.from_openai(
    messages=[{"role": "user", "content": "a"}, {"role": "assistant", "content": "b"}],
    continue_final_message=True,
)
tok.encode_chat_completion(req).tokens
# before: [1, 3, 1032, 4, 1055, 2]   <- trailing EOS (2)
# after:  [1, 3, 1032, 4, 1055]
```

## Fix

Forward `continue_final_message=request.continue_final_message` in both overrides.

## Test

Adds a regression test through the full `encode_chat_completion` path. The existing `test_tokenize_assistant_message_continue_final_message` only exercises `encode_instruct` on a hand-built `InstructRequest`, which bypasses the normalizer — that's why this regressed silently.

Fixes #232. Also resolves the downstream report at huggingface/transformers#46326; no transformers-side change is needed once this lands.