### PR TITLE
Accept OpenAI Responses input content types

### DIFF
--- a/src/mistral_common/protocol/instruct/chunk.py
+++ b/src/mistral_common/protocol/instruct/chunk.py
@@ -456,11 +456,32 @@ UserContentChunk = Annotated[
 ]
 
 
+# The OpenAI Responses API spells text/image content types differently from the
+# Chat Completions API that ``ChunkTypes`` mirrors. Map the Responses spellings
+# onto their Chat Completions equivalents so structured Responses input/output
+# is accepted instead of raising e.g. "'input_text' is not a valid ChunkTypes".
+# (``input_image`` carries ``image_url`` as a bare string, which
+# ``ImageURLChunk`` already accepts.)
+_RESPONSES_CONTENT_TYPE_ALIASES: dict[str, ChunkTypes] = {
+    "input_text": ChunkTypes.text,
+    "output_text": ChunkTypes.text,
+    "input_image": ChunkTypes.image_url,
+}
+
+
 def _convert_openai_content_chunks(openai_content_chunks: dict[str, Any]) -> ContentChunk:
     content_type_str = openai_content_chunks.get("type")
 
     if content_type_str is None:
         raise ValueError("Content chunk must have a type field.")
+
+    # Normalize OpenAI Responses content types to the Chat Completions spellings.
+    # The discriminated chunk models require the canonical ``type``, so rewrite
+    # the field too.
+    aliased_type = _RESPONSES_CONTENT_TYPE_ALIASES.get(content_type_str)
+    if aliased_type is not None:
+        openai_content_chunks = {**openai_content_chunks, "type": aliased_type.value}
+        content_type_str = aliased_type.value
 
     content_type = ChunkTypes(content_type_str)
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -37,11 +37,13 @@ from mistral_common.protocol.instruct.chunk import (
     AudioChunk,
     AudioURL,
     AudioURLChunk,
+    ChunkTypes,
     ImageChunk,
     ImageURL,
     ImageURLChunk,
     TextChunk,
     ThinkChunk,
+    _convert_openai_content_chunks,
 )
 from mistral_common.protocol.instruct.messages import (
     AssistantMessage,
@@ -213,6 +215,28 @@ def test_convert_image_url_chunk(openai_image_url_chunk: dict, image_url_chunk: 
         image_url_chunk.image_url = ImageURL(url=image_url_chunk.image_url, detail=None)
 
     assert ImageURLChunk.from_openai(typeddict_openai) == image_url_chunk
+
+
+@pytest.mark.parametrize("content_type", ["input_text", "output_text"])
+def test_convert_responses_text_chunk(content_type: str) -> None:
+    # The OpenAI Responses API uses "input_text"/"output_text" for text content
+    # (Chat Completions uses "text"); both must parse to a TextChunk rather than
+    # raising "'input_text' is not a valid ChunkTypes".
+    chunk = _convert_openai_content_chunks({"type": content_type, "text": "Hello"})
+    assert isinstance(chunk, TextChunk)
+    assert chunk.type == ChunkTypes.text
+    assert chunk.text == "Hello"
+
+
+def test_convert_responses_image_chunk() -> None:
+    # The OpenAI Responses API uses "input_image" (with image_url as a bare
+    # string) for image content; it must parse to an ImageURLChunk rather than
+    # raising "'input_image' is not a valid ChunkTypes".
+    url = "data:image/png;base64,iVBORw0"
+    chunk = _convert_openai_content_chunks({"type": "input_image", "image_url": url, "detail": "auto"})
+    assert isinstance(chunk, ImageURLChunk)
+    assert chunk.type == ChunkTypes.image_url
+    assert chunk.get_url() == url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary

Make `from_openai` (via `_convert_openai_content_chunks`) accept the OpenAI **Responses API** input content-type spellings and map them onto their Chat Completions equivalents:

- `input_text` / `output_text` → `ChunkTypes.text`
- `input_image` → `ChunkTypes.image_url` (Responses carries `image_url` as a bare string, which `ImageURLChunk` already accepts)

The change is small and additive — it normalizes the discriminator `type` before validation, so structured Responses input is tokenized instead of raising `ValueError: 'input_text' is not a valid ChunkTypes`. No new request type is introduced; existing Chat Completions behaviour is unchanged. Unit tests are included.

> Recreates #242, which was closed due to inactivity (apologies, I missed the question in the comments section). The branch has been resynced to the latest `main` and has no conflicts.

### Why the Responses API is required here (not Chat Completions)

The earlier review asked why we don't just use `ChatCompletionRequest`. The reason is **reasoning support**, and it is grounded in the official OpenAI specification rather than a preference:

- The upstream application consumes model **reasoning output**, and it uses an AI harness that implements **the official OpenAI API specification** (no vendor-specific extensions).
- In the official spec, **reasoning output is exclusive to the Responses API**. A Responses result contains a first-class `reasoning` output item (with `summary[]` / `content[]`), and reasoning is requested via `reasoning.effort`.
- The **Chat Completions** specification has **no field for reasoning content** in the response. The only reasoning-related value it officially returns is a *token count* (`usage.completion_tokens_details.reasoning_tokens`) — the reasoning text itself is never returned. (The `reasoning` / `reasoning_content` fields some servers add to Chat Completions messages are **non-standard vendor extensions**, which a spec-only harness does not consume.)

Because the harness only speaks the official spec, it can obtain reasoning **only** over the Responses API. When those Responses-shaped requests are served by a Mistral model whose tokenization goes through `mistral_common` (e.g. vLLM's `--tokenizer-mode mistral`), the request body uses `input_text` / `output_text` / `input_image`, and `mistral_common` currently rejects it with `400 'input_text' is not a valid ChunkTypes` — even though the underlying content is exactly what the Chat Completions chunks already represent.

This PR removes that mismatch at the parsing boundary, so Responses input can be tokenized without every caller having to pre-rewrite content types.

### Supporting references (official OpenAI docs)

- **Reasoning guide** — reasoning is accessed and returned through the Responses API; "Reasoning models work better with the Responses API": https://platform.openai.com/docs/guides/reasoning
- **Responses API — object** (reasoning output item with `summary` / `content`): https://platform.openai.com/docs/api-reference/responses/object
- **Responses API — create** (`reasoning.effort` request field; `input_text` / `input_image` input parts): https://platform.openai.com/docs/api-reference/responses/create
- **Chat Completions — object** (response `message` has no reasoning field; reasoning appears only as a `reasoning_tokens` count under `usage`): https://platform.openai.com/docs/api-reference/chat/object

### Scope / compatibility

- Additive and backward-compatible: canonical Chat Completions types are untouched; only the three Responses spellings are newly accepted and mapped to existing chunk types.
- No new public API, no new dependency.
- Tests cover `input_text`, `output_text`, and `input_image`.
