### PR TITLE
Emit all render_content macro args explicitly

### DIFF
--- a/src/mistral_common/integrations/chat_templates/template_generator.py
+++ b/src/mistral_common/integrations/chat_templates/template_generator.py
@@ -241,6 +241,85 @@ def _join_types_desc(parts: list[str]) -> str:
     return ", ".join(parts[:-1]) + " and " + parts[-1]
 
 
+def _render_content_call(
+    config: TemplateConfig,
+    content_expr: str,
+    context_name: str,
+    *,
+    supported_types_desc: str,
+    support_thinking: bool,
+    support_images: bool,
+    support_audio: bool,
+    initial_prev_img: str = "false",
+) -> str:
+    r"""Build a `render_content(...)` Jinja call string with all args emitted explicitly.
+
+    Every argument that the `render_content` macro declares for `config` is included
+    as a keyword argument in macro-declared order, so no call site relies on Jinja
+    implicit `undefined`. Arguments for features absent from `config` are omitted
+    because the macro does not declare them.
+
+    Args:
+        config: Template configuration controlling which macro parameters exist.
+        content_expr: Raw Jinja expression for the `content` argument
+            (e.g. `message['content']`).
+        context_name: Human-readable name for the calling context
+            (used in macro error messages).
+        supported_types_desc: Description of supported chunk types for error messages.
+            Only emitted when the macro declares this parameter
+            (i.e. when `config` has any extra-type support enabled).
+        support_thinking: Whether thinking chunks are allowed at this call site.
+            Only emitted when `config.any_thinking_support` is True.
+        support_images: Whether image/image_url chunks are allowed at this call site.
+            Only emitted when `config.image_support` is True.
+        support_audio: Whether audio/audio_url chunks are allowed at this call site.
+            Only emitted when `config.audio_support` is True.
+        initial_prev_img: Initial value for SPM prev-image tracking namespace.
+            Only emitted when `config.uses_spm_prev_img_tracking` is True.
+
+    Returns:
+        A Jinja call string of the form `render_content(<args>)` with all
+        macro-declared arguments emitted as keyword arguments in declaration order.
+        No surrounding `{{- -}}` tags are included.
+
+    Examples:
+        >>> from mistral_common.tokens.tokenizers.base import TokenizerVersion
+        >>> config = TemplateConfig(version=TokenizerVersion.v7)
+        >>> _render_content_call(
+        ...     config=config,
+        ...     content_expr="message['content']",
+        ...     context_name="user message content",
+        ...     supported_types_desc="text",
+        ...     support_thinking=False,
+        ...     support_images=False,
+        ...     support_audio=False,
+        ... )
+        "render_content(content=message['content'], context_name='user message content')"
+    """
+    args = [f"content={content_expr}", f"context_name='{context_name}'"]
+
+    # IMPORTANT: argument emission order below must stay in sync with the
+    # `render_content` macro parameter build order in `_generate_macros`
+    # (the `params` list starting with ["content", "context_name"]).
+    # Any reorder here must be mirrored there, and vice-versa.
+    if config.any_thinking_support or config.image_support or config.audio_support:
+        args.append(f"supported_types_desc='{supported_types_desc}'")
+
+    if config.any_thinking_support:
+        args.append(f"support_thinking={'true' if support_thinking else 'false'}")
+
+    if config.image_support:
+        args.append(f"support_images={'true' if support_images else 'false'}")
+
+    if config.audio_support:
+        args.append(f"support_audio={'true' if support_audio else 'false'}")
+
+    if config.uses_spm_prev_img_tracking:
+        args.append(f"initial_prev_img={initial_prev_img}")
+
+    return "render_content(" + ", ".join(args) + ")"
+
+
 def _generate_header(config: TemplateConfig) -> str:
     r"""Generate template header with default system message.
 
@@ -891,25 +970,24 @@ def _generate_system_message_handling(config: TemplateConfig) -> str:
     else:
         lines.append("        {{- '" + _BEGIN_SYSTEM + "' -}}")
 
-    has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
-    rc_args = "message['content'], 'system message contents'"
-    if has_extra_types:
-        if config.system_supports_thinking:
-            rc_args += ", supported_types_desc='text and thinking'"
-        elif config.system_supports_audio:
-            rc_args += ", supported_types_desc='text and audio'"
-        else:
-            rc_args += ", supported_types_desc='text'"
-    if config.any_thinking_support:
-        if config.system_supports_thinking:
-            rc_args += ", support_thinking=true"
-        else:
-            rc_args += ", support_thinking=false"
-    if config.image_support:
-        rc_args += ", support_images=false"
-    if config.audio_support:
-        rc_args += f", support_audio={'true' if config.system_supports_audio else 'false'}"
-    lines.append("        {{- render_content(" + rc_args + ") -}}")
+    if config.system_supports_thinking:
+        sys_types_desc = "text and thinking"
+    elif config.system_supports_audio:
+        sys_types_desc = "text and audio"
+    else:
+        sys_types_desc = "text"
+
+    rc = _render_content_call(
+        config=config,
+        content_expr="message['content']",
+        context_name="system message contents",
+        supported_types_desc=sys_types_desc,
+        support_thinking=config.system_supports_thinking,
+        support_images=False,
+        support_audio=config.system_supports_audio,
+        initial_prev_img="false",
+    )
+    lines.append("        {{- " + rc + " -}}")
 
     lines.append("        {{- '" + _END_SYSTEM + "' -}}")
 
@@ -1065,7 +1143,12 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
         inst_open = _BEGIN_INST
         inst_close = _END_INST
 
-    has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
+    if config.image_support:
+        user_types_desc = "text, image and image_url"
+    elif config.audio_support:
+        user_types_desc = "text, input_audio and audio_url"
+    else:
+        user_types_desc = "text"
 
     if config.uses_system_prompt_tokens:
         # =================================================================
@@ -1116,27 +1199,21 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
         else:
             lines.append("        {{- '" + _BEGIN_INST + "' -}}")
 
-        # --- Build unified render_content args ---
+        # --- Build unified render_content call (v7+ call site) ---
         content_var = "user_content" if needs_content_prep else "message['content']"
-        rc_args = content_var + ", 'user message content'"
-        if has_extra_types:
-            if config.image_support:
-                rc_args += ", supported_types_desc='text, image and image_url'"
-            elif config.audio_support:
-                rc_args += ", supported_types_desc='text, input_audio and audio_url'"
-            else:
-                rc_args += ", supported_types_desc='text'"
-        if config.any_thinking_support:
-            rc_args += ", support_thinking=false"
-        if config.image_support:
-            rc_args += ", support_images=true"
-        if config.audio_support:
-            rc_args += ", support_audio=true"
-        if config.uses_spm_prev_img_tracking:
-            rc_args += ", initial_prev_img=not added_sp"
+        rc = _render_content_call(
+            config=config,
+            content_expr=content_var,
+            context_name="user message content",
+            supported_types_desc=user_types_desc,
+            support_thinking=False,
+            support_images=config.image_support,
+            support_audio=config.audio_support,
+            initial_prev_img="not added_sp",
+        )
 
         # --- Emit render_content + [/INST] (once each) ---
-        lines.append("        {{- render_content(" + rc_args + ") -}}")
+        lines.append("        {{- " + rc + " -}}")
         lines.append("        {{- '" + inst_close + "' }}")
 
     else:
@@ -1156,7 +1233,19 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
             lines.append("")
             lines.append("")
             lines.append("        {%- if message['content'] is string %}")
-            lines.append("            {{- render_content(message['content'], 'user message content') -}}")
+            # Pre-v7 SPM+image string branch (call site 2): initial_prev_img irrelevant
+            # for string content but added_sp is in scope so use "not added_sp" consistently.
+            rc_str = _render_content_call(
+                config=config,
+                content_expr="message['content']",
+                context_name="user message content",
+                supported_types_desc=user_types_desc,
+                support_thinking=False,
+                support_images=config.image_support,
+                support_audio=config.audio_support,
+                initial_prev_img="not added_sp",
+            )
+            lines.append("            {{- " + rc_str + " -}}")
             lines.append("        {%- elif message['content'] | length > 0 %}")
         else:
             lines.append(f"        {{{{- '{inst_open}' }}}}")
@@ -1167,10 +1256,20 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
             lines.append("            {{- system_message + '\\n\\n' }}")
             lines.append("        {%- endif %}")
             lines.append("        {%- if message['content'] is string %}")
-            lines.append("            {{- render_content(message['content'], 'user message content') -}}")
+            # Pre-v7 plain string branch (call site 2 for non-SPM): simple text-only
+            rc_str = _render_content_call(
+                config=config,
+                content_expr="message['content']",
+                context_name="user message content",
+                supported_types_desc=user_types_desc,
+                support_thinking=False,
+                support_images=config.image_support,
+                support_audio=config.audio_support,
+            )
+            lines.append("            {{- " + rc_str + " -}}")
             lines.append("        {%- elif message['content'] | length > 0 %}")
 
-        # Shared: image sorting + render_content for list case (pre-v7 only)
+        # Shared: image sorting + render_content for list case (pre-v7 only, call site 3)
         if config.image_support:
             lines.append("            {#- When content has exactly one image and one text block, put image first. #}")
             lines.append(
@@ -1184,23 +1283,17 @@ def _generate_user_message_handling(config: TemplateConfig) -> str:
         else:
             block_var = "message['content']"
 
-        rc_call_args = block_var + ", 'user message content'"
-        if has_extra_types:
-            if config.image_support:
-                rc_call_args += ", supported_types_desc='text, image and image_url'"
-            elif config.audio_support:
-                rc_call_args += ", supported_types_desc='text, input_audio and audio_url'"
-            else:
-                rc_call_args += ", supported_types_desc='text'"
-        if config.any_thinking_support:
-            rc_call_args += ", support_thinking=false"
-        if config.image_support:
-            rc_call_args += ", support_images=true"
-        if config.audio_support:
-            rc_call_args += ", support_audio=true"
-        if config.uses_spm_prev_img_tracking:
-            rc_call_args += ", initial_prev_img=not added_sp"
-        lines.append("            {{- render_content(" + rc_call_args + ") -}}")
+        rc_list = _render_content_call(
+            config=config,
+            content_expr=block_var,
+            context_name="user message content",
+            supported_types_desc=user_types_desc,
+            support_thinking=False,
+            support_images=config.image_support,
+            support_audio=config.audio_support,
+            initial_prev_img="not added_sp",
+        )
+        lines.append("            {{- " + rc_list + " -}}")
 
         # Closing
         lines.append("        {%- else %}")
@@ -1258,19 +1351,21 @@ def _generate_assistant_message_handling(config: TemplateConfig) -> str:
         lines.append("        {%- endif %}")
         lines.append("")
 
-    has_extra_types = config.any_thinking_support or config.image_support or config.audio_support
-    rc_call_args = "message['content'], 'assistant message contents'"
-    if has_extra_types:
-        desc_parts = ["text"]
-        if config.any_thinking_support:
-            desc_parts.append("thinking")
-        rc_call_args += f", supported_types_desc='{_join_types_desc(desc_parts)}'"
+    asst_desc_parts: list[str] = ["text"]
     if config.any_thinking_support:
-        rc_call_args += ", support_thinking=true"
-    if config.image_support:
-        rc_call_args += ", support_images=false"
-    if config.audio_support:
-        rc_call_args += ", support_audio=false"
+        asst_desc_parts.append("thinking")
+    asst_types_desc = _join_types_desc(asst_desc_parts)
+
+    rc = _render_content_call(
+        config=config,
+        content_expr="message['content']",
+        context_name="assistant message contents",
+        supported_types_desc=asst_types_desc,
+        support_thinking=True,
+        support_images=False,
+        support_audio=False,
+        initial_prev_img="false",
+    )
 
     lines.append("        {%- if message['content'] %}")
 
@@ -1280,7 +1375,7 @@ def _generate_assistant_message_handling(config: TemplateConfig) -> str:
         lines.append("                {%- set ns.add_space=false %}")
         lines.append("            {%- endif %}")
 
-    lines.append("            {{- render_content(" + rc_call_args + ") -}}")
+    lines.append("            {{- " + rc + " -}}")
 
     if config.uses_v2_tool_format:
         lines.append("            {{- " + config.eos_expr + " }}")
@@ -1514,20 +1609,24 @@ def _generate_tool_message_handling(config: TemplateConfig) -> str:
             )
     elif config.uses_simple_tool_results:
         if config.tool_supports_multimodal:
-            tool_rc_args = "message['content'], 'tool message contents'"
-            if config.image_support or config.audio_support:
-                desc_parts = ["text"]
-                if config.image_support:
-                    desc_parts.append("image")
-                if config.audio_support:
-                    desc_parts.append("audio")
-                tool_rc_args += f", supported_types_desc='{_join_types_desc(desc_parts)}'"
+            tool_desc_parts: list[str] = ["text"]
             if config.image_support:
-                tool_rc_args += ", support_images=true"
+                tool_desc_parts.append("image")
             if config.audio_support:
-                tool_rc_args += ", support_audio=true"
+                tool_desc_parts.append("audio")
+            tool_types_desc = _join_types_desc(tool_desc_parts)
+            tool_rc = _render_content_call(
+                config=config,
+                content_expr="message['content']",
+                context_name="tool message contents",
+                supported_types_desc=tool_types_desc,
+                support_thinking=False,
+                support_images=config.image_support,
+                support_audio=config.audio_support,
+                initial_prev_img="false",
+            )
             lines.append("        {{- '" + _BEGIN_TOOL_RESULTS + "' -}}")
-            lines.append("        {{- render_content(" + tool_rc_args + ") -}}")
+            lines.append("        {{- " + tool_rc + " -}}")
             lines.append("        {{- '" + _END_TOOL_RESULTS + "' }}")
         else:
             lines.append(

--- a/tests/data/chat_templates/v11.jinja
+++ b/tests/data/chat_templates/v11.jinja
@@ -134,7 +134,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content') -}}
+        {{- render_content(content=message['content'], context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -144,7 +144,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -181,7 +181,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v11_audio.jinja
+++ b/tests/data/chat_templates/v11_audio.jinja
@@ -144,7 +144,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -154,7 +154,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -191,7 +191,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_audio=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v11_image.jinja
+++ b/tests/data/chat_templates/v11_image.jinja
@@ -147,7 +147,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -157,7 +157,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -194,7 +194,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13.jinja
+++ b/tests/data/chat_templates/v13.jinja
@@ -135,7 +135,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content') -}}
+        {{- render_content(content=user_content, context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -145,7 +145,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -171,7 +171,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_audio.jinja
+++ b/tests/data/chat_templates/v13_audio.jinja
@@ -140,7 +140,7 @@
             {%- set ns.available_tools_emitted = true %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -150,7 +150,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -176,7 +176,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_audio=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_image.jinja
+++ b/tests/data/chat_templates/v13_image.jinja
@@ -143,7 +143,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -153,7 +153,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -179,7 +179,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_image_think.jinja
+++ b/tests/data/chat_templates/v13_image_think.jinja
@@ -170,7 +170,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -180,7 +180,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -206,7 +206,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v13_think.jinja
+++ b/tests/data/chat_templates/v13_think.jinja
@@ -162,7 +162,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -172,7 +172,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -198,7 +198,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15.jinja
+++ b/tests/data/chat_templates/v15.jinja
@@ -151,7 +151,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content') -}}
+        {{- render_content(content=user_content, context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -161,7 +161,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -183,13 +183,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- render_content(content=message['content'], context_name='tool message contents') -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_audio.jinja
+++ b/tests/data/chat_templates/v15_audio.jinja
@@ -148,7 +148,7 @@
             {%- set ns.available_tools_and_settings_emitted = true %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -158,7 +158,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -180,13 +180,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and audio', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text and audio', support_audio=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text and audio', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text and audio', support_audio=true) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_image.jinja
+++ b/tests/data/chat_templates/v15_image.jinja
@@ -159,7 +159,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -169,7 +169,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -191,13 +191,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text and image', support_images=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_image_think.jinja
+++ b/tests/data/chat_templates/v15_image_think.jinja
@@ -186,7 +186,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_thinking=false, support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -196,7 +196,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true, support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -218,13 +218,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents', supported_types_desc='text and image', support_images=true) -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text and image', support_thinking=false, support_images=true) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_thinking=false, support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_thinking=false, support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v15_think.jinja
+++ b/tests/data/chat_templates/v15_think.jinja
@@ -178,7 +178,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text and thinking content. #}
@@ -188,7 +188,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text and thinking', support_thinking=true) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -210,13 +210,13 @@
     {#- Tool messages (multimodal). #}
     {%- elif message['role'] == 'tool' %}
         {{- '[TOOL_RESULTS]' -}}
-        {{- render_content(message['content'], 'tool message contents') -}}
+        {{- render_content(content=message['content'], context_name='tool message contents', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/TOOL_RESULTS]' }}
 
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_thinking=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_thinking=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v2.jinja
+++ b/tests/data/chat_templates/v2.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -170,7 +170,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
             {{- eos_token }}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 and ns.index > ns.max_idx_user %}
             {{- '[TOOL_CALLS][' }}

--- a/tests/data/chat_templates/v2_spm.jinja
+++ b/tests/data/chat_templates/v2_spm.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -178,7 +178,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
             {{- eos_token }}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 and ns.index > ns.max_idx_user %}
             {%- if ns.add_space %}

--- a/tests/data/chat_templates/v3.jinja
+++ b/tests/data/chat_templates/v3.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -174,7 +174,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/data/chat_templates/v3_image.jinja
+++ b/tests/data/chat_templates/v3_image.jinja
@@ -157,7 +157,7 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {%- elif message['content'] | length > 0 %}
             {#- When content has exactly one image and one text block, put image first. #}
             {%- if message['content'] | length == 2 and message['content'][0]['type'] == 'text' and message['content'][1]['type'] in ['image', 'image_url'] %}
@@ -165,7 +165,7 @@
             {%- else %}
                 {%- set blocks = message['content'] %}
             {%- endif %}
-            {{- render_content(blocks, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+            {{- render_content(content=blocks, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -182,7 +182,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}

--- a/tests/data/chat_templates/v3_image_spm.jinja
+++ b/tests/data/chat_templates/v3_image_spm.jinja
@@ -169,7 +169,7 @@
 
 
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
         {%- elif message['content'] | length > 0 %}
             {#- When content has exactly one image and one text block, put image first. #}
             {%- if message['content'] | length == 2 and message['content'][0]['type'] == 'text' and message['content'][1]['type'] in ['image', 'image_url'] %}
@@ -177,7 +177,7 @@
             {%- else %}
                 {%- set blocks = message['content'] %}
             {%- endif %}
-            {{- render_content(blocks, 'user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
+            {{- render_content(content=blocks, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -198,7 +198,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false, initial_prev_img=false) -}}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
             {%- if ns.add_space %}
                 {%- set ns.add_space=false %}

--- a/tests/data/chat_templates/v3_spm.jinja
+++ b/tests/data/chat_templates/v3_spm.jinja
@@ -155,9 +155,9 @@
             {{- system_message + '\n\n' }}
         {%- endif %}
         {%- if message['content'] is string %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- elif message['content'] | length > 0 %}
-            {{- render_content(message['content'], 'user message content') -}}
+            {{- render_content(content=message['content'], context_name='user message content') -}}
         {%- else %}
             {{- raise_exception('User message must have a string or a list of chunks in content') }}
         {%- endif %}
@@ -178,7 +178,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- elif message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
             {%- if ns.add_space %}
                 {%- set ns.add_space=false %}

--- a/tests/data/chat_templates/v7.jinja
+++ b/tests/data/chat_templates/v7.jinja
@@ -134,7 +134,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content') -}}
+        {{- render_content(content=message['content'], context_name='user message content') -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -144,7 +144,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -185,7 +185,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_audio.jinja
+++ b/tests/data/chat_templates/v7_audio.jinja
@@ -144,7 +144,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(message['content'], 'user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
+        {{- render_content(content=message['content'], context_name='user message content', supported_types_desc='text, input_audio and audio_url', support_audio=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -154,7 +154,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_audio=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_audio=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -195,7 +195,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_audio=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_audio=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_image.jinja
+++ b/tests/data/chat_templates/v7_image.jinja
@@ -147,7 +147,7 @@
             {%- set user_content = message['content'] %}
         {%- endif %}
         {{- '[INST]' -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true) -}}
         {{- '[/INST]' }}
 
     {#- Assistant messages supports text content. #}
@@ -157,7 +157,7 @@
         {%- endif %}
 
         {%- if message['content'] %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -198,7 +198,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT]' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_image_spm.jinja
+++ b/tests/data/chat_templates/v7_image_spm.jinja
@@ -155,7 +155,7 @@
             {%- set inst_tag = '[INST] ' %}
         {%- endif %}
         {{- inst_tag -}}
-        {{- render_content(user_content, 'user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
+        {{- render_content(content=user_content, context_name='user message content', supported_types_desc='text, image and image_url', support_images=true, initial_prev_img=not added_sp) -}}
         {{- '[/INST]' }}
         {%- if loop.index < loop.length %}
             {%- set ns.add_space=true %}
@@ -173,7 +173,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents', supported_types_desc='text', support_images=false) -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents', supported_types_desc='text', support_images=false, initial_prev_img=false) -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -226,7 +226,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT] ' -}}
-        {{- render_content(message['content'], 'system message contents', supported_types_desc='text', support_images=false) -}}
+        {{- render_content(content=message['content'], context_name='system message contents', supported_types_desc='text', support_images=false, initial_prev_img=false) -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/data/chat_templates/v7_spm.jinja
+++ b/tests/data/chat_templates/v7_spm.jinja
@@ -134,7 +134,7 @@
             {{- available_tools }}
         {%- endif %}
         {{- '[INST] ' -}}
-        {{- render_content(message['content'], 'user message content') -}}
+        {{- render_content(content=message['content'], context_name='user message content') -}}
         {{- '[/INST]' }}
         {%- if loop.index < loop.length %}
             {%- set ns.add_space=true %}
@@ -152,7 +152,7 @@
                 {{- ' ' }}
                 {%- set ns.add_space=false %}
             {%- endif %}
-            {{- render_content(message['content'], 'assistant message contents') -}}
+            {{- render_content(content=message['content'], context_name='assistant message contents') -}}
         {%- endif %}
 
         {%- if message['tool_calls'] is defined and message['tool_calls'] is not none and message['tool_calls']|length > 0 %}
@@ -205,7 +205,7 @@
     {#- System messages. #}
     {%- elif message['role'] == 'system' %}
         {{- '[SYSTEM_PROMPT] ' -}}
-        {{- render_content(message['content'], 'system message contents') -}}
+        {{- render_content(content=message['content'], context_name='system message contents') -}}
         {{- '[/SYSTEM_PROMPT]' -}}
 
     {#- Raise exception for unsupported roles. #}

--- a/tests/integrations/chat_templates/unit/test_template_generation.py
+++ b/tests/integrations/chat_templates/unit/test_template_generation.py
@@ -3,7 +3,11 @@ from typing import Any
 import pytest
 
 from mistral_common.integrations.chat_templates.chat_templates import generate_chat_template
-from mistral_common.integrations.chat_templates.template_generator import TemplateConfig, build_chat_template
+from mistral_common.integrations.chat_templates.template_generator import (
+    TemplateConfig,
+    _render_content_call,
+    build_chat_template,
+)
 from mistral_common.tokens.tokenizers.base import TokenizerVersion
 from tests.integrations.chat_templates.helpers import TestConfig, _load_golden_template, _make_config, render_template
 
@@ -193,3 +197,228 @@ class TestMessageContentValidation:
 
         with pytest.raises(ValueError, match="Only text chunks are supported in assistant message contents"):
             render_template(template, messages)
+
+
+class TestRenderContentCall:
+    r"""Unit tests for `_render_content_call` helper."""
+
+    def test_minimal_text_only_config(self) -> None:
+        """Text-only config emits only content and context_name."""
+        config = TemplateConfig(version=TokenizerVersion.v7)
+        result = _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="user message content",
+            supported_types_desc="text",
+            support_thinking=False,
+            support_images=False,
+            support_audio=False,
+        )
+        assert result == "render_content(content=message['content'], context_name='user message content')"
+
+    @pytest.mark.parametrize(
+        ("config", "call_kwargs", "present", "absent"),
+        [
+            pytest.param(
+                TemplateConfig(version=TokenizerVersion.v13, thinking_support=True),
+                {
+                    "content_expr": "message['content']",
+                    "context_name": "assistant message contents",
+                    "supported_types_desc": "text and thinking",
+                    "support_thinking": True,
+                    "support_images": False,
+                    "support_audio": False,
+                },
+                [
+                    "content=message['content']",
+                    "context_name='assistant message contents'",
+                    "supported_types_desc='text and thinking'",
+                    "support_thinking=true",
+                ],
+                ["support_images", "support_audio"],
+                id="thinking_assistant",
+            ),
+            pytest.param(
+                TemplateConfig(version=TokenizerVersion.v7, image_support=True),
+                {
+                    "content_expr": "user_content",
+                    "context_name": "user message content",
+                    "supported_types_desc": "text, image and image_url",
+                    "support_thinking": False,
+                    "support_images": True,
+                    "support_audio": False,
+                },
+                ["support_images=true", "supported_types_desc='text, image and image_url'"],
+                ["support_thinking", "support_audio"],
+                id="image_user",
+            ),
+            pytest.param(
+                TemplateConfig(version=TokenizerVersion.v7, audio_support=True),
+                {
+                    "content_expr": "message['content']",
+                    "context_name": "user message content",
+                    "supported_types_desc": "text, input_audio and audio_url",
+                    "support_thinking": False,
+                    "support_images": False,
+                    "support_audio": True,
+                },
+                ["support_audio=true", "supported_types_desc='text, input_audio and audio_url'"],
+                ["support_thinking", "support_images"],
+                id="audio_user",
+            ),
+        ],
+    )
+    def test_feature_config_emits_correct_args(
+        self,
+        config: TemplateConfig,
+        call_kwargs: dict,
+        present: list[str],
+        absent: list[str],
+    ) -> None:
+        """Feature-specific config emits the expected args and omits absent ones."""
+        result = _render_content_call(config=config, **call_kwargs)
+        for substring in present:
+            assert substring in result
+        for substring in absent:
+            assert substring not in result
+
+    def test_exact_thinking_image_assistant(self) -> None:
+        """Full exact-string check for thinking+image config at assistant site."""
+        config = TemplateConfig(version=TokenizerVersion.v13, thinking_support=True, image_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="assistant message contents",
+            supported_types_desc="text and thinking",
+            support_thinking=True,
+            support_images=False,
+            support_audio=False,
+        )
+        assert result == (
+            "render_content("
+            "content=message['content'], "
+            "context_name='assistant message contents', "
+            "supported_types_desc='text and thinking', "
+            "support_thinking=true, "
+            "support_images=false)"
+        )
+
+    def test_exact_spm_image_user(self) -> None:
+        """Full exact-string check for SPM+image config at user site."""
+        config = TemplateConfig(version=TokenizerVersion.v3, spm=True, image_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="user_content",
+            context_name="user message content",
+            supported_types_desc="text, image and image_url",
+            support_thinking=False,
+            support_images=True,
+            support_audio=False,
+            initial_prev_img="not added_sp",
+        )
+        assert result == (
+            "render_content("
+            "content=user_content, "
+            "context_name='user message content', "
+            "supported_types_desc='text, image and image_url', "
+            "support_images=true, "
+            "initial_prev_img=not added_sp)"
+        )
+
+    def test_tool_ban_thinking_not_in_desc(self) -> None:
+        """Tool call site with thinking config must have support_thinking=false and no 'thinking' in desc."""
+        config = TemplateConfig(version=TokenizerVersion.v15, thinking_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="tool message contents",
+            supported_types_desc="text",
+            support_thinking=False,
+            support_images=False,
+            support_audio=False,
+        )
+        assert "support_thinking=false" in result
+        # The supported_types_desc must not mention thinking
+        desc_value = result.split("supported_types_desc='")[1].split("'")[0]
+        assert "thinking" not in desc_value
+
+    def test_arg_order_matches_macro_declaration(self) -> None:
+        """Args follow macro-declared order: content, context_name, supported_types_desc, support_thinking, support_images."""  # noqa: E501
+        config = TemplateConfig(version=TokenizerVersion.v13, thinking_support=True, image_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="assistant message contents",
+            supported_types_desc="text and thinking",
+            support_thinking=True,
+            support_images=False,
+            support_audio=False,
+        )
+        idx_content = result.index("content=")
+        idx_context = result.index("context_name=")
+        idx_desc = result.index("supported_types_desc=")
+        idx_thinking = result.index("support_thinking=")
+        idx_images = result.index("support_images=")
+        assert idx_content < idx_context < idx_desc < idx_thinking < idx_images
+
+    def test_image_config_emits_support_images(self) -> None:
+        """Image config emits support_images, no support_thinking or support_audio."""
+        config = TemplateConfig(version=TokenizerVersion.v7, image_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="user_content",
+            context_name="user message content",
+            supported_types_desc="text, image and image_url",
+            support_thinking=False,
+            support_images=True,
+            support_audio=False,
+        )
+        assert "support_images=true" in result
+        assert "support_thinking" not in result
+        assert "support_audio" not in result
+
+    def test_spm_image_emits_initial_prev_img(self) -> None:
+        """SPM+image config emits initial_prev_img."""
+        config = TemplateConfig(version=TokenizerVersion.v3, spm=True, image_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="user_content",
+            context_name="user message content",
+            supported_types_desc="text, image and image_url",
+            support_thinking=False,
+            support_images=True,
+            support_audio=False,
+            initial_prev_img="not added_sp",
+        )
+        assert "initial_prev_img=not added_sp" in result
+
+    def test_non_spm_does_not_emit_initial_prev_img(self) -> None:
+        """Non-SPM image config does not emit initial_prev_img."""
+        config = TemplateConfig(version=TokenizerVersion.v7, image_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="user_content",
+            context_name="user message content",
+            supported_types_desc="text, image and image_url",
+            support_thinking=False,
+            support_images=True,
+            support_audio=False,
+        )
+        assert "initial_prev_img" not in result
+
+    def test_audio_config_emits_support_audio(self) -> None:
+        """Audio config emits support_audio and supported_types_desc, no image or thinking."""
+        config = TemplateConfig(version=TokenizerVersion.v7, audio_support=True)
+        result = _render_content_call(
+            config=config,
+            content_expr="message['content']",
+            context_name="user message content",
+            supported_types_desc="text, input_audio and audio_url",
+            support_thinking=False,
+            support_images=False,
+            support_audio=True,
+        )
+        assert "support_audio=true" in result
+        assert "supported_types_desc='text, input_audio and audio_url'" in result
+        assert "support_thinking" not in result
+        assert "support_images" not in result

--- a/tests/integrations/chat_templates/unit/test_v15.py
+++ b/tests/integrations/chat_templates/unit/test_v15.py
@@ -435,6 +435,62 @@ class TestV15MultimodalContent:
         with pytest.raises(ValueError, match="Only text chunks are supported in system message contents"):
             render_template(template, messages)
 
+    def test_v15_image_think_template_rejects_think_in_tool(self) -> None:
+        r"""V15 image+think template raises when a thinking chunk appears in tool message content."""
+        template = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v15,
+            image_support=True,
+            audio_support=False,
+            thinking_support=True,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+
+        tools = [{"type": "function", "function": {"name": "fn", "description": "test", "parameters": {}}}]
+
+        messages_with_think: list[dict[str, Any]] = [
+            {"role": "user", "content": "Use tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "test12345", "function": {"name": "fn", "arguments": "{}"}}],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "thinking", "thinking": "secret reasoning"},
+                    {"type": "text", "text": "result"},
+                ],
+                "tool_call_id": "test12345",
+            },
+        ]
+
+        with pytest.raises(ValueError, match="tool message contents") as excinfo:
+            render_template(template, messages_with_think, tools=tools)
+        assert "secret reasoning" not in str(excinfo.value)
+
+        messages_text_only: list[dict[str, Any]] = [
+            {"role": "user", "content": "Use tool"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "test12345", "function": {"name": "fn", "arguments": "{}"}}],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    {"type": "text", "text": "result"},
+                    {"type": "image_url", "image_url": "http://example.com/img.png"},
+                ],
+                "tool_call_id": "test12345",
+            },
+        ]
+
+        output = render_template(template, messages_text_only, tools=tools)
+        assert "result" in output
+
     def test_pre_v15_image_template_rejects_image_in_tool(self) -> None:
         r"""Pre-V15 image template rejects image chunks in tool message content."""
         template = generate_chat_template(


### PR DESCRIPTION
## What

Refactors the chat-template generator so every `render_content(...)` macro call passes all its arguments explicitly as keywords, via a single `_render_content_call(...)` helper. Replaces the ad-hoc per-site argument string-building in the system/user/assistant/tool handlers.

## Why

Call sites previously relied on Jinja's implicit `undefined` for omitted macro args, and each site rebuilt the argument string by hand. Centralizing this in one helper makes the emitted arguments explicit, ordered, and consistent, and removes duplication.

## Behavior

Pure refactor — rendered template output is unchanged vs `main`. Only the generated `.jinja` text changes (args become keyword form / explicit), so the golden fixtures under `tests/data/chat_templates/` are regenerated to match.

Note: the tool-message call passes `support_thinking=false` (and does not add `thinking` to its supported types), preserving `main`'s behavior — tool messages continue to reject thinking chunks at the template level (the macro raises).

## Tests

- Unit tests for `_render_content_call` (minimal/full/tool-ban/ordering/spm cases), including exact-string assertions locking argument order and formatting.
- New test asserting a v15 (image+think) template raises `ValueError` when a tool message dict carries a thinking chunk, and does not leak the thinking text into the error.
- Regenerated goldens verified by the existing parity suite (`test_dynamic_matches_static`, plus rendered-output parity tests).
- `pytest tests/integrations/chat_templates`, `ruff check`, `ruff format --check`, `mypy` all pass.