### PR TITLE
Reject thinking chunks in tool messages

### DIFF
--- a/src/mistral_common/protocol/instruct/messages.py
+++ b/src/mistral_common/protocol/instruct/messages.py
@@ -370,14 +370,13 @@ class ToolMessage(BaseMessage):
     # Deprecated in V3 tokenization
     name: str | None = None
 
-    # Tool messages accept all content chunk types.
+    # Tool messages do not accept thinking chunks.
     _allowed_content_chunks: ClassVar[tuple[type[BaseContentChunk], ...]] = (
         TextChunk,
         ImageChunk,
         ImageURLChunk,
         AudioChunk,
         AudioURLChunk,
-        ThinkChunk,
     )
 
     def to_openai(self) -> dict[str, Any]:

--- a/src/mistral_common/protocol/instruct/validator.py
+++ b/src/mistral_common/protocol/instruct/validator.py
@@ -586,7 +586,7 @@ class MistralRequestValidatorV15(MistralRequestValidatorV13):
         _validate_content_chunk_types(content, (TextChunk, AudioChunk), "system", InvalidSystemPromptException)
 
     def _validate_tool_content_chunks(self, content: str | Sequence[ContentChunk] | None) -> None:
-        r"""v15 tool messages accept all content chunk types."""
+        r"""v15 tool messages accept all content chunk types except thinking (rejected at ToolMessage model level)."""
         return
 
     def _validate_model_settings(self, request: ChatCompletionRequest) -> None:

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -37,8 +37,12 @@ class TestMessageContentChunkUnions:
             with pytest.raises(ValidationError):
                 SystemMessage(content=_chunks((name,)))
 
-    def test_tool_allows_all_chunk_types(self) -> None:
+    def test_tool_allows_non_thinking_chunk_types(self) -> None:
         ToolMessage(
-            content=_chunks(("text", "image", "image_url", "audio", "audio_url", "think")),
+            content=_chunks(("text", "image", "image_url", "audio", "audio_url")),
             tool_call_id="c1",
         )
+
+    def test_tool_rejects_think(self) -> None:
+        with pytest.raises(ValidationError):
+            ToolMessage(content=_chunks(("think",)), tool_call_id="c1")

--- a/tests/validation/test_chat_validation.py
+++ b/tests/validation/test_chat_validation.py
@@ -422,7 +422,8 @@ class TestChatValidation:
                 )
 
     def test_rejects_non_text_in_tool(self, validator_base: MistralRequestValidator) -> None:
-        for name in ("image", "image_url", "audio", "audio_url", "think"):
+        # "think" is rejected at the Pydantic model level (ToolMessage construction), not by the validator.
+        for name in ("image", "image_url", "audio", "audio_url"):
             with pytest.raises(InvalidToolMessageException, match="Unexpected content chunk types in tool message"):
                 validator_base.validate_messages(_tool_convo(get_content_chunks((name,))), continue_final_message=False)
 
@@ -727,7 +728,8 @@ class TestChatValidationV13:
         validator_v13.validate_messages(_assistant_convo(content), continue_final_message=False)
 
     def test_rejects_non_text_in_tool(self, validator_v13: MistralRequestValidatorV13) -> None:
-        for name in ("image", "image_url", "audio", "audio_url", "think"):
+        # "think" is rejected at the Pydantic model level (ToolMessage construction), not by the validator.
+        for name in ("image", "image_url", "audio", "audio_url"):
             with pytest.raises(InvalidToolMessageException, match="Unexpected content chunk types in tool message"):
                 validator_v13.validate_messages(_tool_convo(get_content_chunks((name,))), continue_final_message=False)
 
@@ -751,6 +753,7 @@ class TestChatValidationV15:
                     _system_convo(get_content_chunks((name,))), continue_final_message=False
                 )
 
-    def test_allows_all_chunk_types_in_tool(self, validator_v15: MistralRequestValidatorV15) -> None:
-        content = get_content_chunks(("text", "image", "image_url", "audio", "audio_url", "think"))
+    def test_allows_non_thinking_chunk_types_in_tool(self, validator_v15: MistralRequestValidatorV15) -> None:
+        # ThinkChunk is rejected at the Pydantic model level before reaching the validator.
+        content = get_content_chunks(("text", "image", "image_url", "audio", "audio_url"))
         validator_v15.validate_messages(_tool_convo(content), continue_final_message=False)


### PR DESCRIPTION
## What

Removes `ThinkChunk` from `ToolMessage._allowed_content_chunks` so a `ToolMessage` whose content carries a thinking chunk now raises a `pydantic.ValidationError` at construction, for **all** tokenizer versions.

## Why

Tool messages should never have carried thinking. Previously the `ToolMessage` model accepted `ThinkChunk` and the v15 request validator let it pass (`_validate_tool_content_chunks` was a no-op), so a thinking chunk in a tool result could slip through at the mistral-common API level. Banning it at the Pydantic model level is the earliest, strongest guard and covers every version uniformly.

## Behavior

- `ToolMessage(content=[ThinkChunk(...)], ...)` → `ValidationError` (all versions).
- `SystemMessage` and `AssistantMessage` still allow thinking chunks (unchanged).
- Validator / normalizer / tokenizer paths are intentionally left as-is: they are unreachable for thinking once the model rejects it. The v15 validator docstring is updated to note the model-level gate.

## Tests

- `tests/test_messages.py`: `test_tool_rejects_think` (new) asserts construction raises; the allowed-chunks test drops `think`.
- `tests/validation/test_chat_validation.py`: pre-v15/v13 tool-rejection loops drop `think` (now rejected at construction, not validation); the v15 test that wrongly asserted tool thinking was allowed is corrected.
- Full non-integration suite, integration suite, doctests, `ruff`, and `mypy` all pass.

## Related

Complements #274 (which keeps the chat-template-level ban for the raw-dict / HF entry point). This PR is independent — it touches `messages.py`, not the template generator.