### PR TITLE
Resolve tokenizer from local cache in offline mode

### DIFF
--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -61,19 +61,20 @@ def list_local_hf_repo_files(repo_id: str, revision: str | None) -> list[str]:
 
     if revision is None:
         revision = huggingface_hub.constants.DEFAULT_REVISION
+    if not revision:
+        return []
 
-    if revision:
-        # Snapshots are keyed by commit hash, so a branch/tag revision (e.g. "main") must first be
-        # resolved to its commit hash via the corresponding `refs/<revision>` file. Otherwise it is
-        # looked up as a literal `snapshots/<revision>` directory, which does not exist -> no files.
-        revision_file = repo_cache / "refs" / revision
-        if revision_file.is_file():
-            with revision_file.open("r") as file:
-                revision = file.read().strip()
+    # Snapshots are keyed by commit hash, so resolve a branch/tag revision (e.g. "main") to its
+    # commit hash via the corresponding `refs/<revision>` file before reading the snapshot
+    # directory. Otherwise it is looked up as a literal `snapshots/<revision>` directory, which
+    # does not exist -> no files.
+    revision_file = repo_cache / "refs" / revision
+    if revision_file.is_file():
+        revision = revision_file.read_text().strip()
 
-        revision_dir = repo_cache / "snapshots" / revision
-        if revision_dir.is_dir():
-            return os.listdir(revision_dir)
+    revision_dir = repo_cache / "snapshots" / revision
+    if revision_dir.is_dir():
+        return os.listdir(revision_dir)
 
     return []
 

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -12,6 +12,7 @@ _hub_installed: bool
 try:
     import huggingface_hub
     import huggingface_hub.constants
+    import huggingface_hub.errors
 
     _hub_installed = True
 except ImportError:
@@ -59,12 +60,17 @@ def list_local_hf_repo_files(repo_id: str, revision: str | None) -> list[str]:
     )
 
     if revision is None:
-        revision_file = repo_cache / "refs" / huggingface_hub.constants.DEFAULT_REVISION
-        if revision_file.is_file():
-            with revision_file.open("r") as file:
-                revision = file.read()
+        revision = huggingface_hub.constants.DEFAULT_REVISION
 
     if revision:
+        # Snapshots are keyed by commit hash, so a branch/tag revision (e.g. "main") must first be
+        # resolved to its commit hash via the corresponding `refs/<revision>` file. Otherwise it is
+        # looked up as a literal `snapshots/<revision>` directory, which does not exist -> no files.
+        revision_file = repo_cache / "refs" / revision
+        if revision_file.is_file():
+            with revision_file.open("r") as file:
+                revision = file.read().strip()
+
         revision_dir = repo_cache / "snapshots" / revision
         if revision_dir.is_dir():
             return os.listdir(revision_dir)
@@ -165,7 +171,14 @@ def download_tokenizer_from_hf_hub(
             hf_api = huggingface_hub.HfApi()
             repo_files = hf_api.list_repo_files(repo_id, revision=revision, token=token)
             local_files_only = False
-        except (requests.ConnectionError, requests.HTTPError, requests.Timeout) as e:
+        # `OfflineModeIsEnabled` (raised when `HF_HUB_OFFLINE` is set) is a builtin `ConnectionError`
+        # subclass, not a `requests.*` error, so it must be caught explicitly to reach the local fallback.
+        except (
+            requests.ConnectionError,
+            requests.HTTPError,
+            requests.Timeout,
+            huggingface_hub.errors.OfflineModeIsEnabled,
+        ) as e:
             if force_download:
                 raise e
 

--- a/src/mistral_common/tokens/tokenizers/utils.py
+++ b/src/mistral_common/tokens/tokenizers/utils.py
@@ -64,10 +64,7 @@ def list_local_hf_repo_files(repo_id: str, revision: str | None) -> list[str]:
     if not revision:
         return []
 
-    # Snapshots are keyed by commit hash, so resolve a branch/tag revision (e.g. "main") to its
-    # commit hash via the corresponding `refs/<revision>` file before reading the snapshot
-    # directory. Otherwise it is looked up as a literal `snapshots/<revision>` directory, which
-    # does not exist -> no files.
+    # Snapshots are keyed by commit hash, so resolve a branch/tag revision (e.g. "main") via `refs`.
     revision_file = repo_cache / "refs" / revision
     if revision_file.is_file():
         revision = revision_file.read_text().strip()
@@ -172,8 +169,6 @@ def download_tokenizer_from_hf_hub(
             hf_api = huggingface_hub.HfApi()
             repo_files = hf_api.list_repo_files(repo_id, revision=revision, token=token)
             local_files_only = False
-        # `OfflineModeIsEnabled` (raised when `HF_HUB_OFFLINE` is set) is a builtin `ConnectionError`
-        # subclass, not a `requests.*` error, so it must be caught explicitly to reach the local fallback.
         except (
             requests.ConnectionError,
             requests.HTTPError,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,10 @@ def test_list_local_hf_repo_files() -> None:
         files = sorted(list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "RANDOM_REVISION"))
         assert files == ["file2.txt", "tekken.json"]
 
+        # Test with a branch/tag revision that must be resolved via refs (e.g. "main")
+        files = sorted(list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "main"))
+        assert files == ["file2.txt", "tekken.json"]
+
         # Test with non-existent revision
         assert list_local_hf_repo_files("mistralai/Mistral-7B-v0.1", "non_existent_revision") == []
 
@@ -183,3 +187,16 @@ def test_download_tokenizer_from_hf_hub_without_connection(mock_list_repo_files:
             download_tokenizer_from_hf_hub(
                 repo_id="mistralai/Mistral-7B-v0.1", token=None, revision=None, local_files_only=True
             )
+
+
+@patch("huggingface_hub.HfApi.list_repo_files")
+def test_download_tokenizer_from_hf_hub_offline_mode(mock_list_repo_files: MagicMock) -> None:
+    # In offline mode, huggingface_hub raises OfflineModeIsEnabled (a builtin ConnectionError subclass, not a
+    # requests.* error) before any network call, so the tokenizer must still be resolved from the local cache.
+    mock_list_repo_files.side_effect = huggingface_hub.errors.OfflineModeIsEnabled("offline mode is enabled")
+
+    hf_cache = _create_temporary_hf_model_cache("mistralai/Mistral-7B-v0.1")
+
+    with patch("huggingface_hub.constants.HF_HUB_CACHE", hf_cache):
+        tokenizer = download_tokenizer_from_hf_hub(repo_id="mistralai/Mistral-7B-v0.1", token=None, revision="main")
+        assert tokenizer == str(hf_cache / "models--mistralai--Mistral-7B-v0.1/snapshots/RANDOM_REVISION/tekken.json")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -191,8 +191,6 @@ def test_download_tokenizer_from_hf_hub_without_connection(mock_list_repo_files:
 
 @patch("huggingface_hub.HfApi.list_repo_files")
 def test_download_tokenizer_from_hf_hub_offline_mode(mock_list_repo_files: MagicMock) -> None:
-    # In offline mode, huggingface_hub raises OfflineModeIsEnabled (a builtin ConnectionError subclass, not a
-    # requests.* error) before any network call, so the tokenizer must still be resolved from the local cache.
     mock_list_repo_files.side_effect = huggingface_hub.errors.OfflineModeIsEnabled("offline mode is enabled")
 
     hf_cache = _create_temporary_hf_model_cache("mistralai/Mistral-7B-v0.1")


### PR DESCRIPTION
Fixes #248

### Bug
With `HF_HUB_OFFLINE=1` and a model fully present in the local cache, `download_tokenizer_from_hf_hub(repo_id, revision="main")` crashes instead of resolving the tokenizer from the cache. This is hit in practice via vLLM / transformers v5, which route any model shipping `tekken.json` to `MistralCommonBackend` and pass `revision="main"`.

### Cause
Two issues combine in `tokens/tokenizers/utils.py`:

1. In offline mode `huggingface_hub` raises `OfflineModeIsEnabled`, which is a *builtin* `ConnectionError` subclass, **not** a `requests.*` error. The `except (requests.ConnectionError, requests.HTTPError, requests.Timeout)` around `list_repo_files` therefore misses it and the existing local-files fallback is skipped.
2. `list_local_hf_repo_files` only consulted `refs/<DEFAULT_REVISION>` when `revision` was `None`. An explicit branch/tag like `"main"` was looked up as a literal `snapshots/main` directory, which never exists (snapshots are keyed by commit hash), so it returned `[]`.

### Fix
- Add `huggingface_hub.errors.OfflineModeIsEnabled` to the caught exceptions so offline mode reaches the same local-files fallback as a dropped connection (`force_download` still re-raises, unchanged).
- Resolve any branch/tag `revision` to its commit hash via `refs/<revision>` before reading the snapshot directory.

### Testing
- Added a `revision="main"` case to `test_list_local_hf_repo_files` and a new `test_download_tokenizer_from_hf_hub_offline_mode`; both fail before the change and pass after.
- `pytest tests/test_utils.py` (23 passing), `ruff check`, `ruff format --check`, and `mypy src` are all green.