### PR TITLE
Fix multi-image content ordering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mistral_common"
-version = "1.11.4"
+version = "1.11.5"
 description = "Mistral-common is a library of common utilities for Mistral AI."
 authors = [{name = "bam4d", email = "bam4d@mistral.ai"}]
 license = "Apache-2.0"

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -741,14 +741,13 @@ class InstructTokenizerV3(
 
     @staticmethod
     def _maybe_put_image_first(content: list[ContentChunk]) -> list[ContentChunk]:
+        # Compatibility hack: this belongs in normalization and will be removed in an upcoming version.
         image_types = (ImageChunk, ImageURLChunk)
-        if sum(isinstance(chunk, image_types) for chunk in content) != 1:
-            return content
-        if not all(isinstance(chunk, (TextChunk, *image_types)) for chunk in content):
-            return content
-        if isinstance(content[0], image_types):
-            return content
-        if isinstance(content[-1], image_types):
+        if (
+            len(content) >= 2
+            and isinstance(content[-1], image_types)
+            and all(isinstance(chunk, TextChunk) for chunk in content[:-1])
+        ):
             return [content[-1], *content[:-1]]
         return content
 

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -739,6 +739,19 @@ class InstructTokenizerV3(
         else:
             raise ValueError(f"Unknown chunk type: {chunk}")
 
+    @staticmethod
+    def _maybe_put_image_first(content: list[ContentChunk]) -> list[ContentChunk]:
+        image_types = (ImageChunk, ImageURLChunk)
+        if sum(isinstance(chunk, image_types) for chunk in content) != 1:
+            return content
+        if not all(isinstance(chunk, (TextChunk, *image_types)) for chunk in content):
+            return content
+        if isinstance(content[0], image_types):
+            return content
+        if isinstance(content[-1], image_types):
+            return [content[-1], *content[:-1]]
+        return content
+
     def _encode_content_chunks(
         self, content: Sequence[ContentChunk]
     ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
@@ -780,10 +793,8 @@ class InstructTokenizerV3(
         images: list[np.ndarray] = []
         audio: list[Audio] = []
 
-        has_one_img_one_text_first = len(content) == 2 and isinstance(content[1], (ImageChunk, ImageURLChunk))
-        if force_img_first and has_one_img_one_text_first:
-            # make sure that if exactly one image and text chunk are passed we force the image chunk to be first
-            content = [content[1], content[0]]
+        if force_img_first:
+            content = self._maybe_put_image_first(content)
 
         first_chunk = True
         for chunk in content:
@@ -929,10 +940,8 @@ class InstructTokenizerV7(InstructTokenizerV3):
         if isinstance(content, str):
             return super().encode_user_content(content, is_last, system_prompt)
 
-        has_one_img_one_text_first = len(content) == 2 and isinstance(content[1], (ImageChunk, ImageURLChunk))
-        if force_img_first and has_one_img_one_text_first:
-            # make sure that if exactly one image and text chunk are passed we force the image chunk to be first
-            content = [content[1], content[0]]
+        if force_img_first:
+            content = self._maybe_put_image_first(content)
 
         tokens, images, audio = self._encode_content_chunks(content)
         return tokens, images, audio

--- a/tests/test_tokenizer_v3_mm.py
+++ b/tests/test_tokenizer_v3_mm.py
@@ -163,11 +163,6 @@ def text_tokenizer() -> MistralTokenizer:
     return tokenizer
 
 
-@pytest.fixture
-def spm_tokenizer() -> MistralTokenizer:
-    return MistralTokenizer.v7(is_mm=True)
-
-
 @pytest.mark.parametrize("r", text_alignment_requests)
 def test_agreement_with_text_only(
     mm_tokenizer: MistralTokenizer,
@@ -291,7 +286,6 @@ def test_image_tokenization_integration(mm_tokenizer: MistralTokenizer) -> None:
         assert output.tokens == expected_tokens, f"Incorrect tokens for request {r}"
 
 
-@pytest.mark.parametrize("tokenizer_fixture_name", ["mm_tokenizer", "spm_tokenizer"])
 @pytest.mark.parametrize(
     "content",
     [
@@ -320,25 +314,18 @@ def test_image_tokenization_integration(mm_tokenizer: MistralTokenizer) -> None:
         ),
     ],
 )
-def test_multi_image_order_is_preserved(
-    request: pytest.FixtureRequest,
-    tokenizer_fixture_name: str,
-    content: list[ContentChunk],
-) -> None:
-    tokenizer = request.getfixturevalue(tokenizer_fixture_name)
-    image_encoder = _set_test_image_patch_size(tokenizer)
-    tokenized = tokenizer.encode_chat_completion(ChatCompletionRequest(messages=[UserMessage(content=content)]))
+def test_multi_image_order_is_preserved(mm_tokenizer: MistralTokenizer, content: list[ContentChunk]) -> None:
+    image_encoder = _set_test_image_patch_size(mm_tokenizer)
+    tokenized = mm_tokenizer.encode_chat_completion(ChatCompletionRequest(messages=[UserMessage(content=content)]))
     assert _image_tokenizer_spans(tokenized.tokens, image_encoder.special_ids) == [
         _image_tokens(2, 2, image_encoder.special_ids),
         _image_tokens(3, 2, image_encoder.special_ids),
     ]
 
 
-@pytest.mark.parametrize("tokenizer_fixture_name", ["mm_tokenizer", "spm_tokenizer"])
-def test_single_trailing_image_moves_first(request: pytest.FixtureRequest, tokenizer_fixture_name: str) -> None:
-    tokenizer = request.getfixturevalue(tokenizer_fixture_name)
-    image_encoder = _set_test_image_patch_size(tokenizer)
-    tokenized = tokenizer.encode_chat_completion(
+def test_single_trailing_image_moves_first(mm_tokenizer: MistralTokenizer) -> None:
+    image_encoder = _set_test_image_patch_size(mm_tokenizer)
+    tokenized = mm_tokenizer.encode_chat_completion(
         ChatCompletionRequest(
             messages=[
                 UserMessage(
@@ -353,15 +340,13 @@ def test_single_trailing_image_moves_first(request: pytest.FixtureRequest, token
     assert _image_tokenizer_spans(tokenized.tokens, image_encoder.special_ids) == [
         _image_tokens(2, 2, image_encoder.special_ids)
     ]
-    x_token = tokenizer.instruct_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
+    x_token = mm_tokenizer.instruct_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
     assert tokenized.tokens.index(image_encoder.special_ids.img) < tokenized.tokens.index(x_token)
 
 
-@pytest.mark.parametrize("tokenizer_fixture_name", ["mm_tokenizer", "spm_tokenizer"])
-def test_single_leading_image_remains_first(request: pytest.FixtureRequest, tokenizer_fixture_name: str) -> None:
-    tokenizer = request.getfixturevalue(tokenizer_fixture_name)
-    image_encoder = _set_test_image_patch_size(tokenizer)
-    tokenized = tokenizer.encode_chat_completion(
+def test_single_leading_image_remains_first(mm_tokenizer: MistralTokenizer) -> None:
+    image_encoder = _set_test_image_patch_size(mm_tokenizer)
+    tokenized = mm_tokenizer.encode_chat_completion(
         ChatCompletionRequest(
             messages=[
                 UserMessage(
@@ -376,5 +361,5 @@ def test_single_leading_image_remains_first(request: pytest.FixtureRequest, toke
     assert _image_tokenizer_spans(tokenized.tokens, image_encoder.special_ids) == [
         _image_tokens(2, 2, image_encoder.special_ids)
     ]
-    x_token = tokenizer.instruct_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
+    x_token = mm_tokenizer.instruct_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
     assert tokenized.tokens.index(image_encoder.special_ids.img) < tokenized.tokens.index(x_token)

--- a/tests/test_tokenizer_v3_mm.py
+++ b/tests/test_tokenizer_v3_mm.py
@@ -15,7 +15,7 @@ from mistral_common.protocol.instruct.messages import (
 )
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
 from mistral_common.tokens.tokenizers.base import Tokenized
-from mistral_common.tokens.tokenizers.image import ImageEncoder
+from mistral_common.tokens.tokenizers.image import ImageEncoder, SpecialImageIDs
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 text_alignment_requests: list[ChatCompletionRequest] = [
@@ -123,6 +123,32 @@ text_requests: list[ChatCompletionRequest] = [
 ]
 
 
+def _image_tokens(width: int, height: int, special_ids: SpecialImageIDs) -> list[int]:
+    image_tokens = ([special_ids.img] * width + [special_ids.img_break]) * height
+    image_tokens[-1] = special_ids.img_end
+    return image_tokens
+
+
+def _set_test_image_patch_size(tokenizer: MistralTokenizer) -> ImageEncoder:
+    image_encoder = tokenizer.instruct_tokenizer.image_encoder
+    assert isinstance(image_encoder, ImageEncoder)
+    image_encoder.image_config.image_patch_size = 2
+    return image_encoder
+
+
+def _image_tokenizer_spans(tokens: list[int], special_ids: SpecialImageIDs) -> list[list[int]]:
+    spans: list[list[int]] = []
+    start_idx: int | None = None
+    for idx, token in enumerate(tokens):
+        if start_idx is None:
+            if token == special_ids.img:
+                start_idx = idx
+        elif token == special_ids.img_end:
+            spans.append(tokens[start_idx : idx + 1])
+            start_idx = None
+    return spans
+
+
 @pytest.fixture
 def mm_tokenizer() -> MistralTokenizer:
     path = str(MistralTokenizer._data_path() / "tekken_240911.json")
@@ -135,6 +161,11 @@ def text_tokenizer() -> MistralTokenizer:
     path = str(MistralTokenizer._data_path() / "tekken_240718.json")
     tokenizer = MistralTokenizer.from_file(path)
     return tokenizer
+
+
+@pytest.fixture
+def spm_tokenizer() -> MistralTokenizer:
+    return MistralTokenizer.v7(is_mm=True)
 
 
 @pytest.mark.parametrize("r", text_alignment_requests)
@@ -258,3 +289,92 @@ def test_image_tokenization_integration(mm_tokenizer: MistralTokenizer) -> None:
     for r, expected_tokens in zip(requests, expected, **kw_args):
         output: Tokenized = mm_tokenizer.encode_chat_completion(r)
         assert output.tokens == expected_tokens, f"Incorrect tokens for request {r}"
+
+
+@pytest.mark.parametrize("tokenizer_fixture_name", ["mm_tokenizer", "spm_tokenizer"])
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            [
+                TextChunk(text=""),
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                ImageChunk(image=Image.new("RGB", (6, 4), "blue")),
+            ],
+            id="empty-text-then-two-images",
+        ),
+        pytest.param(
+            [
+                TextChunk(text="x"),
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                ImageChunk(image=Image.new("RGB", (6, 4), "blue")),
+            ],
+            id="text-then-two-images",
+        ),
+        pytest.param(
+            [
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                ImageChunk(image=Image.new("RGB", (6, 4), "blue")),
+            ],
+            id="two-images",
+        ),
+    ],
+)
+def test_multi_image_order_is_preserved(
+    request: pytest.FixtureRequest,
+    tokenizer_fixture_name: str,
+    content: list[ContentChunk],
+) -> None:
+    tokenizer = request.getfixturevalue(tokenizer_fixture_name)
+    image_encoder = _set_test_image_patch_size(tokenizer)
+    tokenized = tokenizer.encode_chat_completion(ChatCompletionRequest(messages=[UserMessage(content=content)]))
+    assert _image_tokenizer_spans(tokenized.tokens, image_encoder.special_ids) == [
+        _image_tokens(2, 2, image_encoder.special_ids),
+        _image_tokens(3, 2, image_encoder.special_ids),
+    ]
+
+
+@pytest.mark.parametrize("tokenizer_fixture_name", ["mm_tokenizer", "spm_tokenizer"])
+def test_single_trailing_image_moves_first(request: pytest.FixtureRequest, tokenizer_fixture_name: str) -> None:
+    tokenizer = request.getfixturevalue(tokenizer_fixture_name)
+    image_encoder = _set_test_image_patch_size(tokenizer)
+    tokenized = tokenizer.encode_chat_completion(
+        ChatCompletionRequest(
+            messages=[
+                UserMessage(
+                    content=[
+                        TextChunk(text="x"),
+                        ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                    ]
+                )
+            ]
+        )
+    )
+    assert _image_tokenizer_spans(tokenized.tokens, image_encoder.special_ids) == [
+        _image_tokens(2, 2, image_encoder.special_ids)
+    ]
+    x_token = tokenizer.instruct_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
+    assert tokenized.tokens.index(image_encoder.special_ids.img) < tokenized.tokens.index(x_token)
+
+
+@pytest.mark.parametrize("tokenizer_fixture_name", ["mm_tokenizer", "spm_tokenizer"])
+def test_single_leading_image_remains_first(request: pytest.FixtureRequest, tokenizer_fixture_name: str) -> None:
+    tokenizer = request.getfixturevalue(tokenizer_fixture_name)
+    image_encoder = _set_test_image_patch_size(tokenizer)
+    tokenized = tokenizer.encode_chat_completion(
+        ChatCompletionRequest(
+            messages=[
+                UserMessage(
+                    content=[
+                        ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                        TextChunk(text="x"),
+                    ]
+                )
+            ]
+        )
+    )
+    assert _image_tokenizer_spans(tokenized.tokens, image_encoder.special_ids) == [
+        _image_tokens(2, 2, image_encoder.special_ids)
+    ]
+    x_token = tokenizer.instruct_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
+    assert tokenized.tokens.index(image_encoder.special_ids.img) < tokenized.tokens.index(x_token)

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -9,6 +9,7 @@ from mistral_common.exceptions import (
     TokenizerException,
 )
 from mistral_common.protocol.instruct.chunk import (
+    ContentChunk,
     ImageChunk,
     TextChunk,
 )
@@ -533,3 +534,96 @@ def test_encode_chat_completion_continue_final_message() -> None:
     assert encoded.tokens == [1, 3, 1032, 4, 1055]
     assert encoded.tokens[-1] != eos_id
     assert eos_id not in encoded.prefix_ids
+
+
+def _image_tokens(width: int, height: int) -> list[int]:
+    _im = 10
+    _im_break = 14
+    _im_end = 15
+    image_tokens = ([_im] * width + [_im_break]) * height
+    image_tokens[-1] = _im_end
+    return image_tokens
+
+
+def _image_tokenizer_spans(tokens: list[int]) -> list[list[int]]:
+    _im = 10
+    _im_end = 15
+    spans: list[list[int]] = []
+    start_idx: int | None = None
+    for idx, token in enumerate(tokens):
+        if start_idx is None:
+            if token == _im:
+                start_idx = idx
+        elif token == _im_end:
+            spans.append(tokens[start_idx : idx + 1])
+            start_idx = None
+    return spans
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(
+            [
+                TextChunk(text=""),
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                ImageChunk(image=Image.new("RGB", (6, 4), "blue")),
+            ],
+            id="empty-text-then-two-images",
+        ),
+        pytest.param(
+            [
+                TextChunk(text="x"),
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                ImageChunk(image=Image.new("RGB", (6, 4), "blue")),
+            ],
+            id="text-then-two-images",
+        ),
+        pytest.param(
+            [
+                ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                ImageChunk(image=Image.new("RGB", (6, 4), "blue")),
+            ],
+            id="two-images",
+        ),
+    ],
+)
+def test_multi_image_order_is_preserved(spm_tokenizer: InstructTokenizerV7, content: list[ContentChunk]) -> None:
+    tokenized = spm_tokenizer.encode_instruct(InstructRequest(messages=[UserMessage(content=content)]))
+    assert _image_tokenizer_spans(tokenized.tokens) == [_image_tokens(2, 2), _image_tokens(3, 2)]
+
+
+def test_single_trailing_image_moves_first(spm_tokenizer: InstructTokenizerV7) -> None:
+    tokenized = spm_tokenizer.encode_instruct(
+        InstructRequest(
+            messages=[
+                UserMessage(
+                    content=[
+                        TextChunk(text="x"),
+                        ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                    ]
+                )
+            ]
+        )
+    )
+    assert _image_tokenizer_spans(tokenized.tokens) == [_image_tokens(2, 2)]
+    x_token = spm_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
+    assert tokenized.tokens.index(10) < tokenized.tokens.index(x_token)
+
+
+def test_single_leading_image_remains_first(spm_tokenizer: InstructTokenizerV7) -> None:
+    tokenized = spm_tokenizer.encode_instruct(
+        InstructRequest(
+            messages=[
+                UserMessage(
+                    content=[
+                        ImageChunk(image=Image.new("RGB", (4, 4), "red")),
+                        TextChunk(text="x"),
+                    ]
+                )
+            ]
+        )
+    )
+    assert _image_tokenizer_spans(tokenized.tokens) == [_image_tokens(2, 2)]
+    x_token = spm_tokenizer.tokenizer.encode("x", bos=False, eos=False)[0]
+    assert tokenized.tokens.index(10) < tokenized.tokens.index(x_token)

--- a/uv.lock
+++ b/uv.lock
@@ -873,7 +873,7 @@ wheels = [
 
 [[package]]
 name = "mistral-common"
-version = "1.11.4"
+version = "1.11.5"
 source = { editable = "." }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary
- Replace the faulty length-2 image-first swap with `_maybe_put_image_first`, which only moves a single trailing image ahead of text-only content.
- Preserve multi-image ordering, including the `[TextChunk(""), img_a, img_b]` path exposed by empty-text stripping in normalization.
- Bump the package release version to 1.11.5.

## Verification
- `uv --no-config run --all-extras --group dev pytest tests/test_tokenizer_v3_mm.py -q`
- `uv --no-config run ruff format . --check`
- `uv --no-config run ruff check .`
- `uv --no-config run mypy .`
- `uv --no-config lock --check`
- `uv --no-config run pytest --cov=mistral_common tests/ --ignore=tests/integrations --cov-report "xml:coverage.xml"`
- `uv --no-config run pytest --doctest-modules ./src`
- `uv --no-config sync --frozen --all-extras --group dev --group test-integrations && uv --no-config run --no-sync pytest tests/integrations/ -q`
