### PR TITLE
Support Responses API

### DIFF
--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -456,11 +456,32 @@ UserContentChunk = Annotated[
 ]
 
 
+# The OpenAI Responses API spells text/image content types differently from the
+# Chat Completions API that ``ChunkTypes`` mirrors. Map the Responses spellings
+# onto their Chat Completions equivalents so structured Responses input/output
+# is accepted instead of raising e.g. "'input_text' is not a valid ChunkTypes".
+# (``input_image`` carries ``image_url`` as a bare string, which
+# ``ImageURLChunk`` already accepts.)
+_RESPONSES_CONTENT_TYPE_ALIASES: dict[str, ChunkTypes] = {
+    "input_text": ChunkTypes.text,
+    "output_text": ChunkTypes.text,
+    "input_image": ChunkTypes.image_url,
+}
+
+
 def _convert_openai_content_chunks(openai_content_chunks: dict[str, Any]) -> ContentChunk:
     content_type_str = openai_content_chunks.get("type")
 
     if content_type_str is None:
         raise ValueError("Content chunk must have a type field.")
+
+    # Normalize OpenAI Responses content types to the Chat Completions spellings.
+    # The discriminated chunk models require the canonical ``type``, so rewrite
+    # the field too.
+    aliased_type = _RESPONSES_CONTENT_TYPE_ALIASES.get(content_type_str)
+    if aliased_type is not None:
+        openai_content_chunks = {**openai_content_chunks, "type": aliased_type.value}
+        content_type_str = aliased_type.value
 
     content_type = ChunkTypes(content_type_str)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -37,11 +37,13 @@ from mistral_common.protocol.instruct.chunk import (
     AudioChunk,
     AudioURL,
     AudioURLChunk,
+    ChunkTypes,
     ImageChunk,
     ImageURL,
     ImageURLChunk,
     TextChunk,
     ThinkChunk,
+    _convert_openai_content_chunks,
 )
 from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
@@ -213,6 +215,28 @@ def test_convert_image_url_chunk(openai_image_url_chunk: dict, image_url_chunk: 
         image_url_chunk.image_url = ImageURL(url=image_url_chunk.image_url, detail=None)
 
     assert ImageURLChunk.from_openai(typeddict_openai) == image_url_chunk
+
+
+@pytest.mark.parametrize("content_type", ["input_text", "output_text"])
+def test_convert_responses_text_chunk(content_type: str) -> None:
+    # The OpenAI Responses API uses "input_text"/"output_text" for text content
+    # (Chat Completions uses "text"); both must parse to a TextChunk rather than
+    # raising "'input_text' is not a valid ChunkTypes".
+    chunk = _convert_openai_content_chunks({"type": content_type, "text": "Hello"})
+    assert isinstance(chunk, TextChunk)
+    assert chunk.type == ChunkTypes.text
+    assert chunk.text == "Hello"
+
+
+def test_convert_responses_image_chunk() -> None:
+    # The OpenAI Responses API uses "input_image" (with image_url as a bare
+    # string) for image content; it must parse to an ImageURLChunk rather than
+    # raising "'input_image' is not a valid ChunkTypes".
+    url = "data:image/png;base64,iVBORw0"
+    chunk = _convert_openai_content_chunks({"type": "input_image", "image_url": url, "detail": "auto"})
+    assert isinstance(chunk, ImageURLChunk)
+    assert chunk.type == ChunkTypes.image_url
+    assert chunk.get_url() == url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Accept Responses API input_text/output_text/input_image content types

## What

Change `_convert_openai_content_chunks` to also accept the OpenAI **Responses API**
content types `input_text`, `output_text` (→ `TextChunk`) and `input_image`
(→ `ImageURLChunk`).

## Why

`ChunkTypes` mirrors the OpenAI **Chat Completions** content types (`text`,
`image_url`, ...). 

The [Responses API](https://platform.openai.com/docs/api-reference/responses)
names text and image content differently — `input_text`/`output_text` for text
and `input_image` for images. This means parsing structured Responses content fails
with e.g. `'input_text' is not a valid ChunkTypes` /
`'input_image' is not a valid ChunkTypes`.

**This breaks the Responses API for Mistral models served on vLLM.** Serving a
Mistral model on **vLLM 0.23.0** (with `mistral_common` 1.11.3) using
`--tokenizer-mode mistral` and exposing `/v1/responses` hands request content
straight to `mistral_common`. A client sending the standard Responses input
shape — `{"type": "input_text", "text": "..."}` or
`{"type": "input_image", "image_url": "..."}`, which the official OpenAI client
libraries emit — gets an HTTP **400**, making `/v1/responses` unusable for text
and image input alike.

## The proposed change

Map the Responses content-type spellings onto their Chat Completions
equivalents in `_convert_openai_content_chunks` via a small alias table
(`input_text`/`output_text` → `text`, `input_image` → `image_url`). The chunk's
`type` field is rewritten because the discriminated chunk models require the
canonical `type`; `input_image`'s `image_url` is a bare string, which
`ImageURLChunk` already accepts.

## Tests / checks

- Regression tests for text (`input_text`/`output_text`) and image
  (`input_image`) content.
- `pytest tests/test_converters.py` → 116 passed.
- `ruff check`, `ruff format --check`, `mypy` → all clean.

A patched version of mistral_common 1.11.3 was tested on vLLM 0.23.0, using hf model mistralai/Mistral-Medium-3.5-128B and the responses api. 
