### PR TITLE
Render v15 tool-result thinking correctly and pass all render_content args explicitly

### DIFF
--- a/src/mistral_common/integrations/chat_templates/template_generator.py
+++ b/src/mistral_common/integrations/chat_templates/template_generator.py
@@ -559,6 +559,50 @@ def _generate_macros(config: TemplateConfig) -> str:
     return "\n".join(lines)
 
 
+def _render_content_call(
+    config: TemplateConfig,
+    content_expr: str,
+    context_name: str,
+    *,
+    supported_types_desc: str,
+    support_thinking: bool,
+    support_images: bool,
+    support_audio: bool,
+    initial_prev_img: str = "false",
+) -> str:
+    r"""Build a `render_content(...)` call that passes every macro argument the config declares.
+
+    Every parameter the `render_content` macro declares for `config` is emitted explicitly so
+    call sites never rely on Jinja's implicit `undefined`. Arguments are emitted in the same order
+    the macro declares them.
+
+    Args:
+        config: The template configuration.
+        content_expr: Jinja expression for the content argument.
+        context_name: Human-readable context name used in error messages.
+        supported_types_desc: Description of supported chunk types (used only when the macro declares it).
+        support_thinking: Whether thinking chunks are rendered for this call.
+        support_images: Whether image chunks are rendered for this call.
+        support_audio: Whether audio chunks are rendered for this call.
+        initial_prev_img: Jinja expression for `initial_prev_img` (used only for SPM image tracking).
+
+    Returns:
+        The `render_content(...)` call string (without surrounding `{{- ... -}}`).
+    """
+    args = [f"content={content_expr}", f"context_name='{context_name}'"]
+    if config.any_thinking_support or config.image_support or config.audio_support:
+        args.append(f"supported_types_desc='{supported_types_desc}'")
+    if config.any_thinking_support:
+        args.append(f"support_thinking={'true' if support_thinking else 'false'}")
+    if config.image_support:
+        args.append(f"support_images={'true' if support_images else 'false'}")
+    if config.audio_support:
+        args.append(f"support_audio={'true' if support_audio else 'false'}")
+    if config.uses_spm_prev_img_tracking:
+        args.append(f"initial_prev_img={initial_prev_img}")
+    return "render_content(" + ", ".join(args) + ")"
+
+
 def _emit_int_float_parsing(indent: str) -> list[str]:
     r"""Generate the Jinja2 block for parsing `message['content']` as int or float.
 
@@ -891,25 +935,26 @@ def _generate_system_message_handling(config: TemplateConfig) -> str:
     else:
         lines.append("        {{- '" + _BEGIN_SYSTEM + "' -}}")
 
-    has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
-    rc_args = "message['content'], 'system message contents'"
-    if has_extra_types:
-        if config.system_supports_thinking:
-            rc_args += ", supported_types_desc='text and thinking'"
-        elif config.system_supports_audio:
-            rc_args += ", supported_types_desc='text and audio'"
-        else:
-            rc_args += ", supported_types_desc='text'"
-    if config.any_thinking_support:
-        if config.system_supports_thinking:
-            rc_args += ", support_thinking=true"
-        else:
-            rc_args += ", support_thinking=false"
-    if config.image_support:
-        rc_args += ", support_images=false"
-    if config.audio_support:
-        rc_args += f", support_audio={'true' if config.system_supports_audio else 'false'}"
-    lines.append("        {{- render_content(" + rc_args + ") -}}")
+    if config.system_supports_thinking:
+        system_types_desc = "text and thinking"
+    elif config.system_supports_audio:
+        system_types_desc = "text and audio"
+    else:
+        system_types_desc = "text"
+    lines.append(
+        "        {{- "
+        + _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="system message contents",
+            supported_types_desc=system_types_desc,
+            support_thinking=config.system_supports_thinking,
+            support_images=False,
+            support_audio=config.system_supports_audio,
+            initial_prev_img="false",
+        )
+        + " -}}"
+    )
 
     lines.append("        {{- '" + _END_SYSTEM + "' -}}")
 
@@ -1065,7 +1110,12 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
         inst_open = _BEGIN_INST
         inst_close = _END_INST
 
-    has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
+    if config.image_support:
+        user_types_desc = "text, image and image_url"
+    elif config.audio_support:
+        user_types_desc = "text, input_audio and audio_url"
+    else:
+        user_types_desc = "text"
 
     if config.uses_system_prompt_tokens:
         # =================================================================
@@ -1116,27 +1166,25 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
         else:
             lines.append("        {{- '" + _BEGIN_INST + "' -}}")
 
-        # --- Build unified render_content args ---
+        # --- Build unified render_content call ---
         content_var = "user_content" if needs_content_prep else "message['content']"
-        rc_args = content_var + ", 'user message content'"
-        if has_extra_types:
-            if config.image_support:
-                rc_args += ", supported_types_desc='text, image and image_url'"
-            elif config.audio_support:
-                rc_args += ", supported_types_desc='text, input_audio and audio_url'"
-            else:
-                rc_args += ", supported_types_desc='text'"
-        if config.any_thinking_support:
-            rc_args += ", support_thinking=false"
-        if config.image_support:
-            rc_args += ", support_images=true"
-        if config.audio_support:
-            rc_args += ", support_audio=true"
-        if config.uses_spm_prev_img_tracking:
-            rc_args += ", initial_prev_img=not added_sp"
+        user_initial_prev_img = "not added_sp" if config.uses_spm_prev_img_tracking else "false"
 
         # --- Emit render_content + [/INST] (once each) ---
-        lines.append("        {{- render_content(" + rc_args + ") -}}")
+        lines.append(
+            "        {{- "
+            + _render_content_call(
+                config=config,
+                content_expr=content_var,
+                context_name="user message content",
+                supported_types_desc=user_types_desc,
+                support_thinking=False,
+                support_images=True,
+                support_audio=True,
+                initial_prev_img=user_initial_prev_img,
+            )
+            + " -}}"
+        )
         lines.append("        {{- '" + inst_close + "' }}")
 
     else:
@@ -1156,7 +1204,20 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
             lines.append("")
             lines.append("")
             lines.append("        {%- if message['content'] is string %}")
-            lines.append("            {{- render_content(message['content'], 'user message content') -}}")
+            lines.append(
+                "            {{- "
+                + _render_content_call(
+                    config=config,
+                    content_expr="message['content']",
+                    context_name="user message content",
+                    supported_types_desc=user_types_desc,
+                    support_thinking=False,
+                    support_images=True,
+                    support_audio=True,
+                    initial_prev_img="not added_sp",
+                )
+                + " -}}"
+            )
             lines.append("        {%- elif message['content'] | length > 0 %}")
         else:
             lines.append(f"        {{{{- '{inst_open}' }}}}")
@@ -1167,7 +1228,20 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
             lines.append("            {{- system_message + '\\n\\n' }}")
             lines.append("        {%- endif %}")
             lines.append("        {%- if message['content'] is string %}")
-            lines.append("            {{- render_content(message['content'], 'user message content') -}}")
+            lines.append(
+                "            {{- "
+                + _render_content_call(
+                    config=config,
+                    content_expr="message['content']",
+                    context_name="user message content",
+                    supported_types_desc=user_types_desc,
+                    support_thinking=False,
+                    support_images=True,
+                    support_audio=True,
+                    initial_prev_img="false",
+                )
+                + " -}}"
+            )
             lines.append("        {%- elif message['content'] | length > 0 %}")
 
         # Shared: image sorting + render_content for list case (pre-v7 only)
@@ -1184,23 +1258,21 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
         else:
             block_var = "message['content']"
 
-        rc_call_args = block_var + ", 'user message content'"
-        if has_extra_types:
-            if config.image_support:
-                rc_call_args += ", supported_types_desc='text, image and image_url'"
-            elif config.audio_support:
-                rc_call_args += ", supported_types_desc='text, input_audio and audio_url'"
-            else:
-                rc_call_args += ", supported_types_desc='text'"
-        if config.any_thinking_support:
-            rc_call_args += ", support_thinking=false"
-        if config.image_support:
-            rc_call_args += ", support_images=true"
-        if config.audio_support:
-            rc_call_args += ", support_audio=true"
-        if config.uses_spm_prev_img_tracking:
-            rc_call_args += ", initial_prev_img=not added_sp"
-        lines.append("            {{- render_content(" + rc_call_args + ") -}}")
+        list_initial_prev_img = "not added_sp" if config.uses_spm_prev_img_tracking else "false"
+        lines.append(
+            "            {{- "
+            + _render_content_call(
+                config=config,
+                content_expr=block_var,
+                context_name="user message content",
+                supported_types_desc=user_types_desc,
+                support_thinking=False,
+                support_images=True,
+                support_audio=True,
+                initial_prev_img=list_initial_prev_img,
+            )
+            + " -}}"
+        )
 
         # Closing
         lines.append("        {%- else %}")
@@ -1258,19 +1330,7 @@ def _generate_assistant_message_handling(config: TemplateConfig) -> str:
         lines.append("        {%- endif %}")
         lines.append("")
 
-    has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
-    rc_call_args = "message['content'], 'assistant message contents'"
-    if has_extra_types:
-        desc_parts = ["text"]
-        if config.any_thinking_support:
-            desc_parts.append("thinking")
-        rc_call_args += f", supported_types_desc='{_join_types_desc(desc_parts)}'"
-    if config.any_thinking_support:
-        rc_call_args += ", support_thinking=true"
-    if config.image_support:
-        rc_call_args += ", support_images=false"
-    if config.audio_support:
-        rc_call_args += ", support_audio=false"
+    asst_types_desc = _join_types_desc(["text"] + (["thinking"] if config.any_thinking_support else []))
 
     lines.append("        {%- if message['content'] %}")
 
@@ -1280,7 +1340,20 @@ def _generate_assistant_message_handling(config: TemplateConfig) -> str:
         lines.append("                {%- set ns.add_space=false %}")
         lines.append("            {%- endif %}")
 
-    lines.append("            {{- render_content(" + rc_call_args + ") -}}")
+    lines.append(
+        "            {{- "
+        + _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="assistant message contents",
+            supported_types_desc=asst_types_desc,
+            support_thinking=True,
+            support_images=False,
+            support_audio=False,
+            initial_prev_img="false",
+        )
+        + " -}}"
+    )
 
     if config.uses_v2_tool_format:
         lines.append("            {{- " + config.eos_expr + " }}")
@@ -1514,20 +1587,28 @@ def _generate_tool_message_handling(config: TemplateConfig) -> str:
             )
     elif config.uses_simple_tool_results:
         if config.tool_supports_multimodal:
-            tool_rc_args = "message['content'], 'tool message contents'"
-            if config.image_support or config.audio_support:
-                desc_parts = ["text"]
-                if config.image_support:
-                    desc_parts.append("image")
-                if config.audio_support:
-                    desc_parts.append("audio")
-                tool_rc_args += f", supported_types_desc='{_join_types_desc(desc_parts)}'"
+            tool_desc_parts = ["text"]
+            if config.any_thinking_support:
+                tool_desc_parts.append("thinking")
             if config.image_support:
-                tool_rc_args += ", support_images=true"
+                tool_desc_parts.append("image")
             if config.audio_support:
-                tool_rc_args += ", support_audio=true"
+                tool_desc_parts.append("audio")
             lines.append("        {{- '" + _BEGIN_TOOL_RESULTS + "' -}}")
-            lines.append("        {{- render_content(" + tool_rc_args + ") -}}")
+            lines.append(
+                "        {{- "
+                + _render_content_call(
+                    config=config,
+                    content_expr="message['content']",
+                    context_name="tool message contents",
+                    supported_types_desc=_join_types_desc(tool_desc_parts),
+                    support_thinking=True,
+                    support_images=True,
+                    support_audio=True,
+                    initial_prev_img="false",
+                )
+                + " -}}"
+            )
             lines.append("        {{- '" + _END_TOOL_RESULTS + "' }}")
         else:
             lines.append(

--- a/tests/data/chat_templates/v11.jinja
+++ b/tests/data/chat_templates/v11.jinja
@@ -134,7 +134,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content') -}}
+        {{- render_content(content=message['content'], context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -144,7 +144,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -181,7 +181,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v11_audio.jinja
+++ b/tests/data/chat_templates/v11_audio.jinja
@@ -144,7 +144,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -154,7 +154,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -191,7 +191,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_audio=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v11_image.jinja
+++ b/tests/data/chat_templates/v11_image.jinja
@@ -147,7 +147,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -157,7 +157,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -194,7 +194,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v11_image_think.jinja
+++ b/tests/data/chat_templates/v11_image_think.jinja
@@ -174,7 +174,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -184,7 +184,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -221,7 +221,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v11_think.jinja
+++ b/tests/data/chat_templates/v11_think.jinja
@@ -161,7 +161,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -171,7 +171,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -208,7 +208,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13.jinja
+++ b/tests/data/chat_templates/v13.jinja
@@ -135,7 +135,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content') -}}
+        {{- render_content(content=user_content, context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -145,7 +145,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -171,7 +171,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_audio.jinja
+++ b/tests/data/chat_templates/v13_audio.jinja
@@ -140,7 +140,7 @@
             {%- set ns.available_tools_emitted = true %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -150,7 +150,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -176,7 +176,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_audio=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_image.jinja
+++ b/tests/data/chat_templates/v13_image.jinja
@@ -143,7 +143,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -153,7 +153,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -179,7 +179,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_image_think.jinja
+++ b/tests/data/chat_templates/v13_image_think.jinja
@@ -170,7 +170,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -180,7 +180,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -206,7 +206,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_think.jinja
+++ b/tests/data/chat_templates/v13_think.jinja
@@ -162,7 +162,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -172,7 +172,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -198,7 +198,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15.jinja
+++ b/tests/data/chat_templates/v15.jinja
@@ -151,7 +151,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content') -}}
+        {{- render_content(content=user_content, context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -161,7 +161,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -183,13 +183,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- render_content(content=message['content'], context_name='tool message contents') -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_audio.jinja
+++ b/tests/data/chat_templates/v15_audio.jinja
@@ -148,7 +148,7 @@
             {%- set ns.available_tools_and_settings_emitted = true %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -158,7 +158,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -180,13 +180,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and audio', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text and audio', support_audio=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and audio', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and audio', support_audio=true) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_image.jinja
+++ b/tests/data/chat_templates/v15_image.jinja
@@ -159,7 +159,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -169,7 +169,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -191,13 +191,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text and image', support_images=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_image_think.jinja
+++ b/tests/data/chat_templates/v15_image_think.jinja
@@ -186,7 +186,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -196,7 +196,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -218,13 +218,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text, thinking and image', support_thinking=true, support_images=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_thinking=false, support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_thinking=false, support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_think.jinja
+++ b/tests/data/chat_templates/v15_think.jinja
@@ -178,7 +178,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -188,7 +188,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -210,13 +210,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v2.jinja
+++ b/tests/data/chat_templates/v2.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -170,7 +170,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
             {{- eos_token }}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 and ns.index > ns.max_idx_user %}
             {{- '[TOOL_CALLS][' }}

--- a/tests/data/chat_templates/v2_spm.jinja
+++ b/tests/data/chat_templates/v2_spm.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -178,7 +178,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
             {{- eos_token }}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 and ns.index > ns.max_idx_user %}
             {%- if ns.add_space %}

--- a/tests/data/chat_templates/v3.jinja
+++ b/tests/data/chat_templates/v3.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -174,7 +174,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/data/chat_templates/v3_image.jinja
+++ b/tests/data/chat_templates/v3_image.jinja
@@ -157,7 +157,7 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {%- elif message['content'] | length > 0 %}
             {#- When content has exactly one image and one text block, put image first. #}
             {%- if message['content'] | length == 2 and message['content'][0]['type'] == 'text' and message['content'][1]['type'] in ['image', 'image_url'] %}
@@ -165,7 +165,7 @@
             {%- else %}
                 {%- set blocks = message['content'] %}
             {%- endif %}
-            {{- render_content(blocks, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+            {{- render_content(content=blocks, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -182,7 +182,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/data/chat_templates/v3_image_spm.jinja
+++ b/tests/data/chat_templates/v3_image_spm.jinja
@@ -169,7 +169,7 @@
 
 
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
         {%- elif message['content'] | length > 0 %}
             {#- When content has exactly one image and one text block, put image first. #}
             {%- if message['content'] | length == 2 and message['content'][0]['type'] == 'text' and message['content'][1]['type'] in ['image', 'image_url'] %}
@@ -177,7 +177,7 @@
             {%- else %}
                 {%- set blocks = message['content'] %}
             {%- endif %}
-            {{- render_content(blocks, 'user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
+            {{- render_content(content=blocks, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -198,7 +198,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false, initial_prev_img=false) -}}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
             {%- if ns.add_space %}
                 {%- set ns.add_space=false %}

--- a/tests/data/chat_templates/v3_spm.jinja
+++ b/tests/data/chat_templates/v3_spm.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -178,7 +178,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
             {%- if ns.add_space %}
                 {%- set ns.add_space=false %}

--- a/tests/data/chat_templates/v7.jinja
+++ b/tests/data/chat_templates/v7.jinja
@@ -134,7 +134,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content') -}}
+        {{- render_content(content=message['content'], context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -144,7 +144,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -185,7 +185,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_audio.jinja
+++ b/tests/data/chat_templates/v7_audio.jinja
@@ -144,7 +144,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -154,7 +154,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -195,7 +195,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_audio=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_image.jinja
+++ b/tests/data/chat_templates/v7_image.jinja
@@ -147,7 +147,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -157,7 +157,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -198,7 +198,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_image_spm.jinja
+++ b/tests/data/chat_templates/v7_image_spm.jinja
@@ -155,7 +155,7 @@
             {%- set inst_tag = '[INST] ' %}
         {%- endif %}
         {{- inst_tag -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
         {{- '[/INST]' }}
         {%- if loop.index < loop.length %}
             {%- set ns.add_space=true %}
@@ -173,7 +173,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false, initial_prev_img=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -226,7 +226,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT] ' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false, initial_prev_img=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_spm.jinja
+++ b/tests/data/chat_templates/v7_spm.jinja
@@ -134,7 +134,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST] ' -}}
-        {{- render_content(message['content'], 'user message content') -}}
+        {{- render_content(content=message['content'], context_name='user message content') -}}
         {{- '[/INST]' }}
         {%- if loop.index < loop.length %}
             {%- set ns.add_space=true %}
@@ -152,7 +152,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -205,7 +205,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT] ' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/integrations/chat_templates/fixtures_data.py
+++ b/tests/integrations/chat_templates/fixtures_data.py
@@ -1008,6 +1008,33 @@ REQUEST_TOOL_AUDIO_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
     tools=_TOOLS,
 )
 
+REQUEST_TOOL_THINKING_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
+    messages=[
+        UserMessage(content="What's the weather in Paris?"),
+        AssistantMessage(
+            content=None,
+            tool_calls=[
+                ToolCall(
+                    id="tl1mg2345",
+                    function=FunctionCall(
+                        name="tool1",
+                        arguments={"location": "Paris"},  # type: ignore[arg-type]
+                    ),
+                ),
+            ],
+        ),
+        ToolMessage(
+            content=[
+                ThinkChunk(thinking="The tool result needs reasoning before the answer."),
+                TextChunk(text="Sunny, 25C."),
+            ],
+            tool_call_id="tl1mg2345",
+        ),
+        AssistantMessage(content="It is sunny and 25C in Paris."),
+    ],
+    tools=_TOOLS,
+)
+
 REQUEST_SYSTEM_AUDIO_TRAIN = ChatCompletionRequest(  # type: ignore[type-var]
     messages=[
         SystemMessage(
@@ -1182,6 +1209,8 @@ def _get_conversations(
         if audio:
             conversations.append(REQUEST_SYSTEM_AUDIO_TRAIN)
             conversations.append(REQUEST_TOOL_AUDIO_TRAIN)
+        if think:
+            conversations.append(REQUEST_TOOL_THINKING_TRAIN)
 
     conversations = [c.model_copy(deep=True) for c in conversations]
 

--- a/tests/integrations/chat_templates/unit/test_v15.py
+++ b/tests/integrations/chat_templates/unit/test_v15.py
@@ -4,7 +4,12 @@ import pytest
 
 from mistral_common.integrations.chat_templates.chat_templates import generate_chat_template
 from mistral_common.tokens.tokenizers.base import TokenizerVersion
-from tests.integrations.chat_templates.helpers import TestConfig, _load_golden_template, _make_config, render_template
+from tests.integrations.chat_templates.helpers import (
+    TestConfig,
+    _load_golden_template,
+    _make_config,
+    render_template,
+)
 
 
 class TestV15ModelSettings:
@@ -471,3 +476,135 @@ class TestV15MultimodalContent:
         # rather than rendering through render_content — no [IMG] token produced
         output = render_template(template, messages, tools=tools)
         assert "[IMG]" not in output
+
+    def test_v15_think_tool_message_renders_thinking(self) -> None:
+        r"""V15 think template renders tool message with thinking chunk wrapped in [THINK] tokens."""
+        template = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v15,
+            image_support=False,
+            audio_support=False,
+            thinking_support=True,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "abcdefghi", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "thinking", "thinking": "secret reasoning"},
+                    {"type": "text", "text": "result"},
+                ],
+                "tool_call_id": "abcdefghi",
+            },
+            {"role": "assistant", "content": "Done"},
+        ]
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        output = render_template(template, messages, tools=tools, reasoning_effort="none")
+        assert "[TOOL_RESULTS][THINK]secret reasoning[/THINK]result[/TOOL_RESULTS]" in output
+
+    def test_v15_think_tool_message_string_content_ok(self) -> None:
+        r"""V15 think template renders tool message with string content without error."""
+        template = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v15,
+            image_support=False,
+            audio_support=False,
+            thinking_support=True,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "abcdefghi", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {
+                "role": "tool",
+                "content": "plain text result",
+                "tool_call_id": "abcdefghi",
+            },
+            {"role": "assistant", "content": "Done"},
+        ]
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        output = render_template(template, messages, tools=tools, reasoning_effort="none")
+        assert "[TOOL_RESULTS]" in output
+        assert "[/TOOL_RESULTS]" in output
+        assert "plain text result" in output
+
+    def test_v15_image_think_tool_message_accepts_thinking(self) -> None:
+        r"""V15 image+think template renders tool message with leading thinking chunk without error."""
+        template = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v15,
+            image_support=True,
+            audio_support=False,
+            thinking_support=True,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "abcdefghi", "function": {"name": "f", "arguments": "{}"}}],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "thinking", "thinking": "secret reasoning"},
+                    {"type": "text", "text": "result"},
+                ],
+                "tool_call_id": "abcdefghi",
+            },
+            {"role": "assistant", "content": "Done"},
+        ]
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        output = render_template(template, messages, tools=tools, reasoning_effort="none")
+        assert "[THINK]secret reasoning[/THINK]" in output
+        assert "[TOOL_RESULTS]" in output


### PR DESCRIPTION
## Summary

Fixes v15 tool-result rendering when thinking is enabled, and eliminates all implicit `render_content` macro arguments in the generated chat templates.

> **Supersedes #269** (same topic). #269 stops the crash by passing `support_thinking=false` for tool results, but that *rejects* thinking chunks in tool messages — which mistral-common actually supports and encodes. This PR instead renders tool-result thinking (`support_thinking=true`), matching the tokenizer, and additionally makes every `render_content` call pass all declared arguments explicitly. #269 can be closed in favor of this PR.

## Problem

When thinking support is enabled, the generated `render_content` macro declares `support_thinking` (and `supported_types_desc`) as required parameters, but the v15 simple tool-result branch did not pass them:

```jinja
{{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
```

Strict Jinja rendering then fails as soon as a `role: tool` message is appended (`parameter 'supported_types_desc' was not provided` / not enough macro arguments).

## Why `support_thinking=true` (not `false`)

mistral-common v15 tool messages support thinking content:
- `ToolMessage._allowed_content_chunks` includes `ThinkChunk`.
- `MistralRequestValidatorV15._validate_tool_content_chunks` accepts all chunk types.
- `InstructTokenizerV13.encode_tool_message` (inherited by V15) encodes list content via `_encode_content_chunks`, so a `ThinkChunk` becomes `[THINK]...[/THINK]`.

Empirically the tokenizer produces `...[TOOL_RESULTS][THINK]tool reasoning here[/THINK]Sunny, 25C[/TOOL_RESULTS]...`. The chat template must render this identically, so it needs `support_thinking=true` with `thinking` in `supported_types_desc`. Passing `false` (as in #269) would make the template reject content the tokenizer accepts.

## Changes

- **Fix the v15 tool-result branch** to pass `support_thinking=true` and include `thinking` in `supported_types_desc`.
- **Centralize call construction** in a new `_render_content_call(...)` helper so every `render_content` call emits *every* argument the macro declares for the config — no reliance on Jinja implicit `undefined`. This also fixed pre-existing implicit-arg cases in `v3_image`, `v3_image_spm`, and `v7_image_spm` (missing `supported_types_desc` / `support_images` / `initial_prev_img`).
- **All arguments are named**, including `content` and `context_name`: calls now read `render_content(content=..., context_name=..., ...)`.
- **Regenerated all affected golden templates** accordingly.
- **Tests:** focused v15 unit tests for tool-result thinking rendering/acceptance, plus a `REQUEST_TOOL_THINKING_TRAIN` conversation fixture wired into `_get_conversations`, so tool-with-reasoning is covered by both the template-vs-template parity (`test_parity.py`) and the mistral-common-vs-chat-template parity (`transformers/test_core_parity.py`).

## Validation

- `pytest tests/integrations/chat_templates -q` — all pass (incl. transformers cross-implementation parity with the new tool-reasoning fixture).
- Golden parity (`test_dynamic_matches_static`) and rendered-output parity (`test_dynamic_template_produces_same_output`) pass for every config — rendered output for pre-existing configs is unchanged (only made explicit).
- `ruff check`, `ruff format --check`, and `mypy` on changed files — pass.
