### PR TITLE
Fix tool-call validation skipping the first message

### DIFF
--- a/src/mistral_common/protocol/instruct/validator.py
+++ b/src/mistral_common/protocol/instruct/validator.py
@@ -277,13 +277,8 @@ class MistralRequestValidator(Generic[UserMessageType, AssistantMessageType, Too
         - That the number of tool calls and tool messages are the same
         - That the tool calls are followed by tool messages
         """
-        prev_role = None
         expected_tool_messages = 0
         for message in messages:
-            if prev_role is None:
-                prev_role = message.role
-                continue
-
             if message.role == Roles.tool:
                 expected_tool_messages -= 1
             elif message.role == Roles.assistant:
@@ -295,8 +290,6 @@ class MistralRequestValidator(Generic[UserMessageType, AssistantMessageType, Too
                 if message.tool_calls is not None:
                     # Validate that the number of function calls and responses are the same
                     expected_tool_messages = len(message.tool_calls)
-
-            prev_role = message.role
 
         if expected_tool_messages != 0 and self._mode == ValidationMode.serving:
             raise InvalidMessageStructureException("Not the same number of function calls and responses")
@@ -531,14 +524,9 @@ class MistralRequestValidatorV13(MistralRequestValidatorV5):
         - That the tool calls are followed by tool messages
         - That tool calls have distinct ids for a given assistant message
         """
-        prev_role = None
         expected_tool_ids: set[str] = set()
         observed_tool_ids: set[str] = set()
         for message in messages:
-            if prev_role is None:
-                prev_role = message.role
-                continue
-
             if message.role == Roles.tool:
                 tool_call_id = message.tool_call_id
                 if tool_call_id in observed_tool_ids:
@@ -563,8 +551,6 @@ class MistralRequestValidatorV13(MistralRequestValidatorV5):
                                 f"Duplicate tool call id {tool_call.id} in assistant message"
                             )
                         expected_tool_ids.add(tool_call.id)
-
-            prev_role = message.role
 
         if len(expected_tool_ids) != len(observed_tool_ids) and self._mode == ValidationMode.serving:
             raise InvalidMessageStructureException("Not the same number of function calls and responses")

--- a/tests/validation/test_chat_validation.py
+++ b/tests/validation/test_chat_validation.py
@@ -297,6 +297,23 @@ class TestChatValidation:
             continue_final_message=False,
         )
 
+    def test_tool_calls_first_message_assistant_OK(self, validator: MistralRequestValidator) -> None:
+        # A conversation that begins with an assistant tool-call turn (no leading user or
+        # system message) is structurally valid: the tool call is answered by the tool
+        # message that follows. The tool-call/tool-response matching used to skip the very
+        # first message, so these tool calls went uncounted and the responses were wrongly
+        # rejected as unbalanced.
+        validator.validate_messages(
+            messages=[
+                AssistantMessage(
+                    tool_calls=[ToolCall(id="123456789", function=FunctionCall(name="foo", arguments="{}"))]
+                ),
+                ToolMessage(name="foo", content="bar", tool_call_id="123456789"),
+                UserMessage(content="thanks"),
+            ],
+            continue_final_message=False,
+        )
+
     def test_not_enough_tool_messages(self, validator: MistralRequestValidator) -> None:
         with pytest.raises(
             InvalidMessageStructureException, match=r"Not the same number of function calls and responses"


### PR DESCRIPTION
No linked issue — found by reading the code.

## The bug

`_validate_tool_calls_followed_by_tool_messages` skips the first message of the conversation:

```python
prev_role = None
...
for message in messages:
    if prev_role is None:
        prev_role = message.role
        continue
    ...
    prev_role = message.role
```

`prev_role` is never read anywhere except this `is None` check, so its only effect is to `continue` past `messages[0]`. When a conversation **begins with an assistant message that carries tool calls**, those tool-call ids are never registered, and the matching tool responses are then rejected as unbalanced.

## Reproducer

A valid fine-tuning example — an assistant tool-call turn, its result, then the final answer — is rejected:

```python
from mistral_common.protocol.instruct.validator import (
    MistralRequestValidator, MistralRequestValidatorV13, ValidationMode,
)
from mistral_common.protocol.instruct.messages import UserMessage, AssistantMessage, ToolMessage
from mistral_common.protocol.instruct.tool_calls import ToolCall, FunctionCall

conv = [
    AssistantMessage(tool_calls=[ToolCall(id="abcdefghi", function=FunctionCall(name="get", arguments={}))]),
    ToolMessage(tool_call_id="abcdefghi", content="42"),
    AssistantMessage(content="The answer is 42."),
]

MistralRequestValidatorV13(mode=ValidationMode.finetuning).validate_messages(conv, False)
# InvalidMessageStructureException: Unexpected tool call id abcdefghi in tool results

MistralRequestValidator(mode=ValidationMode.finetuning).validate_messages(conv, False)
# InvalidMessageStructureException: Not the same number of function calls and responses
```

`abcdefghi` is exactly the id of the tool call in the preceding assistant message. **Prepending a single `UserMessage` — the only change — makes the identical tool call/response pair validate cleanly**, which confirms the failure comes solely from skipping `messages[0]`.

## Fix

Iterate over every message so the first one is validated like the rest. This is a no-op for conversations that start with a user or system message (those roles are ignored by the loop body), and it correctly counts a leading assistant tool-call turn. The same defect and one-line fix apply to the base validator (v1/v2/v3/v7) and the v11/v13/v15 override, so both are fixed.

## Testing

Added `test_tool_calls_first_message_assistant_OK`, parametrized over the base and v13 validators, which validates a conversation that begins with an assistant tool-call turn. It fails before the change (both validators raise) and passes after. Existing balance-detection tests (`test_not_enough_tool_messages`, `test_too_many_tool_messages`, `test_right_number_results_invalid_id`, …) still pass, and a genuinely unbalanced conversation or a leading bare tool message is still correctly rejected.