### PR TITLE
Add auto-detecting chat template generation from tokenizer file

### DIFF
--- a/scripts/generate_chat_template.py
+++ b/scripts/generate_chat_template.py
@@ -32,19 +32,15 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.tokenizer_file is not None:
-        conflicting: list[str] = []
-        if args.version is not None:
-            conflicting.append("--version")
-        if args.spm:
-            conflicting.append("--spm")
-        if args.image:
-            conflicting.append("--image")
-        if args.audio:
-            conflicting.append("--audio")
-        if args.thinking:
-            conflicting.append("--thinking")
-        if args.plain_thinking:
-            conflicting.append("--plain_thinking")
+        manual_flag_checks: list[tuple[bool, str]] = [
+            (args.version is not None, "--version"),
+            (args.spm, "--spm"),
+            (args.image, "--image"),
+            (args.audio, "--audio"),
+            (args.thinking, "--thinking"),
+            (args.plain_thinking, "--plain_thinking"),
+        ]
+        conflicting = [flag for is_set, flag in manual_flag_checks if is_set]
 
         if conflicting:
             parser.error(f"--tokenizer_file cannot be combined with manual capability flags: {', '.join(conflicting)}")

--- a/scripts/generate_chat_template.py
+++ b/scripts/generate_chat_template.py
@@ -1,13 +1,22 @@
 import argparse
 
-from mistral_common.integrations.chat_templates.chat_templates import generate_chat_template
+from mistral_common.integrations.chat_templates.chat_templates import (
+    convert_tokenizer_to_chat_template,
+    generate_chat_template,
+)
 from mistral_common.tokens.tokenizers.base import TokenizerVersion
 
 
 def main() -> None:
     r"""Generate a chat template and save it to a file."""
     parser = argparse.ArgumentParser(description="Generate a Mistral chat template")
-    parser.add_argument("--version", type=str, required=True, help="Tokenizer version (e.g., v1, v3, v7, v15)")
+    parser.add_argument(
+        "--tokenizer_file",
+        type=str,
+        default=None,
+        help="Path to a tokenizer file for auto-detect mode",
+    )
+    parser.add_argument("--version", type=str, default=None, help="Tokenizer version (e.g., v1, v3, v7, v15)")
     parser.add_argument("--spm", action="store_true", help="Use SentencePiece tokenizer")
     parser.add_argument("--image", action="store_true", help="Enable image support")
     parser.add_argument("--audio", action="store_true", help="Enable audio support")
@@ -22,16 +31,43 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    template = generate_chat_template(
-        spm=args.spm,
-        tokenizer_version=TokenizerVersion(args.version),
-        image_support=args.image,
-        audio_support=args.audio,
-        thinking_support=args.thinking,
-        default_system_prompt=args.default_system_prompt,
-        plain_thinking_support=args.plain_thinking,
-        use_special_token_variables=not args.no_special_token_variables,
-    )
+    if args.tokenizer_file is not None:
+        conflicting: list[str] = []
+        if args.version is not None:
+            conflicting.append("--version")
+        if args.spm:
+            conflicting.append("--spm")
+        if args.image:
+            conflicting.append("--image")
+        if args.audio:
+            conflicting.append("--audio")
+        if args.thinking:
+            conflicting.append("--thinking")
+        if args.plain_thinking:
+            conflicting.append("--plain_thinking")
+
+        if conflicting:
+            parser.error(f"--tokenizer_file cannot be combined with manual capability flags: {', '.join(conflicting)}")
+
+        template = convert_tokenizer_to_chat_template(
+            tokenizer_file=args.tokenizer_file,
+            system_prompt=args.default_system_prompt,
+            use_special_token_variables=not args.no_special_token_variables,
+        )
+    else:
+        if args.version is None:
+            parser.error("--version is required when --tokenizer_file is not provided")
+
+        template = generate_chat_template(
+            spm=args.spm,
+            tokenizer_version=TokenizerVersion(args.version),
+            image_support=args.image,
+            audio_support=args.audio,
+            thinking_support=args.thinking,
+            default_system_prompt=args.default_system_prompt,
+            plain_thinking_support=args.plain_thinking,
+            use_special_token_variables=not args.no_special_token_variables,
+        )
 
     with open(args.saving_path, "w", encoding="utf-8") as f:
         f.write(template)

--- a/src/mistral_common/integrations/chat_templates/chat_templates.py
+++ b/src/mistral_common/integrations/chat_templates/chat_templates.py
@@ -6,7 +6,7 @@ from mistral_common.integrations.chat_templates.template_generator import (
 from mistral_common.integrations.chat_templates.template_generator import (
     build_chat_template as _build_chat_template,
 )
-from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from mistral_common.tokens.tokenizers.base import SpecialTokens, TokenizerVersion
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
 
@@ -82,9 +82,9 @@ def convert_tokenizer_to_chat_template(
     an audio encoder uses plain `<think>`/`</think>` text tags instead of special
     `[THINK]`/`[/THINK]` tokens. When audio is present on a v11 tokenizer,
     `plain_thinking_support` is set to `False` because the two are mutually exclusive.
-    `thinking_support` (special-token thinking) is detected by checking whether the
-    instruct tokenizer exposes a non-`None` `BEGIN_THINK` attribute, which is only
-    set on v13+ tokenizers that include think special tokens.
+    `thinking_support` (special-token thinking) is detected by checking whether both
+    `begin_think` and `end_think` special tokens are registered in the underlying
+    tokenizer via its public `is_special` method.
 
     Args:
         tokenizer_file: Path to the tokenizer file (tekken JSON or SentencePiece `.model.vX`).
@@ -107,7 +107,9 @@ def convert_tokenizer_to_chat_template(
     spm = isinstance(tokenizer, SentencePieceTokenizer)
     image_support = instruct_tokenizer.image_encoder is not None
     audio_support = instruct_tokenizer.audio_encoder is not None
-    thinking_support = getattr(instruct_tokenizer, "BEGIN_THINK", None) is not None
+    thinking_support = tokenizer.is_special(SpecialTokens.begin_think.value) and tokenizer.is_special(
+        SpecialTokens.end_think.value
+    )
     plain_thinking_support = version == TokenizerVersion.v11 and not audio_support
 
     return generate_chat_template(

--- a/src/mistral_common/integrations/chat_templates/chat_templates.py
+++ b/src/mistral_common/integrations/chat_templates/chat_templates.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from mistral_common.integrations.chat_templates.template_generator import (
     TemplateConfig,
 )
@@ -5,6 +7,8 @@ from mistral_common.integrations.chat_templates.template_generator import (
     build_chat_template as _build_chat_template,
 )
 from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
 
 
 def generate_chat_template(
@@ -60,3 +64,57 @@ def generate_chat_template(
         )
 
     return template
+
+
+def convert_tokenizer_to_chat_template(
+    tokenizer_file: str | Path,
+    system_prompt: str | None = None,
+    use_special_token_variables: bool = True,
+) -> str:
+    r"""Load a tokenizer file and auto-detect its capabilities to generate a matching chat template.
+
+    Loads the tokenizer via `MistralTokenizer.from_file`, inspects the resulting
+    instruct tokenizer to determine version, backend (SentencePiece vs Tekken),
+    and supported modalities, then delegates to `generate_chat_template` with the
+    detected flags.
+
+    The `plain_thinking_support` flag is set heuristically: any v11 tokenizer uses
+    plain `<think>`/`</think>` text tags instead of special `[THINK]`/`[/THINK]`
+    tokens. `thinking_support` (special-token thinking) is detected by checking
+    whether the instruct tokenizer exposes a non-`None` `BEGIN_THINK` attribute,
+    which is only set on v13+ tokenizers that include think special tokens.
+
+    Args:
+        tokenizer_file: Path to the tokenizer file (tekken JSON or SentencePiece `.model.vX`).
+        system_prompt: Optional default system prompt to embed in the template.
+            When not `None`, maps to `generate_chat_template`'s `default_system_prompt`.
+        use_special_token_variables: Whether to emit BOS/EOS as Jinja variable
+            references (`bos_token`/`eos_token`) or as literal string values.
+
+    Returns:
+        The generated Jinja2 chat template string matching the tokenizer's capabilities.
+
+    Raises:
+        TokenizerException: If the tokenizer file is not recognized or invalid.
+    """
+    mt = MistralTokenizer.from_file(tokenizer_file)
+    it = mt.instruct_tokenizer
+    tok = it.tokenizer
+
+    version = tok.version
+    spm = isinstance(tok, SentencePieceTokenizer)
+    image_support = it.image_encoder is not None
+    audio_support = it.audio_encoder is not None
+    thinking_support = getattr(it, "BEGIN_THINK", None) is not None
+    plain_thinking_support = version == TokenizerVersion.v11
+
+    return generate_chat_template(
+        spm=spm,
+        tokenizer_version=version,
+        image_support=image_support,
+        audio_support=audio_support,
+        thinking_support=thinking_support,
+        default_system_prompt=system_prompt,
+        plain_thinking_support=plain_thinking_support,
+        use_special_token_variables=use_special_token_variables,
+    )

--- a/src/mistral_common/integrations/chat_templates/chat_templates.py
+++ b/src/mistral_common/integrations/chat_templates/chat_templates.py
@@ -78,11 +78,13 @@ def convert_tokenizer_to_chat_template(
     and supported modalities, then delegates to `generate_chat_template` with the
     detected flags.
 
-    The `plain_thinking_support` flag is set heuristically: any v11 tokenizer uses
-    plain `<think>`/`</think>` text tags instead of special `[THINK]`/`[/THINK]`
-    tokens. `thinking_support` (special-token thinking) is detected by checking
-    whether the instruct tokenizer exposes a non-`None` `BEGIN_THINK` attribute,
-    which is only set on v13+ tokenizers that include think special tokens.
+    The `plain_thinking_support` flag is set heuristically: a v11 tokenizer without
+    an audio encoder uses plain `<think>`/`</think>` text tags instead of special
+    `[THINK]`/`[/THINK]` tokens. When audio is present on a v11 tokenizer,
+    `plain_thinking_support` is set to `False` because the two are mutually exclusive.
+    `thinking_support` (special-token thinking) is detected by checking whether the
+    instruct tokenizer exposes a non-`None` `BEGIN_THINK` attribute, which is only
+    set on v13+ tokenizers that include think special tokens.
 
     Args:
         tokenizer_file: Path to the tokenizer file (tekken JSON or SentencePiece `.model.vX`).
@@ -97,16 +99,16 @@ def convert_tokenizer_to_chat_template(
     Raises:
         TokenizerException: If the tokenizer file is not recognized or invalid.
     """
-    mt = MistralTokenizer.from_file(tokenizer_file)
-    it = mt.instruct_tokenizer
-    tok = it.tokenizer
+    mistral_tokenizer = MistralTokenizer.from_file(tokenizer_file)
+    instruct_tokenizer = mistral_tokenizer.instruct_tokenizer
+    tokenizer = instruct_tokenizer.tokenizer
 
-    version = tok.version
-    spm = isinstance(tok, SentencePieceTokenizer)
-    image_support = it.image_encoder is not None
-    audio_support = it.audio_encoder is not None
-    thinking_support = getattr(it, "BEGIN_THINK", None) is not None
-    plain_thinking_support = version == TokenizerVersion.v11
+    version = mistral_tokenizer.version
+    spm = isinstance(tokenizer, SentencePieceTokenizer)
+    image_support = instruct_tokenizer.image_encoder is not None
+    audio_support = instruct_tokenizer.audio_encoder is not None
+    thinking_support = getattr(instruct_tokenizer, "BEGIN_THINK", None) is not None
+    plain_thinking_support = version == TokenizerVersion.v11 and not audio_support
 
     return generate_chat_template(
         spm=spm,

--- a/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
+++ b/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
@@ -124,6 +124,24 @@ class TestConvertTokenizerToChatTemplate:
         assert "'<s>'" in result
         assert "bos_token" not in result
 
+    def test_tekken_v11_audio_no_plain_thinking(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v11, audio=True)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        expected = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v11,
+            image_support=False,
+            audio_support=True,
+            thinking_support=False,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+        assert "[AUDIO]" in result
+        assert "<think>" not in result
+
     def test_unrecognized_file_raises_tokenizer_exception(self, tmp_path: Path) -> None:
         invalid_path = tmp_path / "tokenizer.txt"
         invalid_path.write_text("not a tokenizer")

--- a/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
+++ b/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
@@ -145,5 +145,5 @@ class TestConvertTokenizerToChatTemplate:
     def test_unrecognized_file_raises_tokenizer_exception(self, tmp_path: Path) -> None:
         invalid_path = tmp_path / "tokenizer.txt"
         invalid_path.write_text("not a tokenizer")
-        with pytest.raises(TokenizerException):
+        with pytest.raises(TokenizerException, match="Unrecognized tokenizer file:"):
             convert_tokenizer_to_chat_template(tokenizer_file=invalid_path)

--- a/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
+++ b/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+import pytest
+
+from mistral_common.exceptions import TokenizerException
+from mistral_common.integrations.chat_templates.chat_templates import (
+    convert_tokenizer_to_chat_template,
+    generate_chat_template,
+)
+from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from tests.integrations.chat_templates.helpers import TestConfig, _build_spm_path, _build_tekken_json
+
+
+class TestConvertTokenizerToChatTemplate:
+    def test_tekken_v13_thinking(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v13, think=True)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        expected = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v13,
+            image_support=False,
+            audio_support=False,
+            thinking_support=True,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+        assert "[THINK]" in result
+
+    def test_tekken_v3_image(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v3, image=True)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        expected = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v3,
+            image_support=True,
+            audio_support=False,
+            thinking_support=False,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+
+    def test_tekken_v7_audio(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v7, audio=True)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        expected = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v7,
+            image_support=False,
+            audio_support=True,
+            thinking_support=False,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+
+    def test_tekken_v11_plain_thinking(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v11)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        expected = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v11,
+            image_support=False,
+            audio_support=False,
+            thinking_support=False,
+            default_system_prompt=None,
+            plain_thinking_support=True,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+        assert "<think>" in result
+        assert "[THINK]" not in result
+
+    def test_spm_v7(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v7, spm=True)
+        path = _build_spm_path(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        expected = generate_chat_template(
+            spm=True,
+            tokenizer_version=TokenizerVersion.v7,
+            image_support=False,
+            audio_support=False,
+            thinking_support=False,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+
+    def test_system_prompt_embedded(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v7)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(
+            tokenizer_file=path,
+            system_prompt="You are helpful.",
+        )
+        assert "You are helpful." in result
+
+    def test_use_special_token_variables_true(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v7)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(
+            tokenizer_file=path,
+            use_special_token_variables=True,
+        )
+        assert "bos_token" in result
+        assert "'<s>'" not in result
+
+    def test_use_special_token_variables_false(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v7)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(
+            tokenizer_file=path,
+            use_special_token_variables=False,
+        )
+        assert "'<s>'" in result
+        assert "bos_token" not in result
+
+    def test_unrecognized_file_raises_tokenizer_exception(self, tmp_path: Path) -> None:
+        invalid_path = tmp_path / "tokenizer.txt"
+        invalid_path.write_text("not a tokenizer")
+        with pytest.raises(TokenizerException):
+            convert_tokenizer_to_chat_template(tokenizer_file=invalid_path)

--- a/tests/test_generate_chat_template_cli.py
+++ b/tests/test_generate_chat_template_cli.py
@@ -104,7 +104,7 @@ def test_cli_invalid_config(tmp_path: Path) -> None:
 
 
 def test_cli_missing_version(tmp_path: Path) -> None:
-    """CLI requires --version."""
+    """CLI requires --version in manual mode and emits the specific error message."""
     output_path = tmp_path / "template.jinja"
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH), "--saving_path", str(output_path)],
@@ -112,6 +112,7 @@ def test_cli_missing_version(tmp_path: Path) -> None:
         text=True,
     )
     assert result.returncode != 0
+    assert "--version is required when --tokenizer_file is not provided" in result.stderr
 
 
 def test_cli_with_audio_flag(tmp_path: Path) -> None:
@@ -222,7 +223,7 @@ def test_autodetect_happy_path(tmp_path: Path, tekken_think_v13_path: Path) -> N
 
 
 def test_autodetect_conflict_version(tmp_path: Path, tekken_think_v13_path: Path) -> None:
-    """Auto-detect + --version exits non-zero."""
+    """Auto-detect + --version exits non-zero with mutual-exclusion error."""
     output_path = tmp_path / "template.jinja"
     result = subprocess.run(
         [
@@ -239,10 +240,11 @@ def test_autodetect_conflict_version(tmp_path: Path, tekken_think_v13_path: Path
         text=True,
     )
     assert result.returncode != 0
+    assert "--tokenizer_file cannot be combined with manual capability flags" in result.stderr
 
 
 def test_autodetect_conflict_capability_flag(tmp_path: Path, tekken_think_v13_path: Path) -> None:
-    """Auto-detect + --image exits non-zero."""
+    """Auto-detect + --image exits non-zero with mutual-exclusion error."""
     output_path = tmp_path / "template.jinja"
     result = subprocess.run(
         [
@@ -258,6 +260,7 @@ def test_autodetect_conflict_capability_flag(tmp_path: Path, tekken_think_v13_pa
         text=True,
     )
     assert result.returncode != 0
+    assert "--tokenizer_file cannot be combined with manual capability flags" in result.stderr
 
 
 def test_autodetect_with_system_prompt(tmp_path: Path, tekken_think_v13_path: Path) -> None:

--- a/tests/test_generate_chat_template_cli.py
+++ b/tests/test_generate_chat_template_cli.py
@@ -2,7 +2,20 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
+from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from tests.integrations.chat_templates.helpers import TestConfig, _build_tekken_json
+
 SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "generate_chat_template.py"
+
+
+@pytest.fixture(scope="session")
+def tekken_think_v13_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Path to a v13 think tekken.json used for auto-detect CLI tests."""
+    build_dir = tmp_path_factory.mktemp("tokenizer")
+    config = TestConfig(version=TokenizerVersion.v13, think=True)
+    return _build_tekken_json(config=config, output_dir=build_dir)
 
 
 def test_cli_generates_template(tmp_path: Path) -> None:
@@ -185,3 +198,107 @@ def test_cli_no_special_token_variables_flag(tmp_path: Path) -> None:
     assert "'</s>'" in content
     assert "bos_token" not in content
     assert "eos_token" not in content
+
+
+def test_autodetect_happy_path(tmp_path: Path, tekken_think_v13_path: Path) -> None:
+    """Auto-detect mode with v13 think tokenizer generates template containing [THINK]."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_think_v13_path),
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert output_path.exists()
+    content = output_path.read_text()
+    assert "[THINK]" in content
+
+
+def test_autodetect_conflict_version(tmp_path: Path, tekken_think_v13_path: Path) -> None:
+    """Auto-detect + --version exits non-zero."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_think_v13_path),
+            "--version",
+            "v13",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_autodetect_conflict_capability_flag(tmp_path: Path, tekken_think_v13_path: Path) -> None:
+    """Auto-detect + --image exits non-zero."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_think_v13_path),
+            "--image",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_autodetect_with_system_prompt(tmp_path: Path, tekken_think_v13_path: Path) -> None:
+    """Auto-detect mode with --default_system_prompt embeds the prompt."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_think_v13_path),
+            "--default_system_prompt",
+            "You are helpful.",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    content = output_path.read_text()
+    assert "You are helpful." in content
+
+
+def test_autodetect_no_special_token_variables(tmp_path: Path, tekken_think_v13_path: Path) -> None:
+    """Auto-detect + --no_special_token_variables embeds literal BOS/EOS values."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_think_v13_path),
+            "--no_special_token_variables",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    content = output_path.read_text()
+    assert "'<s>'" in content
+    assert "bos_token" not in content


### PR DESCRIPTION
## Summary

Add `convert_tokenizer_to_chat_template(tokenizer_file, system_prompt, use_special_token_variables)` that auto-detects a tokenizer's capabilities from its file and generates the matching HuggingFace chat template, removing the need to pass 8 explicit flags to `generate_chat_template`.

Auto-detection loads the tokenizer via `MistralTokenizer.from_file` and derives:
- **version** from the tokenizer
- **spm** (SentencePiece vs Tekken backend)
- **image support** (`image_encoder` present)
- **audio support** (`audio_encoder` present)
- **thinking support** (`[THINK]`/`[/THINK]` special tokens, i.e. `BEGIN_THINK` set on v13+)
- **plain thinking** for v11 (`<think>` text tags), guarded off when audio is present

## Changes

- New `convert_tokenizer_to_chat_template` in `src/mistral_common/integrations/chat_templates/chat_templates.py`, delegating to the existing `generate_chat_template`.
- CLI `scripts/generate_chat_template.py` gains an auto-detect mode via `--tokenizer_file`. It is mutually exclusive with the manual capability flags (`--version`, `--spm`, `--image`, `--audio`, `--thinking`, `--plain_thinking`) and errors clearly if combined; `--version` is now required only in manual mode.

## Test Plan

- [x] `uv run pytest tests/integrations/chat_templates/unit/test_convert_tokenizer.py tests/test_generate_chat_template_cli.py` (28 passed)
- [x] `uv run ruff check .` and `uv run mypy` on changed files clean
- [x] Tests cover tekken v3 image, v7 audio, v11 plain-think, v11+audio guard, v13 thinking, spm v7, system-prompt embedding, special-token-variables toggle, unrecognized-file error, and CLI conflict/missing-version paths