### PR TITLE
Add ToolMessage multimodal ContentChunk support

### DIFF
--- a/src/mistral_common/integrations/chat_templates/template_generator.py
+++ b/src/mistral_common/integrations/chat_templates/template_generator.py
@@ -1484,9 +1484,22 @@ def _generate_tool_message_handling(config: TemplateConfig) -> str:
                 + "' }}"  # noqa: E501
             )
     elif config.uses_simple_tool_results:
-        lines.append(
-            "        {{- '" + _BEGIN_TOOL_RESULTS + "' + message['content']|string + '" + _END_TOOL_RESULTS + "' }}"
-        )  # noqa: E501
+        if config.version >= TokenizerVersion.v15:
+            # V15+: tool messages support non-text content (images, audio)
+            tool_rc_args = "message['content'], 'tool message contents'"
+            if config.image_support or config.audio_support:
+                tool_rc_args += ", supported_types_desc='text'"
+            if config.image_support:
+                tool_rc_args += ", support_images=true"
+            if config.audio_support:
+                tool_rc_args += ", support_audio=true"
+            lines.append("        {{- '" + _BEGIN_TOOL_RESULTS + "' -}}")
+            lines.append("        {{- render_content(" + tool_rc_args + ") -}}")
+            lines.append("        {{- '" + _END_TOOL_RESULTS + "' }}")
+        else:
+            lines.append(
+                "        {{- '" + _BEGIN_TOOL_RESULTS + "' + message['content']|string + '" + _END_TOOL_RESULTS + "' }}"
+            )  # noqa: E501
     else:
         # v3 non-spm style
         lines.extend(_emit_int_float_parsing("        "))

--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import ConfigDict, Field, ValidationError, field_validator, model_validator
-from typing_extensions import Annotated
+from typing_extensions import Annotated, TypeAlias
 
 from mistral_common.base import MistralBase
 from mistral_common.deprecation import warn_once
@@ -454,6 +454,7 @@ ContentChunk = Annotated[
 UserContentChunk = Annotated[
     TextChunk | ImageChunk | ImageURLChunk | AudioChunk | AudioURLChunk, Field(discriminator="type")
 ]
+ToolContentChunk: TypeAlias = ContentChunk
 
 
 def _convert_openai_content_chunks(openai_content_chunks: dict[str, Any]) -> ContentChunk:

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -11,6 +11,7 @@ from mistral_common.protocol.instruct.chunk import (
     ContentChunk,
     TextChunk,
     ThinkChunk,
+    ToolContentChunk,
     UserContentChunk,
     _convert_openai_content_chunks,
 )
@@ -308,7 +309,7 @@ class ToolMessage(BaseMessage):
        >>> message = ToolMessage(content="Hello, how can I help you?", tool_call_id="123")
     """
 
-    content: str | list[TextChunk]
+    content: str | list[ToolContentChunk]
     role: Literal[Roles.tool] = Roles.tool
     tool_call_id: str | None = None
 
@@ -318,11 +319,27 @@ class ToolMessage(BaseMessage):
     def to_openai(self) -> dict[str, Any]:
         r"""Converts the message to the OpenAI format."""
         assert self.tool_call_id is not None, "tool_call_id must be provided for tool messages."
-        return self.model_dump(exclude={"name"})
+        if isinstance(self.content, str):
+            return {"role": self.role, "tool_call_id": self.tool_call_id, "content": self.content}
+        return {
+            "role": self.role,
+            "tool_call_id": self.tool_call_id,
+            "content": [chunk.to_openai() for chunk in self.content],
+        }
 
     @classmethod
     def from_openai(cls, messages: dict[str, str | list[dict[str, str | dict[str, Any]]]]) -> "ToolMessage":
         r"""Converts the OpenAI message to the Mistral format."""
+        content = messages.get("content")
+        if isinstance(content, list):
+            return cls.model_validate(
+                {
+                    "role": messages.get("role", "tool"),
+                    "tool_call_id": messages.get("tool_call_id"),
+                    "content": [_convert_openai_content_chunks(chunk) for chunk in content],
+                    "name": messages.get("name"),
+                }
+            )
         tool_message = cls.model_validate_ignore_extra(messages)
         assert tool_message.tool_call_id is not None, "tool_call_id must be provided for tool messages."
         return tool_message

--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -555,6 +555,39 @@ class InstructRequestNormalizerV15(InstructRequestNormalizerV13):
 
     _chunk_join_str: str = ""
 
+    def _aggregate_tool_messages(self, messages: list[UATS], latest_call_ids: list[str]) -> list[ToolMessageType]:
+        """V15 tool messages preserve non-text content chunks.
+
+        Text-only content is aggregated and JSON-normalized. Mixed content is preserved as-is.
+        """
+        tool_messages: list[ToolMessageType] = []
+        for message in messages:
+            assert isinstance(message, self._tool_message_class), "Expected tool message"
+            content = message.content
+            if isinstance(content, str):
+                normalized_content: str | list[ContentChunk] = self._normalize_json_content(content)
+            elif all(isinstance(chunk, TextChunk) for chunk in content):
+                text = self._aggregate_content_chunks_to_str_same_message(message)
+                normalized_content = self._normalize_json_content(text)
+            else:
+                normalized_content = list(content)
+            tool_messages.append(
+                self._tool_message_class(
+                    content=normalized_content, tool_call_id=message.tool_call_id, name=message.name
+                )
+            )
+
+        # Reorder by tool call order (inherited from V13)
+        id_to_tool_call_idx = {call_id: idx for idx, call_id in enumerate(latest_call_ids)}
+        id_to_tool_result_idx = {message.tool_call_id: idx for idx, message in enumerate(tool_messages)}
+        tool_messages.sort(
+            key=lambda msg: (
+                id_to_tool_call_idx.get(msg.tool_call_id or "null", float("inf")),
+                id_to_tool_result_idx[msg.tool_call_id],
+            ),
+        )
+        return tool_messages
+
     @staticmethod
     def normalizer(model_settings_builder: ModelSettingsBuilder | None = None) -> "InstructRequestNormalizerV15":
         r"""Returns a normalizer for the V15 instruct request.

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -104,7 +104,9 @@ class InstructTokenizerBase(
         return first_user_idx, last_user_idx
 
     @abstractmethod
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> list[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a tool message.
 
         Raises:
@@ -192,7 +194,9 @@ class InstructTokenizerBase(
                 images.extend(new_images)
                 audios.extend(new_audios)
             elif isinstance(msg, ToolMessage):
-                new_tokens = self.encode_tool_message(msg, msg_idx < last_user_idx)
+                new_tokens, new_images, new_audios = self.encode_tool_message(msg, msg_idx < last_user_idx)
+                images.extend(new_images)
+                audios.extend(new_audios)
             elif isinstance(msg, AssistantMessage):
                 continue_message = request.continue_final_message and (msg_idx == len(request.messages) - 1)
 
@@ -318,7 +322,9 @@ class InstructTokenizerV1(
         tokens = self.tokenizer.encode(content, bos=False, eos=False)
         return tokens, [], []
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> list[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a tool message.
 
         Raises:
@@ -480,9 +486,9 @@ class InstructTokenizerV2(
         except json.JSONDecodeError:
             return content
 
-    def _parse_tool_content(self, content: str | list[TextChunk]) -> Any:
+    def _parse_tool_content(self, content: str | list[ContentChunk]) -> Any:
         if isinstance(content, list):
-            content = "".join(chunk.text for chunk in content)
+            content = "".join(chunk.text for chunk in content if isinstance(chunk, TextChunk))
         return self._parse_json_content(content)
 
     def _prepare_tool_result(self, tool_message: ToolMessage) -> dict[str, Any]:
@@ -492,7 +498,9 @@ class InstructTokenizerV2(
             "content": self._parse_tool_content(tool_message.content),
         }
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> list[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a tool message.
 
         Args:
@@ -501,11 +509,11 @@ class InstructTokenizerV2(
                 not encoded.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         if is_before_last_user_message:
             # don't tokenize last tool response before last user msg
-            return []
+            return [], [], []
 
         # Currently only supports single tool results
         tool_result_str = json.dumps([self._prepare_tool_result(message)], ensure_ascii=False)
@@ -514,7 +522,7 @@ class InstructTokenizerV2(
             *self.tokenizer.encode(tool_result_str, bos=False, eos=False),
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, [], []
 
     def _prepare_function_call(self, tool_call: ToolCall) -> dict[str, Any]:
         r"""Bit of a hack due to the way function calls are tokenized."""
@@ -652,7 +660,9 @@ class InstructTokenizerV3(
             "call_id": tool_message.tool_call_id,
         }
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> list[int]:
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a tool message.
 
         Note:
@@ -665,7 +675,7 @@ class InstructTokenizerV3(
                 not encoded.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         tool_result_str = json.dumps(self._prepare_tool_result(message), ensure_ascii=False)
         curr_tokens = [
@@ -673,7 +683,7 @@ class InstructTokenizerV3(
             *self.tokenizer.encode(tool_result_str, bos=False, eos=False),
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, [], []
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
@@ -1081,24 +1091,27 @@ class InstructTokenizerV7(InstructTokenizerV3):
             for message in messages
         )
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> list[int]:
-        r"""Encode a tool message.
-
-        Note:
-            Same as [V3][mistral_common.tokens.tokenizers.instruct.InstructTokenizerV3.encode_tool_message]
-            but tools are not wrapped in a list and history is also tokenized
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
+        """Encode a tool message with multimodal content support.
 
         Args:
             message: The message to encode.
             is_before_last_user_message: Not used.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         assert message.tool_call_id is not None
-        assert isinstance(message.content, str), "Message content must be normalized"
         tool_call_id_tokens = self.tokenizer.encode(message.tool_call_id, bos=False, eos=False)
-        tokens = self.tokenizer.encode(message.content, bos=False, eos=False)
+
+        if isinstance(message.content, str):
+            content_tokens = self.tokenizer.encode(message.content, bos=False, eos=False)
+            images: list[np.ndarray] = []
+            audios: list[Audio] = []
+        else:
+            content_tokens, images, audios = self._encode_content_chunks(message.content)
 
         prefix_tokens = [
             self.BEGIN_TOOL_RESULTS,
@@ -1107,10 +1120,10 @@ class InstructTokenizerV7(InstructTokenizerV3):
         ]
         curr_tokens = [
             *prefix_tokens,
-            *tokens,
+            *content_tokens,
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, images, audios
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
@@ -1282,28 +1295,33 @@ class InstructTokenizerV13(InstructTokenizerV11):
             ]
         return curr_tokens
 
-    def encode_tool_message(self, message: ToolMessage, is_before_last_user_message: bool) -> list[int]:
-        r"""Encode a tool message.
+    def encode_tool_message(
+        self, message: ToolMessage, is_before_last_user_message: bool
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
+        """Encode a tool message with multimodal content support.
 
         Args:
             message: The message to encode.
             is_before_last_user_message: Not used.
+
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         assert message.tool_call_id is not None, "Tool call id must be provided for tokenizer >= v13"
 
-        content = message.content
-        if not isinstance(content, str):
-            content = "".join(chunk.text for chunk in content)
+        if isinstance(message.content, str):
+            content_tokens = self.tokenizer.encode(message.content, bos=False, eos=False)
+            images: list[np.ndarray] = []
+            audios: list[Audio] = []
+        else:
+            content_tokens, images, audios = self._encode_content_chunks(message.content)
 
-        tokens = self.tokenizer.encode(content, bos=False, eos=False)
         curr_tokens = [
             self.BEGIN_TOOL_RESULTS,
-            *tokens,
+            *content_tokens,
             self.END_TOOL_RESULTS,
         ]
-        return curr_tokens
+        return curr_tokens, images, audios
 
     def encode_think(self, chunk: ThinkChunk) -> list[int]:
         r"""Encode a thinking chunk.

--- a/tests/data/chat_templates/v15.jinja
+++ b/tests/data/chat_templates/v15.jinja
@@ -182,7 +182,9 @@
 
     {#- Tool messages only supports text content. #}
     {%- elif message['role'] == 'tool' %}
-        {{- '[TOOL_RESULTS]' + message['content']|string + '[/TOOL_RESULTS]' }}
+        {{- '[TOOL_RESULTS]' -}}
+        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}

--- a/tests/data/chat_templates/v15_audio.jinja
+++ b/tests/data/chat_templates/v15_audio.jinja
@@ -179,7 +179,9 @@
 
     {#- Tool messages only supports text content. #}
     {%- elif message['role'] == 'tool' %}
-        {{- '[TOOL_RESULTS]' + message['content']|string + '[/TOOL_RESULTS]' }}
+        {{- '[TOOL_RESULTS]' -}}
+        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text', support_audio=true) -}}
+        {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}

--- a/tests/data/chat_templates/v15_image.jinja
+++ b/tests/data/chat_templates/v15_image.jinja
@@ -190,7 +190,9 @@
 
     {#- Tool messages only supports text content. #}
     {%- elif message['role'] == 'tool' %}
-        {{- '[TOOL_RESULTS]' + message['content']|string + '[/TOOL_RESULTS]' }}
+        {{- '[TOOL_RESULTS]' -}}
+        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text', support_images=true) -}}
+        {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}

--- a/tests/data/chat_templates/v15_image_think.jinja
+++ b/tests/data/chat_templates/v15_image_think.jinja
@@ -217,7 +217,9 @@
 
     {#- Tool messages only supports text content. #}
     {%- elif message['role'] == 'tool' %}
-        {{- '[TOOL_RESULTS]' + message['content']|string + '[/TOOL_RESULTS]' }}
+        {{- '[TOOL_RESULTS]' -}}
+        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text', support_images=true) -}}
+        {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}

--- a/tests/data/chat_templates/v15_think.jinja
+++ b/tests/data/chat_templates/v15_think.jinja
@@ -209,7 +209,9 @@
 
     {#- Tool messages only supports text content. #}
     {%- elif message['role'] == 'tool' %}
-        {{- '[TOOL_RESULTS]' + message['content']|string + '[/TOOL_RESULTS]' }}
+        {{- '[TOOL_RESULTS]' -}}
+        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}

--- a/tests/integrations/chat_templates/fixtures_data.py
+++ b/tests/integrations/chat_templates/fixtures_data.py
@@ -861,6 +861,28 @@ REQUEST_CONSECUTIVE_USERS_AUDIO_TRAIN = ChatCompletionRequest(  # type: ignore[t
     ]
 )
 
+REQUEST_TOOL_IMAGE_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
+    messages=[
+        UserMessage(content="Get me an image of a cat"),
+        AssistantMessage(
+            tool_calls=[
+                ToolCall(
+                    function=FunctionCall(name="get_image", arguments='{"query": "cat"}'),
+                    id="tool_img_1",
+                ),
+            ]
+        ),
+        ToolMessage(
+            content=[
+                TextChunk(text="Here is the result:"),
+                ImageURLChunk(image_url=_IMAGE_URL),
+            ],
+            tool_call_id="tool_img_1",
+        ),
+        AssistantMessage(content="Here is a cat image."),
+    ]
+)
+
 REQUEST_CONSECUTIVE_ASSISTANTS_THINK_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
     messages=[
         UserMessage(content="Solve this problem"),
@@ -1080,6 +1102,8 @@ def _get_conversations(
                     REQUEST_CONSECUTIVE_USERS_MULTI_IMAGE_TRAIN,
                 ]
             )
+            if tokenizer_version >= TokenizerVersion.v15:
+                conversations.append(REQUEST_TOOL_IMAGE_TRAIN)
         if audio:
             conversations.append(REQUEST_CONSECUTIVE_USERS_AUDIO_TRAIN)
         if think:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from mistral_common.protocol.instruct.chunk import (
+    AudioURLChunk,
     ChunkTypes,
     ContentChunk,
     ImageURLChunk,
@@ -571,7 +572,6 @@ class TestChatCompletionRequestNormalizationV7:
 
     def test_complex_user_aggregation(self, normalizer_v7: InstructRequestNormalizerV7) -> None:
         """Complex multi-user-message aggregation with mixed str, chunks, empty, and non-text chunks."""
-
         chat_completion_request = mock_chat_completion(
             messages=[
                 UserMessage(content=""),
@@ -1093,6 +1093,81 @@ class TestChatCompletionRequestNormalizationV15:
         tool_msg = parsed.messages[2]
         assert isinstance(tool_msg, ToolMessage)
         assert tool_msg.content == "XY"
+
+
+class TestToolMessageContentChunk:
+    @pytest.fixture(autouse=True)
+    def normalizer(self) -> InstructRequestNormalizer:
+        return InstructRequestNormalizer(
+            UserMessage, AssistantMessage, ToolMessage, SystemMessage, InstructRequest, None
+        )
+
+    def test_tool_message_accepts_all_chunk_types(self, normalizer: InstructRequestNormalizer) -> None:
+        ToolMessage(content=[TextChunk(text="hello")], tool_call_id="1")
+        ToolMessage(content=[ThinkChunk(thinking="reasoning")], tool_call_id="1")
+        ToolMessage(content=[ImageURLChunk(image_url="https://example.com/img.png")], tool_call_id="1")
+        ToolMessage(content=[AudioURLChunk(audio_url="https://example.com/audio.wav")], tool_call_id="1")
+
+    def test_pre_v15_rejects_non_text_chunks_in_tool(self, normalizer: InstructRequestNormalizer) -> None:
+        """Pre-V15 normalizers reduce tool content to str, rejecting non-text chunks."""
+        normalizer_v7 = InstructRequestNormalizerV7.normalizer()
+        messages: list[ChatMessage] = [
+            UserMessage(content="What is this?"),
+            AssistantMessage(tool_calls=[ToolCall(function=FunctionCall(name="analyze", arguments="{}"), id="call_1")]),
+            ToolMessage(
+                content=[
+                    TextChunk(text="Analysis result:"),
+                    ImageURLChunk(image_url="https://example.com/result.png"),
+                ],
+                tool_call_id="call_1",
+            ),
+        ]
+        request = ChatCompletionRequest(messages=messages)
+        with pytest.raises(AssertionError):
+            normalizer_v7.from_chat_completion_request(request)
+
+    def test_v15_preserves_non_text_chunks_in_tool(self, normalizer: InstructRequestNormalizer) -> None:
+        """V15 normalizer preserves non-text chunks in tool messages."""
+        normalizer_v15 = InstructRequestNormalizerV15(
+            UserMessage,
+            AssistantMessage,
+            ToolMessage,
+            SystemMessage,
+            InstructRequest,
+            ModelSettingsBuilder(
+                reasoning_effort=EnumBuilder[ReasoningEffort](
+                    values=list(ReasoningEffort), accepts_none=False, default=None
+                )
+            ),
+        )
+        request = ChatCompletionRequest(
+            messages=[
+                UserMessage(content="What is this?"),
+                AssistantMessage(
+                    tool_calls=[ToolCall(function=FunctionCall(name="analyze", arguments="{}"), id="call_1")]
+                ),
+                ToolMessage(
+                    content=[
+                        TextChunk(text="Analysis result:"),
+                        ImageURLChunk(image_url="https://example.com/result.png"),
+                    ],
+                    tool_call_id="call_1",
+                ),
+            ],
+            reasoning_effort=ReasoningEffort.high,
+        )
+        parsed: InstructRequest[ChatMessage, Tool] = normalizer_v15.from_chat_completion_request(request)
+        tool_msg = parsed.messages[2]
+        assert isinstance(tool_msg, ToolMessage)
+        assert isinstance(tool_msg.content, list)
+        assert len(tool_msg.content) == 2
+
+    def test_tool_message_text_only_still_normalized(self, normalizer: InstructRequestNormalizer) -> None:
+        messages: list[ToolMessage] = [
+            ToolMessage(content=[TextChunk(text='{"key": "value"}')], tool_call_id="call_1"),
+        ]
+        result = normalizer._aggregate_tool_messages(messages, ["call_1"])
+        assert result[0].content == '{"key": "value"}'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -237,13 +237,30 @@ def test_end_to_end_v13_wrong_order(
 def test_encode_tool_message(v13_tekkenizer: InstructTokenizerV13) -> None:
     tool_message = ToolMessage(content="R1", tool_call_id="123456789")
     assert isinstance(v13_tekkenizer, InstructTokenizerV13)
-    encoded = v13_tekkenizer.encode_tool_message(tool_message, is_before_last_user_message=False)
+    encoded, images, audios = v13_tekkenizer.encode_tool_message(tool_message, is_before_last_user_message=False)
     assert encoded == [7, 182, 149, 8]
+    assert images == []
+    assert audios == []
 
     tool_message = ToolMessage(content=[TextChunk(text="R1"), TextChunk(text="R2")], tool_call_id="123456789")
     assert isinstance(v13_tekkenizer, InstructTokenizerV13)
-    encoded = v13_tekkenizer.encode_tool_message(tool_message, is_before_last_user_message=False)
+    encoded, images, audios = v13_tekkenizer.encode_tool_message(tool_message, is_before_last_user_message=False)
     assert encoded == [7, 182, 149, 182, 150, 8]
+    assert images == []
+    assert audios == []
+
+
+def test_encode_tool_message_with_audio(v13_tekkenizer_audio: InstructTokenizerV13, audio_chunk: AudioChunk) -> None:
+    tool_message = ToolMessage(
+        content=[TextChunk(text="R1"), audio_chunk],
+        tool_call_id="123456789",
+    )
+    encoded, images, audios = v13_tekkenizer_audio.encode_tool_message(tool_message, is_before_last_user_message=False)
+    assert len(audios) == 1
+    assert images == []
+    # Tokens should contain BEGIN_TOOL_RESULTS, text tokens, audio tokens, END_TOOL_RESULTS
+    assert encoded[0] == v13_tekkenizer_audio.BEGIN_TOOL_RESULTS
+    assert encoded[-1] == v13_tekkenizer_audio.END_TOOL_RESULTS
 
 
 def test_encode_think_chunk(v13_tekkenizer_think: InstructTokenizerV13) -> None:


### PR DESCRIPTION
## Summary

Widen `ToolMessage.content` from `str | list[TextChunk]` to `str | list[ToolContentChunk]` (all 6 chunk types).

**Depends on:** #235

## Changes

- Add `ToolContentChunk` type alias in `chunk.py`
- Widen `ToolMessage.content` type, update `to_openai`/`from_openai`
- Preserve non-text chunks in normalizer `_aggregate_tool_messages`
- Update `encode_tool_message` to return `tuple[list[int], list[np.ndarray], list[Audio]]` across all tokenizer versions
- Collect images/audios from tool messages in `encode_instruct`

## Tests

- Pydantic validation: all chunk types accepted
- Normalization: image chunks preserved, text-only still JSON-normalized
- Tokenizer: audio encoding in tool messages