### PR TITLE
Restore deprecated reasoning parameter in select_jinja_template

### DIFF
--- a/src/mistral_common/guidance/grammar_factory.py
+++ b/src/mistral_common/guidance/grammar_factory.py
@@ -4,6 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable
 
+from mistral_common.deprecation import warn_once
 from mistral_common.guidance.tokenizer import from_mistral_tokenizer
 from mistral_common.imports import (
     assert_jinja2_installed,
@@ -203,7 +204,7 @@ class GrammarFactory:
     def llg_tokenizer(self) -> "llg.LLTokenizer":
         return self._llg_tokenizer
 
-    def select_jinja_template(self) -> str:
+    def select_jinja_template(self, reasoning: bool | None = None) -> str:
         r"""Selects and returns the appropriate jinja template content.
 
         Selection derives from the tokenizer version and presence of think tokens:
@@ -211,9 +212,22 @@ class GrammarFactory:
           `[THINK]` and `[/THINK]` special tokens are registered.
         - Returns the `base` template in all other cases.
 
+        Args:
+            reasoning: Deprecated and ignored. Template selection is determined solely
+                by the tokenizer version and presence of think tokens. Will be removed
+                in 1.13.0.
+
         Returns:
             The jinja template content as a string.
         """
+        if reasoning is not None:
+            warn_once(
+                "select_jinja_template.reasoning",
+                "The reasoning parameter of select_jinja_template is deprecated, "
+                "no longer has any effect, and will be removed in 1.13.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         has_begin_think = SpecialTokens.begin_think.value in self._special_token_map
         has_end_think = SpecialTokens.end_think.value in self._special_token_map
         assert has_begin_think == has_end_think, (

--- a/tests/guidance/test_guidance.py
+++ b/tests/guidance/test_guidance.py
@@ -1,3 +1,4 @@
+import warnings
 from pathlib import Path
 from typing import Any, Literal
 
@@ -5,6 +6,7 @@ import llguidance as llg
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+import mistral_common.deprecation
 from mistral_common.guidance.grammar_factory import JINJA_PATHS, GrammarFactory, _convert_tool_calls, _GrammarVariant
 from mistral_common.protocol.instruct.chunk import TextChunk, ThinkChunk
 from mistral_common.protocol.instruct.messages import AssistantMessage
@@ -1510,10 +1512,25 @@ class TestSelectJinjaTemplate:
         with pytest.raises(AssertionError, match=r"both \[THINK\] and \[/THINK\] should be defined or none of them\."):
             factory.select_jinja_template()
 
-    def test_select_jinja_template_rejects_reasoning_kwarg(self, v11_tekken: MistralTokenizer) -> None:
+    def test_select_jinja_template_reasoning_accepted_and_ignored(self, v11_tekken: MistralTokenizer) -> None:
         factory = GrammarFactory(v11_tekken)
-        with pytest.raises(TypeError, match="reasoning"):
-            factory.select_jinja_template(**{"reasoning": True})
+        expected = factory.select_jinja_template()
+        mistral_common.deprecation._warned_keys.discard("select_jinja_template.reasoning")
+        assert factory.select_jinja_template(reasoning=True) == expected
+        mistral_common.deprecation._warned_keys.discard("select_jinja_template.reasoning")
+        assert factory.select_jinja_template(reasoning=False) == expected
+
+    def test_select_jinja_template_reasoning_true_warns_deprecation(self, v11_tekken: MistralTokenizer) -> None:
+        factory = GrammarFactory(v11_tekken)
+        mistral_common.deprecation._warned_keys.discard("select_jinja_template.reasoning")
+        with pytest.warns(DeprecationWarning):
+            factory.select_jinja_template(reasoning=True)
+
+    def test_select_jinja_template_reasoning_none_no_warn(self, v11_tekken: MistralTokenizer) -> None:
+        factory = GrammarFactory(v11_tekken)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            factory.select_jinja_template()
 
     @pytest.mark.parametrize(
         ("fixture_name", "content"),


### PR DESCRIPTION
## What

Re-adds a backward-compatible `reasoning: bool | None = None` parameter to `GrammarFactory.select_jinja_template`.

## Why

vLLM calls `factory.select_jinja_template(reasoning=...)`. The parameter was removed in #260, breaking that call. This restores it for backward compatibility.

## Behavior

- **Accepted but ignored**: template selection is unchanged (tokenizer version + presence of think tokens).
- **Deprecated**: passing a non-`None` value emits a one-shot `DeprecationWarning` (key `select_jinja_template.reasoning`) stating it no longer has any effect and will be removed in 1.13.0.
- Default (`None`, or no argument) does not warn.

## Tests

Replaced the old TypeError-rejection test with three tests covering: accepted-and-ignored, warns on `reasoning=True`, and no warning on default.

`tests/guidance/test_guidance.py`: 328 passed. ruff + mypy clean.