### PR TITLE
Remove to_openai and from_openai from InstructRequest

### DIFF
--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -248,6 +248,10 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
 class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
     r"""A valid Instruct request to be tokenized.
 
+    Note:
+        This class is intended for internal use only. External users should use `ChatCompletionRequest` to build
+        requests and to convert to and from the OpenAI format.
+
     Attributes:
         messages: The history of the conversation.
         system_prompt: The system prompt to be used for the conversation.
@@ -269,132 +273,3 @@ class InstructRequest(MistralBase, Generic[ChatMessageType, ToolType]):
     truncate_at_max_tokens: int | None = None
     continue_final_message: bool = False
     settings: ModelSettings = Field(default_factory=ModelSettings.none)
-
-    def to_openai(
-        self,
-        reasoning_field_format: ReasoningFieldFormat | None = None,
-        **kwargs: Any,
-    ) -> dict[str, list[dict[str, Any]]]:
-        r"""Convert the request messages and tools into the OpenAI format.
-
-        Args:
-            reasoning_field_format: Format for converting thinking chunks in assistant messages.
-                See `AssistantMessage.to_openai` for details.
-            kwargs: Additional parameters to be added to the request.
-
-        Returns:
-            The request in the OpenAI format.
-
-        Examples:
-            >>> from mistral_common.protocol.instruct.messages import UserMessage
-            >>> from mistral_common.protocol.instruct.tool_calls import Tool, Function
-            >>> request = InstructRequest(messages=[UserMessage(content="Hello, how are you?")])
-            >>> request.to_openai(temperature=0.15, stream=True)
-            {'continue_final_message': False, 'messages': [{'role': 'user', 'content': 'Hello, how are you?'}], 'temperature': 0.15, 'stream': True}
-            >>> request = InstructRequest(
-            ...     messages=[UserMessage(content="Hello, how are you?")],
-            ...     available_tools=[
-            ...     Tool(function=Function(
-            ...         name="get_current_weather",
-            ...         description="Get the current weather in a given location",
-            ...         parameters={
-            ...             "type": "object",
-            ...             "properties": {
-            ...                 "location": {
-            ...                     "type": "string",
-            ...                     "description": "The city and state, e.g. San Francisco, CA",
-            ...                 },
-            ...                 "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
-            ...             },
-            ...             "required": ["location"],
-            ...         },
-            ...     ),
-            ... )])
-            >>> request.to_openai()
-            {'continue_final_message': False, 'messages': [{'role': 'user', 'content': 'Hello, how are you?'}], 'tools': [{'type': 'function', 'function': {'name': 'get_current_weather', 'description': 'Get the current weather in a given location', 'parameters': {'type': 'object', 'properties': {'location': {'type': 'string', 'description': 'The city and state, e.g. San Francisco, CA'}, 'unit': {'type': 'string', 'enum': ['celsius', 'fahrenheit']}}, 'required': ['location']}, 'strict': False}}]}
-        """  # noqa: E501
-
-        # Handle messages, tools, and truncate_at_max_tokens separately.
-        openai_request: dict[str, Any] = self.model_dump(
-            exclude={"messages", "available_tools", "truncate_at_max_tokens", "settings"}, exclude_none=True
-        )
-
-        for kwarg in kwargs:
-            if kwarg in openai_request:
-                raise ValueError(f"Duplicate keyword argument: {kwarg}")
-            elif kwarg in InstructRequest.model_fields:
-                raise ValueError(f"Keyword argument {kwarg} is already set in the request.")
-
-        openai_messages: list[dict[str, Any]] = []
-        if self.system_prompt is not None:
-            openai_messages.append({"role": "system", "content": self.system_prompt})
-
-        for message in self.messages:
-            if isinstance(message, AssistantMessage):
-                openai_messages.append(message.to_openai(reasoning_field_format=reasoning_field_format))
-            else:
-                openai_messages.append(message.to_openai())
-
-        openai_request["messages"] = openai_messages
-        if self.available_tools is not None:
-            # Rename available_tools to tools
-            openai_request["tools"] = [tool.to_openai() for tool in self.available_tools]
-
-        if self.truncate_at_max_tokens is not None:
-            raise NotImplementedError("Truncating at max tokens is not implemented for OpenAI requests.")
-
-        openai_request.update(kwargs)
-        openai_request.update(**self.settings.model_dump(exclude_none=True))
-
-        return openai_request
-
-    @classmethod
-    def from_openai(
-        cls,
-        messages: list[dict[str, str | list[dict[str, str | dict[str, Any]]]]],
-        tools: list[dict[str, Any]] | None = None,
-        continue_final_message: bool = False,
-        **kwargs: Any,
-    ) -> "InstructRequest":
-        r"""Create an instruct request from the OpenAI format.
-
-        Args:
-            messages: The messages in the OpenAI format.
-            tools: The tools in the OpenAI format.
-            continue_final_message: Whether to continue the final message.
-            **kwargs: Additional keyword arguments to pass to the constructor. These should be the same as the fields
-                of the request class or the OpenAI API equivalent.
-
-        Returns:
-            The instruct request.
-        """
-        # Handle the case where the tools are passed as `available_tools`.
-        # This is to maintain compatibility with the OpenAI API.
-        if "available_tools" in kwargs:
-            if tools is None:
-                tools = kwargs.pop("available_tools")
-            else:
-                raise ValueError("Cannot specify both `tools` and `available_tools`.")
-
-        model_settings_fields = ModelSettings.model_fields.keys()
-        instruct_request_fields = cls.model_fields.keys()
-        assert instruct_request_fields.isdisjoint(model_settings_fields), (
-            "ModelSettings fields should not overlap with InstructRequest fields."
-        )
-        valid_fields = instruct_request_fields | model_settings_fields
-        filtered_kwargs = {k: v for k, v in kwargs.items() if k in valid_fields}
-
-        converted_messages: list[ChatMessage] = convert_openai_messages(messages)
-
-        converted_tools = convert_openai_tools(tools) if tools is not None else None
-
-        model_settings = ModelSettings(**{k: v for k, v in filtered_kwargs.items() if k in model_settings_fields})
-        other_kwargs = {k: v for k, v in filtered_kwargs.items() if k not in model_settings_fields}
-
-        return cls(
-            messages=converted_messages,  # type: ignore[arg-type]
-            available_tools=converted_tools,  # type: ignore[arg-type]
-            continue_final_message=continue_final_message,
-            settings=model_settings,
-            **other_kwargs,
-        )

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -53,8 +53,6 @@ from mistral_common.protocol.instruct.messages import (
 )
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest,
-    InstructRequest,
-    ModelSettings,
     ReasoningEffort,
 )
 from mistral_common.protocol.instruct.tool_calls import (
@@ -733,22 +731,12 @@ def test_assistant_message_to_openai_none_no_warning_with_none_content() -> None
     assert result == {"role": "assistant"}
 
 
-@pytest.mark.parametrize(
-    "request_cls",
-    [ChatCompletionRequest, InstructRequest],
-)
-def test_request_to_openai_forwards_reasoning_field_format(
-    request_cls: type[ChatCompletionRequest | InstructRequest],
-) -> None:
+def test_request_to_openai_forwards_reasoning_field_format() -> None:
     messages: list[ChatMessage] = [
         UserMessage(content="Hi"),
         AssistantMessage(content=[ThinkChunk(thinking="Let me think", closed=True), TextChunk(text="Done")]),
     ]
-    request: ChatCompletionRequest | InstructRequest
-    if request_cls == ChatCompletionRequest:
-        request = ChatCompletionRequest(messages=messages)
-    else:
-        request = InstructRequest(messages=messages)
+    request = ChatCompletionRequest(messages=messages)
 
     openai_request = request.to_openai(reasoning_field_format=ReasoningFieldFormat.reasoning)
     assistant_msg = [m for m in openai_request["messages"] if m["role"] == "assistant"][0]
@@ -758,13 +746,6 @@ def test_request_to_openai_forwards_reasoning_field_format(
 @pytest.mark.parametrize(
     "reasoning_effort",
     [None, ReasoningEffort.none, ReasoningEffort.high],
-)
-@pytest.mark.parametrize(
-    ["request_cls"],
-    [
-        (ChatCompletionRequest,),
-        (InstructRequest,),
-    ],
 )
 @pytest.mark.parametrize(
     ["openai_messages", "messages", "openai_tools", "tools"],
@@ -1031,22 +1012,13 @@ def test_convert_requests(
     messages: list[ChatMessage],
     openai_tools: list[dict[str, Any]] | None,
     tools: list[Tool] | None,
-    request_cls: type[ChatCompletionRequest | InstructRequest],
     reasoning_effort: ReasoningEffort | None,
 ) -> None:
-    request: ChatCompletionRequest | InstructRequest
-    if request_cls == ChatCompletionRequest:
-        request = ChatCompletionRequest(
-            messages=messages,
-            tools=tools,
-            reasoning_effort=reasoning_effort,
-        )
-    else:
-        request = InstructRequest(
-            messages=messages,
-            available_tools=tools,
-            settings=ModelSettings(reasoning_effort=reasoning_effort),
-        )
+    request = ChatCompletionRequest(
+        messages=messages,
+        tools=tools,
+        reasoning_effort=reasoning_effort,
+    )
 
     openai_request = request.to_openai(stream=True)
 
@@ -1061,13 +1033,12 @@ def test_convert_requests(
     else:
         assert "reasoning_effort" not in openai_request
 
-    if isinstance(request, ChatCompletionRequest):
-        assert openai_request["temperature"] == 0.7
+    assert openai_request["temperature"] == 0.7
 
     stream = openai_request.pop("stream")
     assert stream is True
 
-    reconstructed_request: ChatCompletionRequest | InstructRequest = type(request).from_openai(**openai_request)
+    reconstructed_request = ChatCompletionRequest.from_openai(**openai_request)
 
     for i, reconstructed_message in enumerate(reconstructed_request.messages):
         if isinstance(reconstructed_message, (SystemMessage, UserMessage, AssistantMessage)):
@@ -1076,11 +1047,7 @@ def test_convert_requests(
             assert reconstructed_message.model_dump(exclude={"name"}) == messages[i].model_dump(exclude={"name"})
 
     if tools is not None:
-        reconstructed_tools = (
-            reconstructed_request.tools
-            if isinstance(reconstructed_request, ChatCompletionRequest)
-            else reconstructed_request.available_tools
-        )
+        reconstructed_tools = reconstructed_request.tools
         assert isinstance(tools, list)
         assert isinstance(reconstructed_tools, list)
 
@@ -1089,10 +1056,7 @@ def test_convert_requests(
         for i in range(len(tools)):
             assert reconstructed_tools[i] == tools[i]
 
-    if isinstance(reconstructed_request, ChatCompletionRequest):
-        assert reconstructed_request.reasoning_effort == reasoning_effort
-    else:
-        assert reconstructed_request.settings.reasoning_effort == reasoning_effort
+    assert reconstructed_request.reasoning_effort == reasoning_effort
 
 
 @pytest.mark.parametrize(
@@ -1399,15 +1363,6 @@ class TestToolChoice:
                 unknown_field="value",
             ),
             ChatCompletionRequest(messages=[UserMessage(content="Hello")], temperature=0.5),
-        ),
-        (
-            lambda: InstructRequest.from_openai(
-                messages=[{"role": "user", "content": "Hello"}],
-                stream=True,
-                n=5,
-                logprobs=False,
-            ),
-            InstructRequest(messages=[UserMessage(content="Hello")]),
         ),
     ],
 )


### PR DESCRIPTION
## Summary

`InstructRequest` is an internal class used by tokenizers; the OpenAI conversion helpers belong on the public `ChatCompletionRequest`. This removes the redundant `to_openai` / `from_openai` from `InstructRequest` and documents that the class is internal.

## Changes
- Delete `InstructRequest.to_openai` and `InstructRequest.from_openai` (`ChatCompletionRequest` versions are untouched).
- Add a note to the `InstructRequest` docstring: it is for internal use only; external users should use `ChatCompletionRequest` to build requests and convert to/from the OpenAI format.
- Update `tests/test_converters.py` to drop the `InstructRequest` OpenAI-conversion cases.

## Verification
- ruff check + format: pass
- mypy (src + tests): pass
- pytest `tests/test_converters.py`: 99 passed
- doctests for `request.py`: 5 passed