### PR TITLE
fix(validator): reject any non-user/tool trailing message, not just assistant

### DIFF
--- a/src/mistral_common/protocol/instruct/validator.py
+++ b/src/mistral_common/protocol/instruct/validator.py
@@ -293,9 +293,16 @@ class MistralRequestValidator(Generic[UserMessageType, AssistantMessageType, Too
             if continue_final_message:
                 raise InvalidMessageStructureException("Cannot continue final message in finetuning mode")
         else:
-            bad_assistant = isinstance(message, AssistantMessage) and not message.prefix and not continue_final_message
             bad_role = message.role not in {Roles.user, Roles.tool}
-            if bad_assistant and bad_role:
+            # A non-user/tool trailing message is only valid when it is an
+            # assistant message to be continued (prefix) or
+            # ``continue_final_message`` is set. The previous condition ANDed
+            # ``bad_role`` with an assistant-only flag, so a trailing message of
+            # another role (e.g. system) was never rejected here.
+            valid_trailing_assistant = isinstance(message, AssistantMessage) and (
+                message.prefix or continue_final_message
+            )
+            if bad_role and not valid_trailing_assistant:
                 raise InvalidMessageStructureException(
                     f"Expected last role User or Tool (or Assistant with prefix or continue_final_message set to True) "
                     f"for serving but got {last_message_role}"

--- a/tests/validation/test_chat_validation.py
+++ b/tests/validation/test_chat_validation.py
@@ -147,6 +147,22 @@ class TestChatValidation:
                 continue_final_message=False,
             )
 
+    def test_ends_with_system(self, validator: MistralRequestValidator) -> None:
+        with pytest.raises(
+            InvalidMessageStructureException,
+            match=(
+                r"Expected last role User or Tool \(or Assistant with prefix or continue_final_message set to "
+                r"True\) for serving but got system"
+            ),
+        ):
+            validator.validate_messages(
+                messages=[
+                    UserMessage(content="foo"),
+                    SystemMessage(content="foo"),
+                ],
+                continue_final_message=False,
+            )
+
     def test_assistant_prefix(self, validator: MistralRequestValidator) -> None:
         validator.validate_messages(
             messages=[


### PR DESCRIPTION
## Problem

`MistralRequestValidator._validate_last_message` (serving / test mode) is meant to require the conversation's last message to be a **user** or **tool** message, or an **assistant** message with `prefix` / `continue_final_message` set — as stated in its own error message and the comment "The last message must be a user or tool message in serving mode...".

But the guard ANDs `bad_role` with an assistant-only flag:

```python
bad_assistant = isinstance(message, AssistantMessage) and not message.prefix and not continue_final_message
bad_role = message.role not in {Roles.user, Roles.tool}
if bad_assistant and bad_role:
    raise InvalidMessageStructureException("Expected last role User or Tool ... for serving but got ...")
```

`bad_assistant` is only ever `True` for an `AssistantMessage`, so the condition **can never fire for any other role**. Since `_validate_message_order` permits `user → system`, a conversation ending in a `SystemMessage` reaches this check and passes — even though it's exactly what the message says should be rejected.

Reproduced (serving mode):

```python
v = MistralRequestValidator(mode=ValidationMode.serving)
v.validate_messages([UserMessage(content="hi"), SystemMessage(content="sys")], continue_final_message=False)
# current: accepted (no exception)   expected: InvalidMessageStructureException
```

The test suite reveals the intent: every case that ends a conversation with a `SystemMessage` appends a trailing `UserMessage` with the comment **"so we don't get an error for ending with a system message"** (`tests/validation/test_chat_validation.py:82, :101`). The maintainers assume a trailing system message is rejected — but the `and` bug means it isn't. No test asserts a trailing system message is *accepted*.

## Fix

Reject when the role is not user/tool **unless** the message is a valid trailing assistant (`prefix` or `continue_final_message`):

```python
bad_role = message.role not in {Roles.user, Roles.tool}
valid_trailing_assistant = isinstance(message, AssistantMessage) and (message.prefix or continue_final_message)
if bad_role and not valid_trailing_assistant:
    raise ...
```

Verified against all role × prefix × `continue_final_message` combinations — only assistant-without-prefix and system-last now raise; user, tool, assistant-with-prefix, and the `continue_final_message` path are unchanged (and the following `elif continue_final_message` branch still behaves identically). A naive `bad_role or bad_assistant` was avoided because it would wrongly reject a valid `prefix=True` assistant.

## Tests

Adds `test_ends_with_system` asserting a trailing system message raises in serving mode. The full `test_chat_validation.py` message-structure suite passes (the only failures in my environment are the pre-existing `test_audio_*` cases that require the optional `soundfile` extra, unrelated to this change).
