### PR TITLE
 Fix `AudioChunk.to_openai()` serialization for raw audio bytes and prefixed base64 audio strings. 

### DIFF
--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -27,13 +27,6 @@ def _strip_audio_data_url_prefix(data: str) -> str:
     return data
 
 
-def _audio_input_to_base64(data: str | bytes) -> str:
-    r"""Convert raw audio bytes or base64 audio text to base64 audio text."""
-    if isinstance(data, bytes):
-        return base64.b64encode(data).decode("utf-8")
-    return _strip_audio_data_url_prefix(data)
-
-
 def _detect_audio_format(data: str | bytes) -> str:
     r"""Detect audio format from base64-encoded string or raw bytes.
 
@@ -393,7 +386,10 @@ class AudioChunk(BaseContentChunk):
         Returns:
             A dictionary representing the audio chunk in the OpenAI format.
         """
-        content = _audio_input_to_base64(self.input_audio)
+        if isinstance(self.input_audio, bytes):
+            content = base64.b64encode(self.input_audio).decode("utf-8")
+        else:
+            content = _strip_audio_data_url_prefix(self.input_audio)
         fmt = _detect_audio_format(self.input_audio)
         return {
             "type": self.type,

--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import io
 import re
 from enum import Enum
@@ -20,6 +21,20 @@ if TYPE_CHECKING:
     from mistral_common.tokens.tokenizers.audio import Audio
 
 
+def _strip_audio_data_url_prefix(data: str) -> str:
+    r"""Remove the optional base64 audio data URL prefix."""
+    if re.match(r"^data:audio/\w+;base64,", data):
+        return data.split(",", 1)[1]
+    return data
+
+
+def _audio_input_to_base64(data: str | bytes) -> str:
+    r"""Convert raw audio bytes or base64 audio text to base64 audio text."""
+    if isinstance(data, bytes):
+        return base64.b64encode(data).decode("utf-8")
+    return _strip_audio_data_url_prefix(data)
+
+
 def _detect_audio_format(data: str | bytes) -> str:
     r"""Detect audio format from base64-encoded string or raw bytes.
 
@@ -37,7 +52,10 @@ def _detect_audio_format(data: str | bytes) -> str:
     assert_soundfile_installed()
 
     if isinstance(data, str):
-        audio_bytes = base64.b64decode(data)
+        try:
+            audio_bytes = base64.b64decode(_strip_audio_data_url_prefix(data))
+        except (binascii.Error, ValueError) as e:
+            raise ValueError("Failed to detect audio format. Verify that the given file is valid wav or mp3.") from e
     else:
         audio_bytes = data
 
@@ -379,7 +397,7 @@ class AudioChunk(BaseContentChunk):
         Returns:
             A dictionary representing the audio chunk in the OpenAI format.
         """
-        content = self.input_audio.decode("utf-8") if isinstance(self.input_audio, bytes) else self.input_audio
+        content = _audio_input_to_base64(self.input_audio)
         fmt = _detect_audio_format(self.input_audio)
         return {
             "type": self.type,

--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -1,5 +1,4 @@
 import base64
-import binascii
 import io
 import re
 from enum import Enum
@@ -52,10 +51,7 @@ def _detect_audio_format(data: str | bytes) -> str:
     assert_soundfile_installed()
 
     if isinstance(data, str):
-        try:
-            audio_bytes = base64.b64decode(_strip_audio_data_url_prefix(data))
-        except (binascii.Error, ValueError) as e:
-            raise ValueError("Failed to detect audio format. Verify that the given file is valid wav or mp3.") from e
+        audio_bytes = base64.b64decode(_strip_audio_data_url_prefix(data))
     else:
         audio_bytes = data
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,3 +1,4 @@
+import base64
 import copy
 import io
 import warnings
@@ -1190,6 +1191,33 @@ def test_audio_chunk_to_openai_format_detection(fmt: str) -> None:
     audio = _make_fake_audio(0.5)
     b64 = audio.to_base64(fmt)
     chunk = AudioChunk(input_audio=b64)
+    result = chunk.to_openai()
+
+    assert result["input_audio"]["format"] == fmt
+    assert result["input_audio"]["data"] == b64
+    assert AudioChunk.from_openai(result).input_audio == b64
+
+
+@pytest.mark.parametrize("fmt", ["wav", "flac"])
+def test_audio_chunk_to_openai_raw_bytes_format_detection(fmt: str) -> None:
+    audio = _make_fake_audio(0.5)
+    buffer = io.BytesIO()
+    sf.write(buffer, audio.audio_array, audio.sampling_rate, format=fmt)
+    raw_bytes = buffer.getvalue()
+
+    result = AudioChunk(input_audio=raw_bytes).to_openai()
+
+    assert result["input_audio"]["format"] == fmt
+    assert result["input_audio"]["data"] == base64.b64encode(raw_bytes).decode("utf-8")
+    assert AudioChunk.from_openai(result).input_audio == result["input_audio"]["data"]
+
+
+@pytest.mark.parametrize("fmt", ["wav", "flac"])
+def test_audio_chunk_to_openai_strips_base64_data_url_prefix(fmt: str) -> None:
+    audio = _make_fake_audio(0.5)
+    b64 = audio.to_base64(fmt)
+    chunk = AudioChunk(input_audio=f"data:audio/{fmt};base64,{b64}")
+
     result = chunk.to_openai()
 
     assert result["input_audio"]["format"] == fmt


### PR DESCRIPTION
## Summary
Fix `AudioChunk.to_openai()` serialization for raw audio bytes and prefixed base64 audio strings. Close #244

## Root Cause
`AudioChunk.to_openai()` decoded raw bytes as UTF-8 instead of base64-encoding them, and `_detect_audio_format()` did not strip `data:audio/...;base64,` prefixes before base64 decoding.

## Tests
- `pytest tests/test_converters.py -q`
- `pytest --cov=mistral_common tests/ --ignore=tests/integrations --cov-report "xml:coverage.xml"`
- `pytest --doctest-modules ./src`
- `pytest tests/integrations/ -v`
- `ruff check .`
- `ruff format . --check`
- `mypy .`
- `mkdocs build --strict`
