### PR TITLE
Add response_format support to model settings

### DIFF
--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -1,9 +1,10 @@
 from enum import Enum
 from typing import Any, Generic
 
-from pydantic import Field
+from pydantic import ConfigDict, Field, field_validator
 
 from mistral_common.base import MistralBase
+from mistral_common.exceptions import InvalidRequestException
 from mistral_common.protocol.base import BaseCompletionRequest
 from mistral_common.protocol.instruct.converters import (
     convert_openai_messages,
@@ -16,6 +17,7 @@ from mistral_common.protocol.instruct.messages import (
     ReasoningFieldFormat,
 )
 from mistral_common.protocol.instruct.tool_calls import Tool, ToolChoice, ToolChoiceEnum, ToolType
+from mistral_common.utils.json_utils import validate_json_schema_by_draft7
 
 
 class ResponseFormats(str, Enum):
@@ -24,6 +26,7 @@ class ResponseFormats(str, Enum):
     Attributes:
         text: The response is a plain text.
         json: The response is a JSON object.
+        json_schema: The response follows a custom JSON schema.
 
     Examples:
         >>> response_format = ResponseFormats.text
@@ -31,6 +34,7 @@ class ResponseFormats(str, Enum):
 
     text = "text"
     json = "json_object"
+    json_schema = "json_schema"
 
 
 class ReasoningEffort(str, Enum):
@@ -55,9 +59,12 @@ class ModelSettings(MistralBase):
     Attributes:
         reasoning_effort: Controls how much reasoning effort the model should apply when
             generating responses. Supported for tokenizer >= v15 and not supported for earlier versions.
+        json_schema: The JSON schema to enforce on the response, derived from the request's
+            response format. Supported for tokenizer >= v15 and not supported for earlier versions.
     """
 
     reasoning_effort: ReasoningEffort | None = None
+    json_schema: dict[str, Any] | None = None
 
     @staticmethod
     def none() -> "ModelSettings":
@@ -65,17 +72,67 @@ class ModelSettings(MistralBase):
         return ModelSettings()
 
 
+class JsonSchema(MistralBase):
+    r"""A named JSON schema for structured responses.
+
+    Attributes:
+        name: The schema name.
+        description: An optional description of the schema.
+        custom_schema: The JSON schema (aliased ``schema``).
+        strict: Whether the model must strictly adhere to the schema.
+
+    Examples:
+        >>> schema = JsonSchema(name="obj", schema={"type": "object"})
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    description: str | None = None
+    custom_schema: dict[str, Any] = Field(..., alias="schema")
+    strict: bool = False
+
+    @field_validator("custom_schema")
+    @classmethod
+    def validate_custom_schema(cls, value: dict[str, Any]) -> dict[str, Any]:
+        r"""Validate the schema against JSON Schema Draft 7."""
+        validate_json_schema_by_draft7(value=value)
+        return value
+
+
 class ResponseFormat(MistralBase):
     r"""The format of the response.
 
     Attributes:
         type: The type of the response.
+        json_schema: The JSON schema when ``type`` is ``json_schema``.
 
     Examples:
         >>> response_format = ResponseFormat(type=ResponseFormats.text)
     """
 
     type: ResponseFormats = ResponseFormats.text
+    json_schema: JsonSchema | None = None
+
+    def get_schema(self) -> dict[str, Any] | None:
+        r"""Return the JSON schema to enforce for this response format.
+
+        Returns:
+            The schema dict, or None when no constraint applies.
+
+        Raises:
+            InvalidRequestException: If ``type`` is ``json_schema`` but no schema is set.
+        """
+        schema: dict[str, Any] | None
+        if self.type == ResponseFormats.json_schema:
+            if self.json_schema is None:
+                raise InvalidRequestException("Response format `json_schema` must define the schema")
+            schema = self.json_schema.custom_schema
+        elif self.type == ResponseFormats.json:
+            schema = {"anyOf": [{"type": "object"}, {"type": "array"}]}
+        else:
+            schema = None
+        return schema
 
 
 class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
@@ -159,7 +216,9 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
 
         # Handle messages and tools separately.
         openai_request: dict[str, Any] = self.model_dump(
-            exclude={"messages", "tools", "truncate_for_context_length", "tool_choice"}, exclude_none=True
+            exclude={"messages", "tools", "truncate_for_context_length", "tool_choice"},
+            exclude_none=True,
+            by_alias=True,
         )
 
         # Rename random_seed to seed.

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -1401,7 +1401,9 @@ class InstructTokenizerV15(InstructTokenizerV13):
         self._validate_settings(settings)
         if settings == ModelSettings.none():
             return []
-        dumped_settings = json.dumps(settings.model_dump(exclude_none=True), ensure_ascii=False, sort_keys=True)
+        dumped = settings.model_dump(exclude_none=True)
+        ordered = {k: dumped[k] for k in sorted(dumped)}
+        dumped_settings = json.dumps(ordered, ensure_ascii=False)
         setting_json_tokens = self.tokenizer.encode(dumped_settings, bos=False, eos=False)
         settings_tokens = [
             self.BEGIN_MODEL_SETTINGS,

--- a/src/mistral_common/tokens/tokenizers/model_settings_builder.py
+++ b/src/mistral_common/tokens/tokenizers/model_settings_builder.py
@@ -1,11 +1,17 @@
 from enum import Enum
-from typing import Any, Generic, TypeVar, final
+from typing import Any, ClassVar, Generic, Literal, TypeAlias, TypeVar, final
 
 from pydantic import model_validator
 
 from mistral_common.base import MistralBase
 from mistral_common.exceptions import InvalidRequestException
-from mistral_common.protocol.instruct.request import ChatCompletionRequest, ModelSettings, ReasoningEffort
+from mistral_common.protocol.instruct.request import (
+    ChatCompletionRequest,
+    ModelSettings,
+    ReasoningEffort,
+    ResponseFormat,
+)
+from mistral_common.utils.json_utils import validate_json_schema_by_draft7
 
 
 class ValidatorType(str, Enum):
@@ -13,20 +19,22 @@ class ValidatorType(str, Enum):
 
     Attributes:
         ENUM: Indicates that the validator is for enum values.
+        JSON_SCHEMA: Indicates that the validator is for JSON schema values.
     """
 
     ENUM = "enum"
+    JSON_SCHEMA = "json_schema"
 
 
-T = TypeVar("T")
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+JSONSchemaDict: TypeAlias = dict[str, Any] | None
 
 
-class FieldBuilder(MistralBase, Generic[T]):
+class FieldBuilder(MistralBase, Generic[InputT, OutputT]):
     r"""Base class for field builders.
 
-    This class serves as the base for all field builders in the validation framework.
-    It ensures that all builders have a type attribute that specifies the kind of
-    validation being performed.
+    `InputT` is the request field type, `OutputT` is the converted `ModelSettings` field type.
 
     Attributes:
         type: The type of validator (e.g., ENUM).
@@ -36,7 +44,7 @@ class FieldBuilder(MistralBase, Generic[T]):
 
     type: ValidatorType
     accepts_none: bool
-    default: T | None
+    default: OutputT | None
 
     @model_validator(mode="after")
     def validate_default_accept_none(self) -> "FieldBuilder":
@@ -47,51 +55,42 @@ class FieldBuilder(MistralBase, Generic[T]):
             )
         return self
 
-    def _validate_built_value(self, field_name: str, value: Any) -> None:
-        r"""Validate a non-None built value. Must be implemented by subclasses."""
-        raise NotImplementedError(f"{field_name} is not supported")
+    def _convert(self, input_value: InputT) -> OutputT:
+        r"""Convert a request value to the model-settings value."""
+        raise NotImplementedError
 
-    def _build_from_optional(self, field_name: str, value: T | None) -> T | None:
-        r"""Resolve an optional value, substituting the default if value is None.
+    def _build_from_optional(self, field_name: str, input_value: InputT | None) -> OutputT | None:
+        r"""Resolve an optional value, substituting the default if input is None.
 
         Raises:
-            InvalidRequestException: If value is None and the field does not accept None.
+            InvalidRequestException: If input is None and the field does not accept None.
         """
-        if value is None:
+        if input_value is None:
             if not self.accepts_none:
                 raise InvalidRequestException(f"{field_name} should be set for this model.")
             return self.default
-        return value
+        return self._convert(input_value=input_value)
+
+    def validate_built_value(self, field_name: str, built_value: OutputT | None) -> None:
+        r"""Validate a fully built value. Must be implemented by subclasses."""
+        raise NotImplementedError
 
     @final
-    def validate_built_value(self, field_name: str, value: Any) -> None:
-        r"""Validate a fully built value, including None checks.
-
-        Raises:
-            InvalidRequestException: If value is None when not permitted, or fails subclass validation.
-        """
-        if value is None:
-            if not (self.accepts_none and self.default is None):
-                raise InvalidRequestException(f"{field_name} should be set for this model.")
-        else:
-            self._validate_built_value(field_name, value)
-
-    @final
-    def build_value(self, field_name: str, value: T | None) -> T | None:
+    def build_value(self, field_name: str, input_value: InputT | None) -> OutputT | None:
         r"""Resolve and validate a field value, returning the final built result.
 
         Raises:
             InvalidRequestException: If the value is invalid or missing when required.
         """
-        value = self._build_from_optional(field_name, value)
-        self.validate_built_value(field_name, value)
-        return value
+        built_value = self._build_from_optional(field_name, input_value)
+        self.validate_built_value(field_name, built_value)
+        return built_value
 
 
 E = TypeVar("E", bound=Enum)
 
 
-class EnumBuilder(FieldBuilder[E]):
+class EnumBuilder(FieldBuilder[E, E]):
     r"""Builder for enum fields.
 
     This class validates that enum fields contain only authorized values.
@@ -105,6 +104,10 @@ class EnumBuilder(FieldBuilder[E]):
 
     type: ValidatorType = ValidatorType.ENUM
     values: list[E]
+
+    def _convert(self, input_value: E) -> E:
+        r"""Enum builders pass values through unchanged."""
+        return input_value
 
     @model_validator(mode="after")
     def validate_unique_values(self) -> "EnumBuilder":
@@ -127,16 +130,42 @@ class EnumBuilder(FieldBuilder[E]):
             raise ValueError(f"Default value {self.default=} is not in {self.values=}.")
         return self
 
-    def _validate_built_value(self, field_name: str, value: Any) -> None:
-        r"""Check that value is one of the allowed enum values.
+    def validate_built_value(self, field_name: str, built_value: E | None) -> None:
+        r"""Check that the built value is one of the allowed enum values.
 
         Raises:
-            InvalidRequestException: If no values are allowed, or value is not in the allowed list.
+            InvalidRequestException: If unset when required, unsupported, or not allowed.
         """
-        if len(self.values) == 0:
+        if built_value is None:
+            if not (self.accepts_none and self.default is None):
+                raise InvalidRequestException(f"{field_name} should be set for this model.")
+        elif len(self.values) == 0:
             raise InvalidRequestException(f"{field_name} not supported for this model.")
-        if value not in self.values:
-            raise InvalidRequestException(f"{field_name} should be one of {self.values}, got {value}.")
+        elif built_value not in self.values:
+            raise InvalidRequestException(f"{field_name} should be one of {self.values}, got {built_value}.")
+
+
+class JSONSchemaBuilder(FieldBuilder[ResponseFormat, JSONSchemaDict]):
+    r"""Converts a `ResponseFormat` into a JSON-schema dict for model settings.
+
+    Attributes:
+        type: The type of validator (always JSON_SCHEMA for this class).
+        accepts_none: Always False, as a response format is always present on the request.
+        default: Always None, no default schema is supported.
+    """
+
+    type: ValidatorType = ValidatorType.JSON_SCHEMA
+    accepts_none: Literal[False]
+    default: None
+
+    def _convert(self, input_value: ResponseFormat) -> JSONSchemaDict:
+        r"""Render the response format's schema for model-settings encoding."""
+        return input_value.get_schema()
+
+    def validate_built_value(self, field_name: str, built_value: JSONSchemaDict) -> None:
+        r"""Validate the built schema against Draft 7 when present."""
+        if built_value is not None:
+            validate_json_schema_by_draft7(built_value)
 
 
 class ModelSettingsBuilder(MistralBase):
@@ -151,9 +180,16 @@ class ModelSettingsBuilder(MistralBase):
 
     Attributes:
         reasoning_effort: Builder for the allowed ReasoningEffort values, or None if unsupported.
+        json_schema: Builder for the response-format JSON schema, or None if unsupported.
     """
 
+    _SETTINGS_TO_CONV_FIELDS_MAP: ClassVar[dict[str, str]] = {
+        "reasoning_effort": "reasoning_effort",
+        "json_schema": "response_format",
+    }
+
     reasoning_effort: EnumBuilder[ReasoningEffort] | None = None
+    json_schema: JSONSchemaBuilder | None = None
 
     @staticmethod
     def none() -> "ModelSettingsBuilder":
@@ -177,8 +213,8 @@ class ModelSettingsBuilder(MistralBase):
         """
         dict_settings = {}
         for field_name in ModelSettingsBuilder.model_fields:
-            # We have a CI test to ensure all fields match between ModelSettings and ModelSettingsEncoder.
-            value = getattr(request, field_name)
+            # We have a CI test to ensure all fields match between ModelSettings and ModelSettingsBuilder.
+            value = getattr(request, self._SETTINGS_TO_CONV_FIELDS_MAP[field_name])
             field_builder: FieldBuilder | None = getattr(self, field_name)
             if field_builder is not None:
                 dict_settings[field_name] = field_builder.build_value(field_name, value)

--- a/src/mistral_common/utils/json_utils.py
+++ b/src/mistral_common/utils/json_utils.py
@@ -1,0 +1,17 @@
+import jsonschema
+import jsonschema.exceptions
+
+
+def validate_json_schema_by_draft7(value: dict) -> None:
+    r"""Validate that a dict is a valid Draft 7 JSON Schema.
+
+    Args:
+        value: The candidate JSON schema.
+
+    Raises:
+        ValueError: If the value is not a valid Draft 7 JSON Schema.
+    """
+    try:
+        jsonschema.Draft7Validator.check_schema(value)
+    except jsonschema.exceptions.SchemaError as e:
+        raise ValueError(f"Invalid JSON Schema: {e.message}") from e

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -762,6 +762,8 @@ def test_from_openai_accepts_schema_key() -> None:
         messages=[{"role": "user", "content": "hi"}],
         response_format={"type": "json_schema", "json_schema": {"name": "x", "schema": schema}},
     )
+    assert req.response_format is not None
+    assert req.response_format.json_schema is not None
     assert req.response_format.json_schema.custom_schema == schema
 
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -55,7 +55,10 @@ from mistral_common.protocol.instruct.messages import (
 )
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest,
+    JsonSchema,
     ReasoningEffort,
+    ResponseFormat,
+    ResponseFormats,
 )
 from mistral_common.protocol.instruct.tool_calls import (
     Function,
@@ -743,6 +746,23 @@ def test_request_to_openai_forwards_reasoning_field_format() -> None:
     openai_request = request.to_openai(reasoning_field_format=ReasoningFieldFormat.reasoning)
     assistant_msg = [m for m in openai_request["messages"] if m["role"] == "assistant"][0]
     assert assistant_msg == {"role": "assistant", "reasoning": "Let me think", "content": "Done"}
+
+
+def test_to_openai_renames_custom_schema_to_schema() -> None:
+    schema = {"type": "object"}
+    rf = ResponseFormat(type=ResponseFormats.json_schema, json_schema=JsonSchema(name="x", schema=schema))
+    out = ChatCompletionRequest(messages=[UserMessage(content="hi")], response_format=rf).to_openai()
+    assert out["response_format"]["json_schema"]["schema"] == schema
+    assert "custom_schema" not in out["response_format"]["json_schema"]
+
+
+def test_from_openai_accepts_schema_key() -> None:
+    schema = {"type": "object"}
+    req = ChatCompletionRequest.from_openai(
+        messages=[{"role": "user", "content": "hi"}],
+        response_format={"type": "json_schema", "json_schema": {"name": "x", "schema": schema}},
+    )
+    assert req.response_format.json_schema.custom_schema == schema
 
 
 @pytest.mark.parametrize(

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,12 @@
+import pytest
+
+from mistral_common.utils.json_utils import validate_json_schema_by_draft7
+
+
+def test_valid_schema_passes() -> None:
+    validate_json_schema_by_draft7({"type": "object"})
+
+
+def test_invalid_schema_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid JSON Schema"):
+        validate_json_schema_by_draft7({"type": 123})

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -2,13 +2,20 @@ import pytest
 from pydantic import ValidationError
 
 from mistral_common.exceptions import InvalidRequestException
-from mistral_common.protocol.instruct.messages import UATS
+from mistral_common.protocol.instruct.messages import UATS, UserMessage
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest,
+    JsonSchema,
     ModelSettings,
     ReasoningEffort,
+    ResponseFormat,
+    ResponseFormats,
 )
-from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, ModelSettingsBuilder
+from mistral_common.tokens.tokenizers.model_settings_builder import (
+    EnumBuilder,
+    JSONSchemaBuilder,
+    ModelSettingsBuilder,
+)
 
 
 class TestModelSettings:
@@ -204,6 +211,50 @@ class TestModelSettingsBuilder:
         else:
             with pytest.raises(InvalidRequestException, match=r"reasoning_effort should be set for this model"):
                 builder.validate_settings(settings)
+
+
+JSON_SCHEMA_DICT = {"type": "object", "properties": {"a": {"type": "string"}}}
+
+
+def _req(rf: ResponseFormat) -> ChatCompletionRequest:
+    return ChatCompletionRequest(messages=[UserMessage(content="hi")], response_format=rf)
+
+
+def test_builder_text_yields_none() -> None:
+    b = ModelSettingsBuilder(json_schema=JSONSchemaBuilder(accepts_none=False, default=None))
+    assert b.build_settings(_req(ResponseFormat(type=ResponseFormats.text))).json_schema is None
+
+
+def test_builder_json_yields_anyof() -> None:
+    b = ModelSettingsBuilder(json_schema=JSONSchemaBuilder(accepts_none=False, default=None))
+    assert b.build_settings(_req(ResponseFormat(type=ResponseFormats.json))).json_schema == {
+        "anyOf": [{"type": "object"}, {"type": "array"}]
+    }
+
+
+def test_builder_json_schema_yields_custom_schema() -> None:
+    b = ModelSettingsBuilder(json_schema=JSONSchemaBuilder(accepts_none=False, default=None))
+    rf = ResponseFormat(type=ResponseFormats.json_schema, json_schema=JsonSchema(name="x", schema=JSON_SCHEMA_DICT))
+    assert b.build_settings(_req(rf)).json_schema == JSON_SCHEMA_DICT
+
+
+def test_json_schema_missing_schema_raises() -> None:
+    with pytest.raises(InvalidRequestException, match="must define the schema"):
+        ResponseFormat(type=ResponseFormats.json_schema).get_schema()
+
+
+def test_builder_without_json_schema_ignores_response_format() -> None:
+    assert ModelSettingsBuilder().build_settings(_req(ResponseFormat(type=ResponseFormats.json))).json_schema is None
+
+
+def test_model_settings_json_schema_field() -> None:
+    s = ModelSettings(json_schema={"type": "object"})
+    assert s.json_schema == {"type": "object"}
+    assert s.model_dump(exclude_none=True) == {"json_schema": {"type": "object"}}
+
+
+def test_model_settings_none_excludes_json_schema() -> None:
+    assert ModelSettings.none().model_dump(exclude_none=True) == {}
 
 
 def test_all_model_settings_and_builder_fields_match() -> None:

--- a/tests/test_tokenizer_v15.py
+++ b/tests/test_tokenizer_v15.py
@@ -24,8 +24,11 @@ from mistral_common.protocol.instruct.normalize import get_normalizer
 from mistral_common.protocol.instruct.request import (
     ChatCompletionRequest,
     InstructRequest,
+    JsonSchema,
     ModelSettings,
     ReasoningEffort,
+    ResponseFormat,
+    ResponseFormats,
 )
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.protocol.instruct.validator import ValidationMode, get_validator
@@ -34,7 +37,11 @@ from mistral_common.tokens.tokenizers.base import SpecialTokens, TokenizerVersio
 from mistral_common.tokens.tokenizers.image import ImageConfig, ImageEncoder, SpecialImageIDs
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV15
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
-from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, ModelSettingsBuilder
+from mistral_common.tokens.tokenizers.model_settings_builder import (
+    EnumBuilder,
+    JSONSchemaBuilder,
+    ModelSettingsBuilder,
+)
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 from tests.fixtures.audio import get_dummy_audio_chunk, get_dummy_audio_url_chunk
 from tests.test_tekken import get_special_tokens, quick_vocab
@@ -461,6 +468,107 @@ def test_end_to_end_no_default(messages: list[ChatMessage], reasoning_effort: Re
     else:
         # None with no default -> no model settings encoded
         assert "[MODEL_SETTINGS]" not in text
+
+
+@pytest.fixture
+def v15_json_schema_mistral_tokenizer() -> MistralTokenizer:
+    builder = ModelSettingsBuilder(json_schema=JSONSchemaBuilder(accepts_none=False, default=None))
+    return get_v15_mistral_tokenizer(builder)
+
+
+@pytest.mark.parametrize(
+    ("response_format", "expected_text"),
+    [
+        pytest.param(
+            ResponseFormat(type=ResponseFormats.text),
+            "<s>[INST]hi[/INST]",
+            id="text",
+        ),
+        pytest.param(
+            ResponseFormat(type=ResponseFormats.json),
+            '<s>[MODEL_SETTINGS]{"json_schema": {"anyOf": [{"type": "object"}, {"type": "array"}]}}'
+            "[/MODEL_SETTINGS][INST]hi[/INST]",
+            id="json",
+        ),
+        pytest.param(
+            ResponseFormat(
+                type=ResponseFormats.json_schema,
+                json_schema=JsonSchema(name="x", schema={"type": "object"}),
+            ),
+            '<s>[MODEL_SETTINGS]{"json_schema": {"type": "object"}}[/MODEL_SETTINGS][INST]hi[/INST]',
+            id="json_schema",
+        ),
+    ],
+)
+def test_v15_encodes_json_schema_into_model_settings(
+    v15_json_schema_mistral_tokenizer: MistralTokenizer,
+    response_format: ResponseFormat,
+    expected_text: str,
+) -> None:
+    request = ChatCompletionRequest(messages=[UserMessage(content="hi")], response_format=response_format)
+    tokenized = v15_json_schema_mistral_tokenizer.encode_chat_completion(request)
+    assert tokenized.text == expected_text, tokenized.text
+
+
+@pytest.fixture
+def v15_reasoning_and_json_schema_mistral_tokenizer() -> MistralTokenizer:
+    builder = ModelSettingsBuilder(
+        reasoning_effort=EnumBuilder[ReasoningEffort](values=list(ReasoningEffort), accepts_none=True, default=None),
+        json_schema=JSONSchemaBuilder(accepts_none=False, default=None),
+    )
+    return get_v15_mistral_tokenizer(builder)
+
+
+@pytest.mark.parametrize(
+    ("response_format", "reasoning_effort", "expected_text"),
+    [
+        pytest.param(
+            ResponseFormat(type=ResponseFormats.text),
+            ReasoningEffort.high,
+            '<s>[MODEL_SETTINGS]{"reasoning_effort": "high"}[/MODEL_SETTINGS][INST]hi[/INST]',
+            id="text",
+        ),
+        pytest.param(
+            ResponseFormat(type=ResponseFormats.json),
+            ReasoningEffort.high,
+            '<s>[MODEL_SETTINGS]{"json_schema": {"anyOf": [{"type": "object"}, {"type": "array"}]}, '
+            '"reasoning_effort": "high"}[/MODEL_SETTINGS][INST]hi[/INST]',
+            id="json",
+        ),
+        pytest.param(
+            ResponseFormat(
+                type=ResponseFormats.json_schema,
+                json_schema=JsonSchema(
+                    name="x",
+                    schema={
+                        "type": "object",
+                        "properties": {"zeta": {"type": "string"}, "alpha": {"type": "number"}},
+                        "required": ["zeta", "alpha"],
+                    },
+                ),
+            ),
+            ReasoningEffort.none,
+            '<s>[MODEL_SETTINGS]{"json_schema": {"type": "object", "properties": '
+            '{"zeta": {"type": "string"}, "alpha": {"type": "number"}}, '
+            '"required": ["zeta", "alpha"]}, "reasoning_effort": "none"}'
+            "[/MODEL_SETTINGS][INST]hi[/INST]",
+            id="json_schema",
+        ),
+    ],
+)
+def test_v15_encodes_reasoning_effort_and_json_schema_into_model_settings(
+    v15_reasoning_and_json_schema_mistral_tokenizer: MistralTokenizer,
+    response_format: ResponseFormat,
+    reasoning_effort: ReasoningEffort,
+    expected_text: str,
+) -> None:
+    request = ChatCompletionRequest(
+        messages=[UserMessage(content="hi")],
+        response_format=response_format,
+        reasoning_effort=reasoning_effort,
+    )
+    tokenized = v15_reasoning_and_json_schema_mistral_tokenizer.encode_chat_completion(request)
+    assert tokenized.text == expected_text, tokenized.text
 
 
 def test_encode_chat_completion_continue_final_message() -> None:


### PR DESCRIPTION
## Why

Some models constrain their output to a JSON schema. To support this end-to-end, the encoded `ModelSettings` (which is what the tokenizer emits to condition the model) needs to carry the JSON schema derived from a request's `response_format`. This adds first-class `response_format` / JSON-schema support so those models can be driven correctly through mistral-common.

## Summary

- Adds `json_schema` support to `ResponseFormat`:
  - New `ResponseFormats.json_schema` enum value.
  - New `JsonSchema` model (`name`, `description`, `schema` aliased to `custom_schema`, `strict`) with Draft 7 validation.
  - `ResponseFormat.get_schema()` resolves the effective schema: custom schema for `json_schema`, generic object/array `anyOf` for `json_object`, `None` for `text`.
- Adds `json_schema` field to encoded `ModelSettings` (tokenizer >= v15).
- Reworks `ModelSettingsBuilder` / `FieldBuilder` to a typed `InputT -> OutputT` convert-then-validate design so a request field (e.g. `response_format`) can be converted into a different settings field (e.g. `json_schema`), via `_SETTINGS_TO_CONV_FIELDS_MAP`.
- New `JSONSchemaBuilder` converts a `ResponseFormat` to a validated schema dict.
- New `mistral_common/utils/json_utils.py` with `validate_json_schema_by_draft7`.
- `ChatCompletionRequest.to_openai` now serializes `by_alias=True` so `schema` is emitted correctly.

## Reviewer guide

Real logic:
- `src/mistral_common/protocol/instruct/request.py` — new `JsonSchema`, `ResponseFormat.get_schema()`, `ModelSettings.json_schema`, `by_alias` serialization.
- `src/mistral_common/tokens/tokenizers/model_settings_builder.py` — the `FieldBuilder` generic refactor (convert vs validate split) and new `JSONSchemaBuilder` + field mapping. Most careful review here.

New:
- `src/mistral_common/utils/json_utils.py` (+ `utils/__init__.py`) — Draft 7 schema validation helper.

Tests:
- `tests/test_model_settings.py`, `tests/test_request.py`, `tests/test_json_utils.py`, `tests/test_converters.py`, `tests/test_tokenizer_v15.py` — coverage for the new behavior.

## Test plan

- `pytest tests/test_model_settings.py tests/test_request.py tests/test_json_utils.py tests/test_converters.py tests/test_tokenizer_v15.py` — 171 passed.
- `ruff format --check`, `ruff check`, `mypy` on changed sources — all clean.