### PR TITLE
Handle audio data URL MIME variants

### DIFF
--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 def _strip_audio_data_url_prefix(data: str) -> str:
     r"""Remove the optional base64 audio data URL prefix."""
-    if re.match(r"^data:audio/\w+;base64,", data):
+    if re.match(r"^data:audio/[^;,]+(?:;[^;,]*)*;base64,", data):
         return data.split(",", 1)[1]
     return data
 

--- a/src/mistral_common/tokens/tokenizers/audio.py
+++ b/src/mistral_common/tokens/tokenizers/audio.py
@@ -2,7 +2,6 @@ import base64
 import io
 import logging
 import math
-import re
 import warnings
 from dataclasses import dataclass
 from enum import Enum
@@ -19,7 +18,12 @@ from mistral_common.imports import (
     is_soundfile_installed,
     is_soxr_installed,
 )
-from mistral_common.protocol.instruct.chunk import AudioChunk, AudioURLChunk, AudioURLType
+from mistral_common.protocol.instruct.chunk import (
+    AudioChunk,
+    AudioURLChunk,
+    AudioURLType,
+    _strip_audio_data_url_prefix,
+)
 
 if is_soxr_installed():
     import soxr
@@ -114,8 +118,7 @@ class Audio:
         """
         assert_soundfile_installed()
 
-        if re.match(r"^data:audio/\w+;base64,", audio_base64):
-            audio_base64 = audio_base64.split(",")[1]
+        audio_base64 = _strip_audio_data_url_prefix(audio_base64)
 
         try:
             audio_bytes = base64.b64decode(audio_base64)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -144,6 +144,15 @@ def test_audio_base64(prefix: bool) -> None:
             raise ValueError(f"Unknown format {format}")
 
 
+@pytest.mark.parametrize("mime_type", ["audio/x-wav", "audio/vnd.wave", "audio/wav;codec=pcm"])
+def test_audio_from_audio_chunk_accepts_data_url_mime_variants(mime_type: str) -> None:
+    b64 = _make_dummy_base64()
+    audio = Audio.from_audio_chunk(AudioChunk(input_audio=f"data:{mime_type};base64,{b64}"))
+
+    assert audio.sampling_rate == 16000
+    assert audio.format == "wav"
+
+
 @pytest.mark.parametrize(
     "freq, expected_mel",
     [

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -44,6 +44,7 @@ from mistral_common.protocol.instruct.chunk import (
     ImageURLChunk,
     TextChunk,
     ThinkChunk,
+    _strip_audio_data_url_prefix,
 )
 from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
@@ -165,6 +166,30 @@ def test_convert_input_audio_chunk() -> None:
 
     typeddict_openai = OpenAIInputAudioChunk(**openai_dict)  # type: ignore[typeddict-item]
     assert AudioChunk.from_openai(typeddict_openai) == chunk
+
+
+@pytest.mark.parametrize("mime_type", ["audio/x-wav", "audio/vnd.wave", "audio/wav;codec=pcm"])
+def test_convert_input_audio_chunk_with_data_url_mime_variants(mime_type: str) -> None:
+    input_audio = DUMMY_AUDIO_CHUNK.input_audio
+    assert isinstance(input_audio, str)
+    chunk = AudioChunk(input_audio=f"data:{mime_type};base64,{input_audio}")
+
+    openai_dict = chunk.to_openai()
+
+    assert openai_dict["input_audio"]["data"] == input_audio
+    assert openai_dict["input_audio"]["format"] == "wav"
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        f"data:audio/wav{';' * 30}x",  # repeated parameter separators, no `;base64,` terminator
+        "data:audio/wav;codec=pcm",  # media-type parameter but no `;base64,` terminator
+        "cmF3IGJhc2U2NCBwYXlsb2Fk",  # raw base64 without any data URL prefix
+    ],
+)
+def test_audio_data_url_prefix_left_untouched_without_base64_terminator(malformed: str) -> None:
+    assert _strip_audio_data_url_prefix(malformed) == malformed
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Audio data URL prefix stripping only matched word-only MIME subtypes. Valid data URLs such as `data:audio/x-wav;base64,...`, `data:audio/vnd.wave;base64,...`, and `data:audio/wav;codec=pcm;base64,...` were left untouched.

That made audio parsing try to base64-decode the full data URL rather than the payload, so valid audio bytes failed with a base64 or audio-format error. This affected both `AudioChunk.to_openai()` and tokenizer/audio parsing through `Audio.from_base64()` / `Audio.from_audio_chunk()`. The same bytes worked when the MIME subtype was simply `audio/wav`.

This broadens the audio data URL prefix match to allow MIME subtype punctuation and media-type parameters before `;base64,`, and makes `Audio.from_base64()` reuse the same helper as `AudioChunk.to_openai()`. The parameter match avoids consuming semicolon separators, so malformed inputs with repeated semicolons do not trigger pathological backtracking. The payload and detected format are unchanged.

## Testing

- `pytest tests/test_converters.py tests/test_audio.py -q`
- `ruff check src/mistral_common/protocol/instruct/chunk.py src/mistral_common/tokens/tokenizers/audio.py tests/test_converters.py tests/test_audio.py`
- `ruff format src/mistral_common/protocol/instruct/chunk.py src/mistral_common/tokens/tokenizers/audio.py tests/test_converters.py tests/test_audio.py --check`
- `mypy src tests scripts`
- `pytest tests/ --ignore=tests/integrations -q`
- `pytest --doctest-modules ./src -q`
- `mkdocs build --strict`
- `pytest tests/integrations/ -q`

No related issue. This follows the same audio conversion surface as #245.
