### PR TITLE
Add AssistantMessage multimodal ContentChunk support

### DIFF
--- a/src/mistral_common/experimental/app/routers.py
+++ b/src/mistral_common/experimental/app/routers.py
@@ -145,7 +145,7 @@ async def detokenize_to_assistant_message(
 
     has_eos = tokens[-1] == settings.tokenizer.instruct_tokenizer.tokenizer.eos_id
 
-    return AssistantMessage(content=content, tool_calls=tool_calls, prefix=not has_eos)
+    return AssistantMessage(content=content, tool_calls=tool_calls, prefix=not has_eos)  # type: ignore[arg-type]
 
 
 @main_router.post("/v1/chat/completions", tags=["chat", "completions"])

--- a/src/mistral_common/integrations/chat_templates/template_generator.py
+++ b/src/mistral_common/integrations/chat_templates/template_generator.py
@@ -1232,6 +1232,10 @@ def _generate_assistant_message_handling(config: TemplateConfig) -> str:
         lines.append("        {%- endif %}")
         lines.append("")
 
+    # V15+ allows images/audio in assistant messages (matching normalizer's widened ContentChunk types)
+    assistant_supports_images = config.image_support and config.version >= TokenizerVersion.v15
+    assistant_supports_audio = config.audio_support and config.version >= TokenizerVersion.v15
+
     has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
     rc_call_args = "message['content'], 'assistant message contents'"
     if has_extra_types:
@@ -1242,9 +1246,9 @@ def _generate_assistant_message_handling(config: TemplateConfig) -> str:
     if config.any_thinking_support:
         rc_call_args += ", support_thinking=true"
     if config.image_support:
-        rc_call_args += ", support_images=false"
+        rc_call_args += f", support_images={'true' if assistant_supports_images else 'false'}"
     if config.audio_support:
-        rc_call_args += ", support_audio=false"
+        rc_call_args += f", support_audio={'true' if assistant_supports_audio else 'false'}"
 
     lines.append("        {%- if message['content'] %}")
 

--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import ConfigDict, Field, ValidationError, field_validator, model_validator
-from typing_extensions import Annotated
+from typing_extensions import Annotated, TypeAlias
 
 from mistral_common.base import MistralBase
 from mistral_common.deprecation import warn_once
@@ -454,6 +454,7 @@ ContentChunk = Annotated[
 UserContentChunk = Annotated[
     TextChunk | ImageChunk | ImageURLChunk | AudioChunk | AudioURLChunk, Field(discriminator="type")
 ]
+AssistantContentChunk: TypeAlias = ContentChunk
 
 
 def _convert_openai_content_chunks(openai_content_chunks: dict[str, Any]) -> ContentChunk:

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -8,6 +8,7 @@ from typing_extensions import Annotated, TypeAlias
 from mistral_common.base import MistralBase
 from mistral_common.exceptions import InvalidAssistantMessageException
 from mistral_common.protocol.instruct.chunk import (
+    AssistantContentChunk,
     ContentChunk,
     TextChunk,
     ThinkChunk,
@@ -23,11 +24,11 @@ warnings.filterwarnings(
 )
 
 
-def _are_think_chunks(think_chunks: list[ThinkChunk | TextChunk]) -> TypeGuard[list[ThinkChunk]]:
+def _are_think_chunks(think_chunks: list[ContentChunk]) -> TypeGuard[list[ThinkChunk]]:
     return all(isinstance(c, ThinkChunk) for c in think_chunks)
 
 
-def _are_text_chunks(think_chunks: list[ThinkChunk | TextChunk]) -> TypeGuard[list[TextChunk]]:
+def _are_text_chunks(think_chunks: list[ContentChunk]) -> TypeGuard[list[TextChunk]]:
     return all(isinstance(c, TextChunk) for c in think_chunks)
 
 
@@ -158,7 +159,7 @@ class AssistantMessage(BaseMessage):
     """
 
     role: Literal[Roles.assistant] = Roles.assistant
-    content: str | list[TextChunk | ThinkChunk] | None = None
+    content: str | list[AssistantContentChunk] | None = None
     tool_calls: list[ToolCall] | None = None
     prefix: bool = False
 

--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -266,6 +266,28 @@ class InstructRequestNormalizer(
             id=tool_call.id,
         )
 
+    def _narrow_assistant_content(self, content: list[ContentChunk] | str) -> str | list[TextChunk | ThinkChunk]:
+        """Validate and narrow content chunks for assistant messages.
+
+        Pre-V15 normalizers only allow TextChunk and ThinkChunk.
+
+        Args:
+            content: The aggregated content chunks.
+
+        Returns:
+            The validated and narrowed content.
+
+        Raises:
+            InvalidRequestException: If unsupported chunk types are found.
+        """
+        if isinstance(content, str):
+            return content
+        if _is_assistant_content(content):
+            return content
+        raise InvalidRequestException(
+            f"Unexpected content chunk types in assistant message: {[type(c).__name__ for c in content]}"
+        )
+
     def _aggregate_system_messages(self, messages: list[UATS]) -> list[SystemMessageType]:
         return []
 
@@ -296,15 +318,10 @@ class InstructRequestNormalizer(
                     )
                 weight = message.weight
 
-        if isinstance(content, str) or _is_assistant_content(content):
-            narrowed_content: str | list[TextChunk | ThinkChunk] = content
-        else:
-            raise InvalidRequestException(
-                f"Unexpected content chunk types in assistant message: {[type(c).__name__ for c in content]}"
-            )
+        validated_content = self._narrow_assistant_content(content)
 
         aggregated_message = self._assistant_message_class(
-            content=narrowed_content,
+            content=validated_content,
             tool_calls=tool_calls or None,
             prefix=prefix,
         )
@@ -554,6 +571,10 @@ class InstructRequestNormalizerV15(InstructRequestNormalizerV13):
     """
 
     _chunk_join_str: str = ""
+
+    def _narrow_assistant_content(self, content: list[ContentChunk] | str) -> str | list[ContentChunk]:
+        """V15 accepts all ContentChunk types in assistant messages."""
+        return content
 
     @staticmethod
     def normalizer(model_settings_builder: ModelSettingsBuilder | None = None) -> "InstructRequestNormalizerV15":

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -115,7 +115,7 @@ class InstructTokenizerBase(
     @abstractmethod
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
-    ) -> list[int]:
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode an assistant message.
 
         Raises:
@@ -196,9 +196,11 @@ class InstructTokenizerBase(
             elif isinstance(msg, AssistantMessage):
                 continue_message = request.continue_final_message and (msg_idx == len(request.messages) - 1)
 
-                new_tokens = self.encode_assistant_message(
+                new_tokens, new_images, new_audios = self.encode_assistant_message(
                     msg, msg_idx < last_user_idx, continue_message=continue_message
                 )
+                images.extend(new_images)
+                audios.extend(new_audios)
                 if msg_idx == len(request.messages) - 1:
                     prefix_ids = new_tokens
             elif isinstance(msg, SystemMessage):
@@ -328,7 +330,7 @@ class InstructTokenizerV1(
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
-    ) -> list[int]:
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode an assistant message.
 
         Args:
@@ -338,7 +340,7 @@ class InstructTokenizerV1(
                 Only use this if the assistant message is the last message.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         assert isinstance(message, AssistantMessage), message
         if message.tool_calls is not None and len(message.tool_calls) > 0:
@@ -354,7 +356,7 @@ class InstructTokenizerV1(
             raise TokenizerException(f"{message.content} // {message.tool_calls}")
         if not message.prefix and not continue_message:
             curr_tokens.append(self.tokenizer.eos_id)
-        return curr_tokens
+        return curr_tokens, [], []
 
     def encode_think(self, chunk: ThinkChunk) -> list[int]:
         r"""Encode a think chunk.
@@ -550,7 +552,7 @@ class InstructTokenizerV2(
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
-    ) -> list[int]:
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode an assistant message.
 
         Args:
@@ -561,7 +563,7 @@ class InstructTokenizerV2(
                 Only use this if the assistant message is the last message.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         if message.tool_calls and message.content:
             raise ValueError(f"Cannot have tool calls and content defined in the same assistant message {message}")
@@ -572,8 +574,7 @@ class InstructTokenizerV2(
 
         if message.tool_calls:
             if is_before_last_user_message:
-                # don't tokenize tool call before last user message
-                return []
+                return [], [], []
             curr_tokens = self._encode_tool_calls_in_assistant_message(message)
         elif message.content:
             assert isinstance(message.content, str), "Message content must be a string for tokenizer < V7"
@@ -582,7 +583,7 @@ class InstructTokenizerV2(
             raise TokenizerException(f"Invalid assistant message: {message.content}")
         if not message.prefix and not continue_message:
             curr_tokens.append(self.tokenizer.eos_id)
-        return curr_tokens
+        return curr_tokens, [], []
 
     def _encode_infilling(self, text: str) -> list[int]:
         r"""Remove prefix space in the case of SentencePieceTokenizers."""
@@ -677,7 +678,7 @@ class InstructTokenizerV3(
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
-    ) -> list[int]:
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode an assistant message.
 
         Note:
@@ -691,7 +692,7 @@ class InstructTokenizerV3(
             is_before_last_user_message: Not used.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         return super().encode_assistant_message(message, False, continue_message)
 
@@ -1114,7 +1115,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
 
     def encode_assistant_message(
         self, message: AssistantMessageType, is_before_last_user_message: bool, continue_message: bool
-    ) -> list[int]:
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode an assistant message.
 
         Args:
@@ -1124,7 +1125,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
                 Only use this if the assistant message is the last message.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
         if not message.content and not message.tool_calls:
             raise TokenizerException(f"Invalid assistant message: {message}")
@@ -1133,18 +1134,23 @@ class InstructTokenizerV7(InstructTokenizerV3):
                 "`continue_message` is only supported for assistant messages that have `prefix=False`."
             )
 
-        curr_tokens: list = []
+        curr_tokens: list[int] = []
+        images: list[np.ndarray] = []
+        audios: list[Audio] = []
         if message.content:
             if isinstance(message.content, str):
                 curr_tokens = self._encode_normal_content_assistant_message(message)
             elif isinstance(message.content, list):
-                curr_tokens += self._encode_content_chunks(message.content)[0]
+                content_tokens, new_images, new_audios = self._encode_content_chunks(message.content)
+                curr_tokens += content_tokens
+                images.extend(new_images)
+                audios.extend(new_audios)
         if message.tool_calls:
             curr_tokens += self._encode_tool_calls_in_assistant_message(message)
         if not message.prefix and not continue_message:
             curr_tokens.append(self.tokenizer.eos_id)
 
-        return curr_tokens
+        return curr_tokens, images, audios
 
     def _encode_audio_for_speech_request(self, ref_audio: str | bytes | None, voice: str | None) -> Tokenized:
         r"""Encode reference audio or voice preset into a Tokenized object.

--- a/tests/data/chat_templates/v15_audio.jinja
+++ b/tests/data/chat_templates/v15_audio.jinja
@@ -158,7 +158,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/data/chat_templates/v15_image.jinja
+++ b/tests/data/chat_templates/v15_image.jinja
@@ -169,7 +169,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/data/chat_templates/v15_image_think.jinja
+++ b/tests/data/chat_templates/v15_image_think.jinja
@@ -196,7 +196,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/guidance/test_guidance.py
+++ b/tests/guidance/test_guidance.py
@@ -228,16 +228,17 @@ def _encode_content(
     tokenizer = instruct_tokenizer.tokenizer
 
     if isinstance(content, str):
-        return instruct_tokenizer.encode_assistant_message(
+        tokens, _, _ = instruct_tokenizer.encode_assistant_message(
             AssistantMessage(content=content), is_before_last_user_message=False, continue_message=False
         )
+        return tokens
 
     tool_calls = [x for x in content if isinstance(x, ToolCall)]
     content_chunks = [x for x in content if not isinstance(x, ToolCall)]
 
-    tokens: list[int] = []
+    tokens = []
     if content_chunks:
-        tokens = instruct_tokenizer.encode_assistant_message(
+        tokens, _, _ = instruct_tokenizer.encode_assistant_message(
             AssistantMessage(content=content_chunks),
             is_before_last_user_message=False,
             continue_message=False,

--- a/tests/integrations/chat_templates/fixtures_data.py
+++ b/tests/integrations/chat_templates/fixtures_data.py
@@ -861,6 +861,19 @@ REQUEST_CONSECUTIVE_USERS_AUDIO_TRAIN = ChatCompletionRequest(  # type: ignore[t
     ]
 )
 
+REQUEST_ASSISTANT_IMAGE_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
+    messages=[
+        UserMessage(content="Describe this image"),
+        AssistantMessage(
+            content=[
+                TextChunk(text="Here is the image:"),
+                ImageURLChunk(image_url=_IMAGE_URL),
+                TextChunk(text="It shows a landscape."),
+            ]
+        ),
+    ]
+)
+
 REQUEST_CONSECUTIVE_ASSISTANTS_THINK_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
     messages=[
         UserMessage(content="Solve this problem"),
@@ -1080,6 +1093,8 @@ def _get_conversations(
                     REQUEST_CONSECUTIVE_USERS_MULTI_IMAGE_TRAIN,
                 ]
             )
+            if tokenizer_version >= TokenizerVersion.v15:
+                conversations.append(REQUEST_ASSISTANT_IMAGE_TRAIN)
         if audio:
             conversations.append(REQUEST_CONSECUTIVE_USERS_AUDIO_TRAIN)
         if think:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -588,7 +588,7 @@ def test_non_leading_think_chunks_construction_ok() -> None:
 )
 def test_non_leading_think_chunks_to_openai_raises(content: list[TextChunk | ThinkChunk]) -> None:
     """to_openai raises when ThinkChunks are not leading."""
-    msg = AssistantMessage(content=content)
+    msg = AssistantMessage(content=content)  # type: ignore[arg-type]
     with pytest.raises(InvalidAssistantMessageException, match="ThinkChunks must be leading"):
         msg.to_openai()
 

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -2,7 +2,9 @@ import json
 
 import pytest
 
+from mistral_common.exceptions import InvalidRequestException
 from mistral_common.protocol.instruct.chunk import (
+    AudioURLChunk,
     ChunkTypes,
     ContentChunk,
     ImageURLChunk,
@@ -1093,6 +1095,95 @@ class TestChatCompletionRequestNormalizationV15:
         tool_msg = parsed.messages[2]
         assert isinstance(tool_msg, ToolMessage)
         assert tool_msg.content == "XY"
+
+
+class TestAssistantMessageContentChunk:
+    def test_assistant_message_accepts_all_chunk_types(self) -> None:
+        AssistantMessage(content=[TextChunk(text="hello")])
+        AssistantMessage(content=[ThinkChunk(thinking="reasoning")])
+        AssistantMessage(content=[ImageURLChunk(image_url="https://example.com/img.png")])
+        AssistantMessage(content=[AudioURLChunk(audio_url="https://example.com/audio.wav")])
+
+    @staticmethod
+    def _make_v15_normalizer() -> InstructRequestNormalizerV15:
+        """Create a V15 normalizer with required model settings builder."""
+        return InstructRequestNormalizerV15(
+            UserMessage,
+            AssistantMessage,
+            ToolMessage,
+            SystemMessage,
+            InstructRequest,
+            ModelSettingsBuilder(
+                reasoning_effort=EnumBuilder[ReasoningEffort](
+                    values=list(ReasoningEffort), accepts_none=False, default=None
+                )
+            ),
+        )
+
+    def test_pre_v15_rejects_non_text_chunks_in_assistant(self) -> None:
+        """Pre-V15 normalizers reject non-text/think chunks in assistant messages."""
+        normalizer_v7 = InstructRequestNormalizerV7.normalizer()
+        messages: list[ChatMessage] = [
+            AssistantMessage(
+                content=[
+                    TextChunk(text="result"),
+                    ImageURLChunk(image_url="https://example.com/img.png"),
+                ]
+            ),
+        ]
+        request = ChatCompletionRequest(messages=messages)
+        with pytest.raises(InvalidRequestException, match="Unexpected content chunk types"):
+            normalizer_v7.from_chat_completion_request(request)
+
+    def test_v15_preserves_non_text_chunks_in_assistant(self) -> None:
+        """V15 normalizer accepts all ContentChunk types in assistant messages."""
+        normalizer_v15 = self._make_v15_normalizer()
+        request = ChatCompletionRequest(
+            messages=[
+                AssistantMessage(
+                    content=[
+                        TextChunk(text="result"),
+                        ImageURLChunk(image_url="https://example.com/img.png"),
+                    ]
+                ),
+            ],
+            reasoning_effort=ReasoningEffort.high,
+        )
+        parsed: InstructRequest[ChatMessage, Tool] = normalizer_v15.from_chat_completion_request(request)
+        assistant_msg = parsed.messages[0]
+        assert isinstance(assistant_msg, AssistantMessage)
+        assert isinstance(assistant_msg.content, list)
+        assert len(assistant_msg.content) == 2
+
+    def test_complex_assistant_aggregation_with_image_v15(self) -> None:
+        """Multi-assistant-message aggregation with ImageURLChunk on V15 (widened type, chunk_join_str="")."""
+        normalizer_v15 = self._make_v15_normalizer()
+        chat_completion_request = ChatCompletionRequest(
+            messages=[
+                AssistantMessage(content="A"),
+                AssistantMessage(content=[TextChunk(text="B")]),
+                AssistantMessage(
+                    content=[
+                        TextChunk(text="C"),
+                        TextChunk(text="D"),
+                        ImageURLChunk(image_url="E"),
+                        TextChunk(text="G"),
+                        TextChunk(text="H"),
+                    ]
+                ),
+            ],
+            reasoning_effort=ReasoningEffort.high,
+        )
+        parsed_request: InstructRequest[ChatMessage, Tool] = normalizer_v15.from_chat_completion_request(
+            chat_completion_request
+        )
+        first_message = parsed_request.messages[0]
+        assert isinstance(first_message, AssistantMessage)
+        assert first_message.content == [
+            TextChunk(text="A\n\nB\n\nCD"),
+            ImageURLChunk(image_url="E"),
+            TextChunk(text="GH"),
+        ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tokenizer_v11.py
+++ b/tests/test_tokenizer_v11.py
@@ -32,7 +32,7 @@ def test_special_tokens(tekkenizer: InstructTokenizerV11) -> None:
 
 
 def test_tokenize_assistant_message(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, images, audios = tekkenizer.encode_assistant_message(
         AssistantMessage(
             tool_calls=[ToolCall(function=FunctionCall(name="a_a_a", arguments="blabla"))],
         ),
@@ -61,7 +61,7 @@ def test_tokenize_assistant_message(tekkenizer: InstructTokenizerV11) -> None:
 
 
 def test_tokenize_assistant_message_continue_message(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, images, audios = tekkenizer.encode_assistant_message(
         AssistantMessage(
             content='"blabla"',
         ),
@@ -95,7 +95,7 @@ def test_tokenize_assistant_message_continue_message(tekkenizer: InstructTokeniz
 
 
 def test_tokenize_assistant_messages(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, images, audios = tekkenizer.encode_assistant_message(
         AssistantMessage(
             tool_calls=[
                 ToolCall(function=FunctionCall(name="a_a_a", arguments="blabla")),
@@ -135,7 +135,7 @@ def test_tokenize_assistant_messages(tekkenizer: InstructTokenizerV11) -> None:
 
 
 def test_tokenize_assistant_message_train(tekkenizer: InstructTokenizerV11) -> None:
-    tokens = tekkenizer.encode_assistant_message(
+    tokens, images, audios = tekkenizer.encode_assistant_message(
         AssistantMessage(
             tool_calls=[ToolCall(function=FunctionCall(name="a_a_a", arguments="blabla"), id="ABC")],
         ),

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -246,6 +246,20 @@ def test_encode_tool_message(v13_tekkenizer: InstructTokenizerV13) -> None:
     assert encoded == [7, 182, 149, 182, 150, 8]
 
 
+def test_encode_assistant_message_with_audio(
+    v13_tekkenizer_audio: InstructTokenizerV13, audio_chunk: AudioChunk
+) -> None:
+    message = AssistantMessage(content=[TextChunk(text="result"), audio_chunk])
+    tokens, images, audios = v13_tekkenizer_audio.encode_assistant_message(
+        message, is_before_last_user_message=False, continue_message=False
+    )
+    decoded = v13_tekkenizer_audio.decode(tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert "result" in decoded
+    assert "[BEGIN_AUDIO]" in decoded
+    assert len(audios) == 1
+    assert images == []
+
+
 def test_encode_think_chunk(v13_tekkenizer_think: InstructTokenizerV13) -> None:
     assert isinstance(v13_tekkenizer_think, InstructTokenizerV13)
     think_chunk = ThinkChunk(
@@ -295,7 +309,7 @@ def test_tokenize_assistant_message(
     v13_tekkenizer_think: InstructTokenizerV13, message: AssistantMessage, expected: str, continue_final_message: bool
 ) -> None:
     if not continue_final_message:
-        tokens = v13_tekkenizer_think.encode_assistant_message(
+        tokens, images, audios = v13_tekkenizer_think.encode_assistant_message(
             message, is_before_last_user_message=False, continue_message=continue_final_message
         )
         if not message.prefix:
@@ -310,7 +324,7 @@ def test_tokenize_assistant_message(
                     message, is_before_last_user_message=False, continue_message=continue_final_message
                 )
             return
-        tokens = v13_tekkenizer_think.encode_assistant_message(
+        tokens, images, audios = v13_tekkenizer_think.encode_assistant_message(
             message, is_before_last_user_message=False, continue_message=continue_final_message
         )
     assert v13_tekkenizer_think.decode(tokens, special_token_policy=SpecialTokenPolicy.KEEP) == expected


### PR DESCRIPTION
## Summary

Widen `AssistantMessage.content` from `str | list[TextChunk | ThinkChunk] | None` to `str | list[AssistantContentChunk] | None` (all 6 chunk types).

**Depends on:** #235

## Changes

- Add `AssistantContentChunk` type alias in `chunk.py`
- Widen `AssistantMessage.content` type
- Widen `_are_think_chunks`/`_are_text_chunks` helpers to accept `list[ContentChunk]`
- Update `encode_assistant_message` to return `tuple[list[int], list[np.ndarray], list[Audio]]` across all tokenizer versions
- Collect images/audios from assistant messages in `encode_instruct`

## Tests

- Pydantic validation: all chunk types accepted
- Normalization: non-text chunks preserved in assistant messages
- Tokenizer: audio encoding in assistant messages, ImageURLChunk aggregation