### PR TITLE
Decode normal tokens under SpecialTokenPolicy.RAISE in SentencePiece

### DIFF
--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -218,8 +218,13 @@ class SentencePieceTokenizer(Tokenizer):
                 f"Expected `special_token_policy` to be a SpecialTokenPolicy, got {type(special_token_policy)}."
             )
 
-        if special_token_policy in [SpecialTokenPolicy.KEEP, SpecialTokenPolicy.RAISE]:
-            return self._decode_with_special_tokens(tokens, special_token_policy)
+        if special_token_policy == SpecialTokenPolicy.RAISE:
+            if any(self.is_special(tok) for tok in tokens):
+                raise ValueError("Decoding `tokens` that contain special tokens with special_token_policy=RAISE.")
+            return self._model.decode(tokens)  # type: ignore[no-any-return]
+
+        if special_token_policy == SpecialTokenPolicy.KEEP:
+            return self._decode_with_special_tokens(tokens)
 
         return self._model.decode(tokens)  # type: ignore[no-any-return]
 
@@ -227,13 +232,13 @@ class SentencePieceTokenizer(Tokenizer):
         r"""Convert the given token id to a token piece."""
         return self._model.id_to_piece(token_id)  # type: ignore
 
-    def _decode_with_special_tokens(self, tokens: list[int], special_token_policy: SpecialTokenPolicy) -> str:
+    def _decode_with_special_tokens(self, tokens: list[int]) -> str:
+        # KEEP policy: special tokens are rendered as their piece string and normal tokens are kept
+        # as SentencePiece pieces (see the note in `decode`).
         text_list = []
         curr_tokens: list[int] = []
         for tok in tokens:
             if self.is_special(tok):
-                if special_token_policy == SpecialTokenPolicy.RAISE:
-                    raise ValueError("Decoding `tokens` that contain special tokens with special_token_policy=RAISE.")
                 if curr_tokens:
                     text_list.extend([self.id_to_piece(tok) for tok in curr_tokens])
                     curr_tokens = []

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -220,7 +220,7 @@ class SentencePieceTokenizer(Tokenizer):
 
         if special_token_policy == SpecialTokenPolicy.IGNORE:
             decoded = self._model.decode(tokens)
-            assert isinstance(decoded, str), f"Mode decoded a {type(decoded)}, not a string."
+            assert isinstance(decoded, str), f"Sentencepiece model decoded a {type(decoded)}, not a string."
             return decoded
 
         return self._decode_with_special_tokens(tokens, special_token_policy)

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -218,29 +218,27 @@ class SentencePieceTokenizer(Tokenizer):
                 f"Expected `special_token_policy` to be a SpecialTokenPolicy, got {type(special_token_policy)}."
             )
 
-        if special_token_policy == SpecialTokenPolicy.RAISE:
-            if any(self.is_special(tok) for tok in tokens):
-                raise ValueError("Decoding `tokens` that contain special tokens with special_token_policy=RAISE.")
+        if special_token_policy == SpecialTokenPolicy.IGNORE:
             return self._model.decode(tokens)  # type: ignore[no-any-return]
 
-        if special_token_policy == SpecialTokenPolicy.KEEP:
-            return self._decode_with_special_tokens(tokens)
-
-        return self._model.decode(tokens)  # type: ignore[no-any-return]
+        return self._decode_with_special_tokens(tokens, special_token_policy)
 
     def id_to_piece(self, token_id: int) -> str:
         r"""Convert the given token id to a token piece."""
         return self._model.id_to_piece(token_id)  # type: ignore
 
-    def _decode_with_special_tokens(self, tokens: list[int]) -> str:
-        # KEEP policy: special tokens are rendered as their piece string and normal tokens are kept
-        # as SentencePiece pieces (see the note in `decode`).
+    def _decode_with_special_tokens(self, tokens: list[int], special_token_policy: SpecialTokenPolicy) -> str:
+        # KEEP renders special tokens (and the normal tokens around them) as their SentencePiece
+        # pieces; RAISE rejects any special token in a single pass and otherwise decodes the
+        # (all-normal) sequence normally.
         text_list = []
         curr_tokens: list[int] = []
         for tok in tokens:
             if self.is_special(tok):
+                if special_token_policy == SpecialTokenPolicy.RAISE:
+                    raise ValueError("Decoding `tokens` that contain special tokens with special_token_policy=RAISE.")
                 if curr_tokens:
-                    text_list.extend([self.id_to_piece(tok) for tok in curr_tokens])
+                    text_list.extend([self.id_to_piece(t) for t in curr_tokens])
                     curr_tokens = []
 
                 text_list.append(self.id_to_piece(tok))
@@ -249,7 +247,11 @@ class SentencePieceTokenizer(Tokenizer):
                 curr_tokens.append(tok)
 
         if curr_tokens:
-            text_list.extend([self.id_to_piece(tok) for tok in curr_tokens])
+            if special_token_policy == SpecialTokenPolicy.RAISE:
+                # Reached only when no special token was present, so decode the whole run.
+                text_list.append(self._model.decode(curr_tokens))
+            else:
+                text_list.extend([self.id_to_piece(t) for t in curr_tokens])
 
         return "".join(text_list)
 

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -219,7 +219,9 @@ class SentencePieceTokenizer(Tokenizer):
             )
 
         if special_token_policy == SpecialTokenPolicy.IGNORE:
-            return self._model.decode(tokens)  # type: ignore[no-any-return]
+            decoded = self._model.decode(tokens)
+            assert isinstance(decoded, str), f"Mode decoded a {type(decoded)}, not a string."
+            return decoded
 
         return self._decode_with_special_tokens(tokens, special_token_policy)
 

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -228,9 +228,6 @@ class SentencePieceTokenizer(Tokenizer):
         return self._model.id_to_piece(token_id)  # type: ignore
 
     def _decode_with_special_tokens(self, tokens: list[int], special_token_policy: SpecialTokenPolicy) -> str:
-        # KEEP renders special tokens (and the normal tokens around them) as their SentencePiece
-        # pieces; RAISE rejects any special token in a single pass and otherwise decodes the
-        # (all-normal) sequence normally.
         text_list = []
         curr_tokens: list[int] = []
         for tok in tokens:
@@ -248,7 +245,6 @@ class SentencePieceTokenizer(Tokenizer):
 
         if curr_tokens:
             if special_token_policy == SpecialTokenPolicy.RAISE:
-                # Reached only when no special token was present, so decode the whole run.
                 text_list.append(self._model.decode(curr_tokens))
             else:
                 text_list.extend([self.id_to_piece(t) for t in curr_tokens])

--- a/tests/test_sentencepiece.py
+++ b/tests/test_sentencepiece.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
 
 
@@ -48,3 +49,19 @@ def test_sentencepiece_tokenizer_num_specials_property(tokenizer_v7: SentencePie
 
     # Test that num_special_tokens matches the length of special_ids
     assert num_special == len(tokenizer_v7.special_ids)
+
+
+def test_decode_raise_policy_decodes_normal_tokens(tokenizer_v7: SentencePieceTokenizer) -> None:
+    # With no special tokens present, RAISE should decode normal tokens to text just like IGNORE,
+    # not return raw SentencePiece pieces (which is the documented behavior of KEEP only).
+    text = "Hello world, how are you?"
+    ids = tokenizer_v7.encode(text, bos=False, eos=False)
+    assert tokenizer_v7.decode(ids, SpecialTokenPolicy.RAISE) == text
+    assert tokenizer_v7.decode(ids, SpecialTokenPolicy.RAISE) == tokenizer_v7.decode(ids, SpecialTokenPolicy.IGNORE)
+
+
+def test_decode_raise_policy_raises_on_special_tokens(tokenizer_v7: SentencePieceTokenizer) -> None:
+    ids = tokenizer_v7.encode("Hello world", bos=True, eos=True)
+    assert any(tokenizer_v7.is_special(tok) for tok in ids)
+    with pytest.raises(ValueError):
+        tokenizer_v7.decode(ids, SpecialTokenPolicy.RAISE)

--- a/tests/test_sentencepiece.py
+++ b/tests/test_sentencepiece.py
@@ -52,8 +52,6 @@ def test_sentencepiece_tokenizer_num_specials_property(tokenizer_v7: SentencePie
 
 
 def test_decode_raise_policy_decodes_normal_tokens(tokenizer_v7: SentencePieceTokenizer) -> None:
-    # With no special tokens present, RAISE should decode normal tokens to text just like IGNORE,
-    # not return raw SentencePiece pieces (which is the documented behavior of KEEP only).
     text = "Hello world, how are you?"
     ids = tokenizer_v7.encode(text, bos=False, eos=False)
     assert tokenizer_v7.decode(ids, SpecialTokenPolicy.RAISE) == text


### PR DESCRIPTION
While decoding with `SpecialTokenPolicy.RAISE` on a SentencePiece tokenizer, I noticed it returns the raw SentencePiece pieces instead of decoded text when the tokens contain no special token:

```python
tok = MistralTokenizer.v3().instruct_tokenizer.tokenizer
ids = tok.encode("Hello world, how are you?", bos=False, eos=False)
tok.decode(ids, SpecialTokenPolicy.IGNORE)  # 'Hello world, how are you?'
tok.decode(ids, SpecialTokenPolicy.RAISE)   # '▁Hello▁world,▁how▁are▁you?'  <- pieces, not text
```

RAISE was sharing the KEEP code path (`_decode_with_special_tokens`), which keeps non-special tokens as pieces. That's documented behavior for KEEP, but RAISE is only meant to raise when a special token is present and otherwise decode normally — the way IGNORE here and Tekken already do. So a perfectly valid "decode and make sure there are no special tokens" call comes back garbled.

I split RAISE out of that path: raise if any token is special, otherwise decode through SentencePiece like IGNORE. KEEP is left as-is. Added tests for both the no-special-token decode and the raise-on-special-token case; ruff, mypy, and the full pytest + doctest suites pass.
