### PR TITLE
Fix v15 tool-result rendering when thinking is enabled

### DIFF
--- a/src/mistral_common/integrations/chat_templates/template_generator.py
+++ b/src/mistral_common/integrations/chat_templates/template_generator.py
@@ -1522,6 +1522,8 @@ def _generate_tool_message_handling(config: TemplateConfig) -> str:
                 if config.audio_support:
                     desc_parts.append("audio")
                 tool_rc_args += f", supported_types_desc='{_join_types_desc(desc_parts)}'"
+            if config.any_thinking_support:
+                tool_rc_args += ", support_thinking=false"
             if config.image_support:
                 tool_rc_args += ", support_images=true"
             if config.audio_support:

--- a/tests/data/chat_templates/v15_image_think.jinja
+++ b/tests/data/chat_templates/v15_image_think.jinja
@@ -218,7 +218,7 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
+        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_thinking=false, support_images=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}

--- a/tests/data/chat_templates/v15_think.jinja
+++ b/tests/data/chat_templates/v15_think.jinja
@@ -210,7 +210,7 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- render_content(message['content'], 'tool message contents', support_thinking=false) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}

--- a/tests/integrations/chat_templates/unit/test_v15.py
+++ b/tests/integrations/chat_templates/unit/test_v15.py
@@ -145,6 +145,43 @@ class TestV15ModelSettings:
         assert "[AVAILABLE_TOOLS]" in output
         assert "get_weather" in output
 
+    @pytest.mark.parametrize("image_support", [False, True])
+    def test_v15_tool_result_with_thinking_support(self, image_support: bool) -> None:
+        template = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v15,
+            image_support=image_support,
+            audio_support=False,
+            thinking_support=True,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+
+        messages = [
+            {"role": "user", "content": "Use the tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "test12345",
+                        "type": "function",
+                        "function": {"name": "preflight_echo", "arguments": '{"value":"ok"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "test12345",
+                "name": "preflight_echo",
+                "content": "ok",
+            },
+        ]
+
+        output = render_template(template, messages, reasoning_effort="high")
+        assert "[TOOL_RESULTS]ok[/TOOL_RESULTS]" in output
+
     @pytest.mark.parametrize(
         ("has_system", "has_tools", "reasoning_effort"),
         [


### PR DESCRIPTION
## Summary

- pass `support_thinking=false` when rendering simple v15 tool results if the generated `render_content` macro declares the thinking parameter
- update the v15 thinking golden templates
- add regression coverage for text-only and image-capable v15 templates

## Problem

When thinking support is enabled, `render_content` declares `support_thinking` as a required macro parameter. The simple tool-result branch did not pass it:

```jinja
{{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
```

Strict Jinja rendering therefore accepts the first assistant tool call but fails as soon as the client appends a `role: tool` result:

```text
Not enough arguments provided to macro 'render_content'
```

The official Leanstral 1.5 template currently contains the affected generated call:
https://huggingface.co/mistralai/Leanstral-1.5-119B-A6B/blob/81592da95d94ab0439bfce16df1d55b402e598b6/chat_template.jinja#L221

This change renders tool content with `support_thinking=false`, matching the intended tool-result content types and the explicit handling used by other message-role branches.

## Reproduction

A minimal failing conversation is:

1. user message
2. assistant message with native `tool_calls`
3. client-appended `role: tool` result

The new test renders that sequence for v15 with thinking enabled, both with and without image support. Before this patch, both cases fail at Jinja macro evaluation; after it, they render `[TOOL_RESULTS]ok[/TOOL_RESULTS]`.

An independent llama.cpp deployment using the generated fixed template was also exercised end to end:

- native structured tool calls: 10/10
- textual pseudo-calls: 0/10
- direct tool-result continuations: 3/3 HTTP 200
- routed tool-result continuations: 3/3 HTTP 200
- stock Mistral Vibe completed multi-turn tool execution

Sanitized reproduction and evidence:
https://github.com/Th0rgal/mistral-vibe-leanstral-repro/blob/main/COMPARISON.md

## Validation

- `pytest tests/integrations/chat_templates/unit/test_v15.py -q` — 27 passed
- `pytest tests/integrations/chat_templates/unit -q` — 180 passed
- Ruff check and format check — passed
- mypy on the changed Python files — passed
- llama.cpp `test-chat-template --with-tools` on the generated fixed template — passed
