### PR TITLE
Reject AudioConfig with sampling_rate < frame_rate instead of a later ZeroDivisionError

### DIFF
--- a/src/mistral_common/tokens/tokenizers/audio.py
+++ b/src/mistral_common/tokens/tokenizers/audio.py
@@ -348,7 +348,7 @@ class AudioConfig:
     def __post_init__(self) -> None:
         assert self.frame_rate > 0, self.frame_rate
         assert self.sampling_rate > 0, self.sampling_rate
-        assert self.raw_audio_length_per_tok > 0, (
+        assert self.sampling_rate >= self.frame_rate, (
             f"sampling_rate must be >= frame_rate so that each token spans at least one sample, "
             f"got sampling_rate={self.sampling_rate} and frame_rate={self.frame_rate}"
         )

--- a/src/mistral_common/tokens/tokenizers/audio.py
+++ b/src/mistral_common/tokens/tokenizers/audio.py
@@ -348,6 +348,10 @@ class AudioConfig:
     def __post_init__(self) -> None:
         assert self.frame_rate > 0, self.frame_rate
         assert self.sampling_rate > 0, self.sampling_rate
+        assert self.raw_audio_length_per_tok > 0, (
+            f"sampling_rate must be >= frame_rate so that each token spans at least one sample, "
+            f"got sampling_rate={self.sampling_rate} and frame_rate={self.frame_rate}"
+        )
 
         if self.chunk_length_s is not None:
             assert self.chunk_length_s > 0, self.chunk_length_s

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -28,8 +28,6 @@ def sin_wave(sampling_rate: int, duration: float) -> np.ndarray:
 
 
 def test_audio_config_rejects_sampling_rate_below_frame_rate() -> None:
-    # sampling_rate < frame_rate makes raw_audio_length_per_tok == int(sampling_rate // frame_rate) == 0,
-    # which later raises a ZeroDivisionError in the streaming pad path; reject it at construction instead.
     encoding_config = AudioSpectrogramConfig(num_mel_bins=80, hop_length=160, window_size=400)
     with pytest.raises(AssertionError):
         AudioConfig(sampling_rate=1, frame_rate=2.0, encoding_config=encoding_config)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -14,7 +14,7 @@ import soundfile as sf
 from mistral_common.audio import hertz_to_mel, mel_filter_bank
 from mistral_common.protocol.instruct.chunk import AudioChunk, RawAudio
 from mistral_common.protocol.transcription.request import TranscriptionRequest
-from mistral_common.tokens.tokenizers.audio import Audio
+from mistral_common.tokens.tokenizers.audio import Audio, AudioConfig, AudioSpectrogramConfig
 
 
 def _make_dummy_base64() -> str:
@@ -25,6 +25,14 @@ def _make_dummy_base64() -> str:
 
 def sin_wave(sampling_rate: int, duration: float) -> np.ndarray:
     return np.sin(np.ones([int(duration * sampling_rate)]))
+
+
+def test_audio_config_rejects_sampling_rate_below_frame_rate() -> None:
+    # sampling_rate < frame_rate makes raw_audio_length_per_tok == int(sampling_rate // frame_rate) == 0,
+    # which later raises a ZeroDivisionError in the streaming pad path; reject it at construction instead.
+    encoding_config = AudioSpectrogramConfig(num_mel_bins=80, hop_length=160, window_size=400)
+    with pytest.raises(AssertionError):
+        AudioConfig(sampling_rate=1, frame_rate=2.0, encoding_config=encoding_config)
 
 
 def test_audio_resample() -> None:


### PR DESCRIPTION
## Describe your change

`AudioConfig.__post_init__` validates `frame_rate > 0` and `sampling_rate > 0`, and guards `chunk_frames > 0` for the chunking path, but nothing guards `raw_audio_length_per_tok`:

```python
@property
def raw_audio_length_per_tok(self) -> int:
    return int(self.sampling_rate // self.frame_rate)
```

When `sampling_rate < frame_rate` this floors to `0`. The config is still accepted, and that `0` flows into the streaming pad path as `mult_of`, where `num_samples % mult_of` raises a cryptic `ZeroDivisionError` rather than a clear validation error:

```python
from mistral_common.tokens.tokenizers.audio import AudioConfig, AudioSpectrogramConfig

enc = AudioSpectrogramConfig(num_mel_bins=80, hop_length=160, window_size=400)
cfg = AudioConfig(sampling_rate=1, frame_rate=2.0, encoding_config=enc)  # accepted
cfg.raw_audio_length_per_tok                                             # 0
# AudioEncoder(cfg).encode_audio(...) -> pad -> _get_streaming_pad -> num_samples % 0 -> ZeroDivisionError
```

This adds `assert self.raw_audio_length_per_tok > 0` to `__post_init__`, mirroring the existing `chunk_frames > 0` guard, so an invalid config is rejected at construction with a clear message. Realistic configs (sampling rates in the thousands, frame rates in the tens) are unaffected.

A regression test is added in `tests/test_audio.py`.
