### PR TITLE
Add MLX (Apple Silicon) inference example to the docs

### DIFF
--- a/docs/examples/inference.md
+++ b/docs/examples/inference.md
@@ -9,6 +9,7 @@ We have a few examples of how to use the library with our models:
   - [Audio](#audio)
 - [Fill-in-the-middle (FIM) Completion](#fim)
 - [Audio Transcription](#audio-transcription)
+- [MLX (Apple Silicon)](#mlx-apple-silicon)
 
 ## Chat Completion
 
@@ -227,4 +228,32 @@ print(tokenized.text)
 ```
 
 
+## MLX (Apple Silicon)
 
+To run a model locally on Apple Silicon, install [mlx-lm](https://github.com/ml-explore/mlx-lm) (`pip install mlx-lm`) and drive the model at token level with the tokens from `encode_chat_completion`:
+
+```python
+import mlx.core as mx
+from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from mlx_lm import load
+from mlx_lm.generate import generate_step
+
+repo_id = "mistralai/Ministral-3-3B-Instruct-2512"
+tokenizer = MistralTokenizer.from_hf_hub(repo_id)
+model, _ = load("mlx-community/Ministral-3-3B-Instruct-2512-4bit")
+eos_id = tokenizer.instruct_tokenizer.tokenizer.eos_id
+
+request = ChatCompletionRequest(messages=[UserMessage(content="What is the capital of France?")])
+tokenized = tokenizer.encode_chat_completion(request)
+
+generated = []
+for token, _ in generate_step(mx.array(tokenized.tokens), model, max_tokens=128):
+    if int(token) == eos_id:
+        break
+    generated.append(int(token))
+
+# decode the generated tokens with the same tokenizer
+print(tokenizer.decode(generated))
+```


### PR DESCRIPTION
Adds an MLX (Apple Silicon) inference example to `docs/examples/inference.md`: encode with mistral-common, generate at token level with mlx-lm, decode with the same tokenizer. No nav change.

### Context
With transformers v5, `AutoTokenizer` loads Mistral models that ship a `tekken.json` as `MistralCommonBackend`. Wrappers that assume fast-tokenizer attributes currently break on this (ml-explore/mlx-lm#1576), and there is no guidance on the mistral-common side for MLX users. The token-level pattern documented here is the path that works today and keeps prompt construction on the official tokenizer.

Example validated verbatim with mistral-common 1.11.5, mlx-lm 0.31.3, and `mlx-community/Ministral-3-3B-Instruct-2512-4bit`.
