### PR TITLE
fix: drop field in TranscriptionRequest.to_openai

### DIFF
--- a/src/mistral_common/protocol/transcription/request.py
+++ b/src/mistral_common/protocol/transcription/request.py
@@ -96,8 +96,7 @@ class TranscriptionRequest(BaseCompletionRequest):
         format consumed by OpenAI-compatible servers. It handles the conversion of audio data and
         additional parameters into the required format.
 
-        Note that "OpenAI" here refers to the de facto request format rather than OpenAI's hosted API:
-        the payload may include extension fields (e.g. ``seed`` and ``top_p``) that are supported by
+        The payload may include extension fields (e.g. ``seed`` and ``top_p``) that are supported by
         OpenAI-compatible servers such as vLLM but are not part of OpenAI's hosted transcription API.
         Pass them via ``exclude`` if you need a strictly OpenAI-valid payload.
 

--- a/src/mistral_common/protocol/transcription/request.py
+++ b/src/mistral_common/protocol/transcription/request.py
@@ -21,6 +21,18 @@ class StreamingMode(str, Enum):
     OFFLINE = "offline"
 
 
+# Fields of `TranscriptionRequest` that are specific to mistral-common / Mistral's
+# transcription API and are not part of the OpenAI transcription API. They are dropped
+# by `TranscriptionRequest.to_openai`.
+_MISTRAL_TRANSCRIPTION_ONLY_FIELDS: tuple[str, ...] = (
+    "id",
+    "max_tokens",
+    "strict_audio_validation",
+    "streaming",
+    "target_streaming_delay_ms",
+)
+
+
 class TranscriptionRequest(BaseCompletionRequest):
     r"""A class representing a request for audio transcription.
 
@@ -80,15 +92,26 @@ class TranscriptionRequest(BaseCompletionRequest):
     def to_openai(self, exclude: tuple = (), **kwargs: Any) -> dict[str, list[dict[str, Any]]]:
         r"""Convert the transcription request into the OpenAI format.
 
-        This method prepares the transcription request data for compatibility with the OpenAI API.
-        It handles the conversion of audio data and additional parameters into the required format.
+        This method prepares the transcription request data into the OpenAI-compatible transcription
+        format consumed by OpenAI-compatible servers. It handles the conversion of audio data and
+        additional parameters into the required format.
+
+        Note that "OpenAI" here refers to the de facto request format rather than OpenAI's hosted API:
+        the payload may include extension fields (e.g. ``seed`` and ``top_p``) that are supported by
+        OpenAI-compatible servers such as vLLM but are not part of OpenAI's hosted transcription API.
+        Pass them via ``exclude`` if you need a strictly OpenAI-valid payload.
+
+        Fields that are specific to mistral-common / Mistral's transcription API and are not part of
+        the OpenAI-compatible transcription format are always dropped (see
+        ``_MISTRAL_TRANSCRIPTION_ONLY_FIELDS``).
 
         Args:
-            exclude: Fields to exclude from the conversion.
+            exclude: Additional fields to exclude from the conversion, on top of the mistral-specific
+                fields that are always dropped.
             kwargs: Additional parameters to be added to the request.
 
         Returns:
-            The request in the OpenAI format.
+            The request in the OpenAI-compatible transcription format.
 
         Raises:
             ImportError: If the required soundfile library is not installed.
@@ -119,10 +142,9 @@ class TranscriptionRequest(BaseCompletionRequest):
         openai_request["seed"] = openai_request.pop("random_seed")
         openai_request.update(kwargs)
 
-        # remove mistral-specific
-        # TODO: revisit which fields to expose in the OpenAI format
-        default_exclude = ("id", "max_tokens", "strict_audio_validation", "streaming")
-        default_exclude += exclude
+        # Drop fields that are specific to mistral-common / Mistral's transcription API
+        # and are not part of the OpenAI transcription API.
+        default_exclude = _MISTRAL_TRANSCRIPTION_ONLY_FIELDS + exclude
         for k in default_exclude:
             openai_request.pop(k, None)
 

--- a/tests/test_tokenizer_v7_audio_transcribe.py
+++ b/tests/test_tokenizer_v7_audio_transcribe.py
@@ -2,7 +2,10 @@ import numpy as np
 import pytest
 from pydantic_extra_types.language_code import LanguageAlpha2
 
-from mistral_common.protocol.transcription.request import TranscriptionRequest
+from mistral_common.protocol.transcription.request import (
+    StreamingMode,
+    TranscriptionRequest,
+)
 from mistral_common.tokens.tokenizers.audio import (
     Audio,
 )
@@ -54,6 +57,47 @@ def test_tokenize_transcribe(tekkenizer: InstructTokenizerV7) -> None:
     assert isinstance(base64_audio, str)
     audio_array = Audio.from_base64(base64_audio).audio_array
     assert np.allclose(tokenized.audios[0].audio_array, audio_array, atol=1e-3)
+
+
+def test_to_openai_drops_mistral_specific_fields() -> None:
+    audio_chunk = _get_audio_chunk(1.0)
+    request = TranscriptionRequest(
+        id="some-id",
+        model="dummy",
+        audio=audio_chunk.input_audio,
+        language=LanguageAlpha2("en"),
+        temperature=0.5,
+        max_tokens=128,
+        streaming=StreamingMode.OFFLINE,
+        target_streaming_delay_ms=480,
+    )
+
+    openai_request = request.to_openai()
+
+    # mistral-common / Mistral-specific fields must not leak into the OpenAI payload.
+    for field in ("id", "max_tokens", "strict_audio_validation", "streaming", "target_streaming_delay_ms", "audio"):
+        assert field not in openai_request, field
+
+    # OpenAI-valid fields are preserved and audio is exposed as a file buffer.
+    assert openai_request["model"] == "dummy"
+    assert openai_request["language"] == "en"
+    assert openai_request["temperature"] == 0.5
+    assert "file" in openai_request
+
+
+def test_to_openai_exclude_strips_compatible_extension_fields() -> None:
+    audio_chunk = _get_audio_chunk(1.0)
+    request = TranscriptionRequest(model="dummy", audio=audio_chunk.input_audio, target_streaming_delay_ms=None)
+
+    # `seed` and `top_p` are OpenAI-compatible extension fields (e.g. accepted by vLLM) but not part
+    # of OpenAI's hosted transcription API. `exclude` can drop them to get a strictly OpenAI-valid payload.
+    openai_request = request.to_openai(exclude=("seed", "top_p"))
+
+    assert "seed" not in openai_request
+    assert "top_p" not in openai_request
+    # Unrelated OpenAI-valid fields are still present.
+    assert openai_request["model"] == "dummy"
+    assert "file" in openai_request
 
 
 def test_tokenize_transcribe_with_lang(tekkenizer: InstructTokenizerV7) -> None:


### PR DESCRIPTION
- `TranscriptionRequest.to_openai` excluded `streaming` but kept its companion
  `target_streaming_delay_ms`, leaking a Mistral-specific field into the payload.
  Both are now dropped together.
- Clarified in the docstring that "OpenAI" means the OpenAI-compatible format:
  extension fields like `seed`/`top_p` are valid on some OpenAI-compatible servers
  (e.g. vLLM) but not OpenAI's hosted API, and can be removed via `exclude`.