### PR TITLE
Raise ValueError instead of ValidationError in audio chunk validators

### DIFF
--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import ConfigDict, Field, ValidationError, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Annotated
 
 from mistral_common.base import MistralBase
@@ -232,7 +232,7 @@ class RawAudio(MistralBase):
     @field_validator("format")
     def should_not_be_empty(cls, v: str) -> str:
         if not v.strip():
-            raise ValidationError("`format` should not be empty")
+            raise ValueError("`format` should not be empty")
 
         return v
 
@@ -363,9 +363,9 @@ class AudioChunk(BaseContentChunk):
     def should_not_be_empty(cls, v: str | bytes) -> str | bytes:
         r"""Validate that the audio data is not empty."""
         if isinstance(v, str) and not v.strip():
-            raise ValidationError("`input_audio` should not be empty.")
+            raise ValueError("`input_audio` should not be empty.")
         if isinstance(v, bytes) and not v:
-            raise ValidationError("`input_audio` should not be empty.")
+            raise ValueError("`input_audio` should not be empty.")
         return v
 
     @classmethod

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 import requests
 import soundfile as sf
+from pydantic import ValidationError
 
 from mistral_common.audio import hertz_to_mel, mel_filter_bank
 from mistral_common.protocol.instruct.chunk import AudioChunk, RawAudio
@@ -343,6 +344,11 @@ class TestRawAudioBackwardCompat:
     def test_audiochunk_with_bytes_new_api(self) -> None:
         chunk = AudioChunk(input_audio=b"raw_bytes")
         assert chunk.input_audio == b"raw_bytes"
+
+    @pytest.mark.parametrize("empty_audio", ["", "   ", b""])
+    def test_audiochunk_empty_input_raises_validation_error(self, empty_audio: str | bytes) -> None:
+        with pytest.raises(ValidationError, match="should not be empty"):
+            AudioChunk(input_audio=empty_audio)
 
 
 def test_transcription_request_with_rawaudio_backward_compat() -> None:


### PR DESCRIPTION
Constructing an `AudioChunk` with empty input raises a confusing `TypeError` instead of a validation error:

```python
>>> from mistral_common.protocol.instruct.chunk import AudioChunk
>>> AudioChunk(input_audio="")
TypeError: ValidationError.__new__() missing 1 required positional argument: 'line_errors'
```

The `should_not_be_empty` validator raises `pydantic.ValidationError("...")` directly, but in Pydantic v2 that type has no public string constructor, so the validator itself blows up before it can report the real problem. The deprecated `RawAudio.format` validator has the same issue.

I switched both to a plain `ValueError`, which is what every other validator in the library already does and which Pydantic wraps into a proper `ValidationError` carrying the message. Empty `str`, whitespace-only `str`, and empty `bytes` now all raise a clear validation error.

Added a parametrized test in `tests/test_audio.py` for those three inputs. Ran the full test suite, ruff, ruff format, mypy and the doctests locally, all green.