### PR TITLE
Add SystemMessage audio ContentChunk support

### DIFF
--- a/src/mistral_common/integrations/chat_templates/template_generator.py
+++ b/src/mistral_common/integrations/chat_templates/template_generator.py
@@ -867,11 +867,16 @@ def _generate_system_message_handling(config: TemplateConfig) -> str:
     else:
         lines.append("        {{- '" + _BEGIN_SYSTEM + "' -}}")
 
+    # V15+ allows audio in system messages (matching tokenizer's widened SystemContentChunk types)
+    system_supports_audio = config.audio_support and config.version >= TokenizerVersion.v15
+
     has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
     rc_args = "message['content'], 'system message contents'"
     if has_extra_types:
         if config.system_supports_thinking:
             rc_args += ", supported_types_desc='text and thinking'"
+        elif system_supports_audio:
+            rc_args += ", supported_types_desc='text and audio'"
         else:
             rc_args += ", supported_types_desc='text'"
     if config.any_thinking_support:
@@ -882,7 +887,7 @@ def _generate_system_message_handling(config: TemplateConfig) -> str:
     if config.image_support:
         rc_args += ", support_images=false"
     if config.audio_support:
-        rc_args += ", support_audio=false"
+        rc_args += f", support_audio={'true' if system_supports_audio else 'false'}"
     lines.append("        {{- render_content(" + rc_args + ") -}}")
 
     lines.append("        {{- '" + _END_SYSTEM + "' -}}")

--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -454,6 +454,7 @@ ContentChunk = Annotated[
 UserContentChunk = Annotated[
     TextChunk | ImageChunk | ImageURLChunk | AudioChunk | AudioURLChunk, Field(discriminator="type")
 ]
+SystemContentChunk = Annotated[TextChunk | AudioChunk | ThinkChunk, Field(discriminator="type")]
 
 
 def _convert_openai_content_chunks(openai_content_chunks: dict[str, Any]) -> ContentChunk:

--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -9,6 +9,7 @@ from mistral_common.base import MistralBase
 from mistral_common.exceptions import InvalidAssistantMessageException
 from mistral_common.protocol.instruct.chunk import (
     ContentChunk,
+    SystemContentChunk,
     TextChunk,
     ThinkChunk,
     UserContentChunk,
@@ -132,15 +133,25 @@ class SystemMessage(BaseMessage):
     """
 
     role: Literal[Roles.system] = Roles.system
-    content: str | list[TextChunk | ThinkChunk]
+    content: str | list[SystemContentChunk]
 
     def to_openai(self) -> dict[str, Any]:
         r"""Converts the message to the OpenAI format."""
-        return self.model_dump()
+        if isinstance(self.content, str):
+            return {"role": self.role, "content": self.content}
+        return {"role": self.role, "content": [chunk.to_openai() for chunk in self.content]}
 
     @classmethod
     def from_openai(cls, openai_message: dict[str, Any]) -> "SystemMessage":
         r"""Converts the OpenAI message to the Mistral format."""
+        content = openai_message.get("content")
+        if isinstance(content, list):
+            return cls.model_validate(
+                {
+                    "role": openai_message.get("role", "system"),
+                    "content": [_convert_openai_content_chunks(chunk) for chunk in content],
+                }
+            )
         return cls.model_validate_ignore_extra(openai_message)
 
 

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -202,7 +202,9 @@ class InstructTokenizerBase(
                 if msg_idx == len(request.messages) - 1:
                     prefix_ids = new_tokens
             elif isinstance(msg, SystemMessage):
-                new_tokens = self.encode_system_message(msg)
+                new_tokens, new_images, new_audios = self.encode_system_message(msg)
+                images.extend(new_images)
+                audios.extend(new_audios)
             else:
                 raise TokenizerException(f"Unknown message type {type(msg)}")
 
@@ -289,7 +291,12 @@ class InstructTokenizerV1(
         curr_tokens, image, audio = self.encode_user_content(content=message_txt, is_last=False, system_prompt=None)
         return curr_tokens, image, audio
 
-    def encode_system_message(self, message: SystemMessage) -> list[int]:
+    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[np.ndarray], list[Audio]]:
+        """Encode a system message.
+
+        Raises:
+            NotImplementedError: System message encoding is not implemented for this version.
+        """
         raise NotImplementedError(f"System message encoding not implemented for {self.__class__.__name__}")
 
     def encode_user_content(
@@ -867,22 +874,22 @@ class InstructTokenizerV7(InstructTokenizerV3):
         if to_drop > 0:
             raise TokenizerException("Input couldn't fit in truncate_at_max_token")
 
-    def encode_system_message(self, message: SystemMessage) -> list[int]:
-        r"""Encode a system message.
+    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[np.ndarray], list[Audio]]:
+        """Encode a system message with audio content support.
 
         Args:
             message: The message to encode.
 
         Returns:
-            The encoded tokens.
+            The encoded tokens, images, and audios.
         """
-
         tokens = [self.BEGIN_SYSTEM]
         if isinstance(content := message.content, str):
             content = [TextChunk(text=content)]
-        tokens += self._encode_content_chunks(content)[0]
+        content_tokens, images, audios = self._encode_content_chunks(content)
+        tokens += content_tokens
         tokens.append(self.END_SYSTEM)
-        return tokens
+        return tokens, images, audios
 
     def encode_user_content(
         self,
@@ -1368,7 +1375,7 @@ class InstructTokenizerV15(InstructTokenizerV13):
         ]
         return settings_tokens
 
-    def encode_system_message(self, message: SystemMessage) -> list[int]:
+    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a system message, rejecting ThinkChunk content."""
         if isinstance(message.content, list):
             if any(isinstance(chunk, ThinkChunk) for chunk in message.content):

--- a/tests/data/chat_templates/v15_audio.jinja
+++ b/tests/data/chat_templates/v15_audio.jinja
@@ -184,7 +184,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and audio', support_audio=true) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/integrations/chat_templates/fixtures_data.py
+++ b/tests/integrations/chat_templates/fixtures_data.py
@@ -861,6 +861,19 @@ REQUEST_CONSECUTIVE_USERS_AUDIO_TRAIN = ChatCompletionRequest(  # type: ignore[t
     ]
 )
 
+REQUEST_SYSTEM_AUDIO_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
+    messages=[
+        SystemMessage(
+            content=[
+                TextChunk(text="You are a transcription assistant. Listen to this context:"),
+                AudioURLChunk(audio_url=_AUDIO_URL),
+            ]
+        ),
+        UserMessage(content="Summarize what you heard"),
+        AssistantMessage(content="The audio contains a brief conversation."),
+    ]
+)
+
 REQUEST_CONSECUTIVE_ASSISTANTS_THINK_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
     messages=[
         UserMessage(content="Solve this problem"),
@@ -1082,6 +1095,8 @@ def _get_conversations(
             )
         if audio:
             conversations.append(REQUEST_CONSECUTIVE_USERS_AUDIO_TRAIN)
+            if tokenizer_version >= TokenizerVersion.v15:
+                conversations.append(REQUEST_SYSTEM_AUDIO_TRAIN)
         if think:
             conversations.extend(
                 [

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,8 +1,10 @@
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from mistral_common.protocol.instruct.chunk import (
+    AudioChunk,
     ChunkTypes,
     ContentChunk,
     ImageURLChunk,
@@ -34,6 +36,7 @@ from mistral_common.protocol.instruct.request import (
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.tokens.tokenizers.base import TokenizerVersion
 from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, ModelSettingsBuilder
+from tests.fixtures.audio import get_dummy_audio_chunk
 
 
 def mock_chat_completion(messages: list[ChatMessage]) -> ChatCompletionRequest:
@@ -571,7 +574,6 @@ class TestChatCompletionRequestNormalizationV7:
 
     def test_complex_user_aggregation(self, normalizer_v7: InstructRequestNormalizerV7) -> None:
         """Complex multi-user-message aggregation with mixed str, chunks, empty, and non-text chunks."""
-
         chat_completion_request = mock_chat_completion(
             messages=[
                 UserMessage(content=""),
@@ -1093,6 +1095,49 @@ class TestChatCompletionRequestNormalizationV15:
         tool_msg = parsed.messages[2]
         assert isinstance(tool_msg, ToolMessage)
         assert tool_msg.content == "XY"
+
+
+class TestSystemMessageContentChunk:
+    def test_system_message_accepts_text_audio_think(self) -> None:
+        audio_chunk = get_dummy_audio_chunk()
+        message = SystemMessage(
+            content=[
+                TextChunk(text="hello"),
+                audio_chunk,
+                ThinkChunk(thinking="thinking", closed=True),
+            ]
+        )
+        assert len(message.content) == 3
+
+    def test_system_message_rejects_image_url_chunk(self) -> None:
+        with pytest.raises(ValidationError):
+            SystemMessage(
+                content=[
+                    TextChunk(text="hello"),
+                    ImageURLChunk(image_url="https://example.com/image.png"),  # type: ignore[list-item]
+                ]
+            )
+
+    def test_v7_normalization_preserves_audio_in_system_message(self) -> None:
+        audio_chunk = get_dummy_audio_chunk()
+        normalizer = InstructRequestNormalizerV7.normalizer()
+        messages: list[ChatMessage] = [
+            SystemMessage(
+                content=[
+                    TextChunk(text="hello"),
+                    audio_chunk,
+                ]
+            ),
+            UserMessage(content="test"),
+        ]
+        request = mock_chat_completion(messages)
+        parsed: InstructRequest[ChatMessage, Tool] = normalizer.from_chat_completion_request(request)
+        system_msg = parsed.messages[0]
+        assert isinstance(system_msg, SystemMessage)
+        assert isinstance(system_msg.content, list)
+        assert len(system_msg.content) == 2
+        assert isinstance(system_msg.content[0], TextChunk)
+        assert isinstance(system_msg.content[1], AudioChunk)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -371,8 +371,19 @@ def test_tokenize_assistant_message_error(v13_tekkenizer: InstructTokenizerV13) 
 def test_encode_system_message(
     v13_tekkenizer_think: InstructTokenizerV13, message: SystemMessage, expected: str
 ) -> None:
-    encoded = v13_tekkenizer_think.encode_system_message(message)
+    encoded, images, audios = v13_tekkenizer_think.encode_system_message(message)
     assert v13_tekkenizer_think.decode(encoded, special_token_policy=SpecialTokenPolicy.KEEP) == expected
+    assert images == []
+    assert audios == []
+
+
+def test_encode_system_message_with_audio(v13_tekkenizer_audio: InstructTokenizerV13, audio_chunk: AudioChunk) -> None:
+    message = SystemMessage(content=[TextChunk(text="hello"), audio_chunk])
+    encoded, images, audios = v13_tekkenizer_audio.encode_system_message(message)
+    decoded = v13_tekkenizer_audio.decode(encoded, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert decoded == "[SYSTEM_PROMPT]hello[BEGIN_AUDIO][AUDIO][AUDIO][/SYSTEM_PROMPT]"
+    assert images == []
+    assert len(audios) == 1
 
 
 @pytest.mark.parametrize("audio_fixture", ["audio_chunk", "audio_url_chunk"])


### PR DESCRIPTION
## Summary

Widen `SystemMessage.content` from `str | list[TextChunk | ThinkChunk]` to `str | list[SystemContentChunk]` where `SystemContentChunk = TextChunk | AudioChunk | ThinkChunk` (restricted subset — no images, no AudioURLChunk).

**Depends on:** #235

## Changes

- Add `SystemContentChunk` type alias in `chunk.py` (restricted: Text + Audio + Think)
- Widen `SystemMessage.content` type, update `to_openai`/`from_openai`
- Update `encode_system_message` to return `tuple[list[int], list[np.ndarray], list[Audio]]` across all tokenizer versions
- Collect images/audios from system messages in `encode_instruct`

## Tests

- Pydantic validation: Text+Audio+Think accepted, ImageURLChunk rejected
- Normalization: AudioChunk preserved in V7+ system messages
- Tokenizer: audio encoding in system messages