### PR TITLE
Fix documentation drift from code

### DIFF
--- a/docs/usage/experimental.md
+++ b/docs/usage/experimental.md
@@ -72,7 +72,7 @@ The Swagger UI provides interactive documentation for all available endpoints.
 
 #### Tokenize Request
 
-- **Route**: `/tokenize/request`
+- **Route**: `/v1/tokenize/`
 - **Method**: POST
 - **Description**: Tokenizes a chat completion request
 - **Request Body**: 
@@ -93,7 +93,7 @@ from mistral_common.protocol.instruct.messages import SystemMessage, UserMessage
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
 
 # Simple request
-response = requests.post("http://localhost:8000/v1/tokenize/request", json={
+response = requests.post("http://localhost:8000/v1/tokenize/", json={
     "messages": [
         {"role": "user", "content": "Hello, how are you?"}
     ]
@@ -126,7 +126,7 @@ system_message = SystemMessage(
 
 
 response = requests.post(
-    "http://localhost:8000/v1/tokenize/request",
+    "http://localhost:8000/v1/tokenize/",
     json=jsonable_encoder(
         ChatCompletionRequest(messages=[
             system_message,
@@ -142,7 +142,7 @@ print(response.json())
 
 #### Detokenize to Assistant Message
 
-- **Route**: `/detokenize/`
+- **Route**: `/v1/detokenize/`
 - **Method**: POST
 - **Description**: Converts tokens to an assistant message with tool call parsing
 - **Request Body**: 
@@ -180,7 +180,7 @@ print(response.json())
 
 #### Detokenize to String
 
-- **Route**: `/detokenize/string`
+- **Route**: `/v1/detokenize/string`
 - **Method**: POST
 - **Description**: Converts tokens to a raw string
 - **Request Body**:

--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -12,6 +12,7 @@ We propose different dependencies to install depending on your needs:
 - `audio`: to use the audio tokenizers.
 - `hf-hub`: to download the tokenizers from the Hugging Face Hub.
 - `sentencepiece`: to allow the use of SentencePiece tokenizers. This is now optional as we only release `Tekken` tokenizers for recent models.
+- `guidance`: to use the grammar-based guided generation feature.
 - \[Experimental\] `server`: to use our tokenizers in a server mode.
 
 Each dependency is optional and can be installed separately or all together using the following commands:
@@ -20,8 +21,9 @@ pip install "mistral-common[image]"
 pip install "mistral-common[audio]"
 pip install "mistral-common[hf-hub]"
 pip install "mistral-common[sentencepiece]"
+pip install "mistral-common[guidance]"
 pip install "mistral-common[server]"
-pip install "mistral-common[image,audio,hf-hub,sentencepiece,server]"
+pip install "mistral-common[image,audio,hf-hub,sentencepiece,guidance,server]"
 ```
 
 ## From source

--- a/docs/usage/tokenizers.md
+++ b/docs/usage/tokenizers.md
@@ -32,7 +32,7 @@ tokenizer.encode_chat_completion(chat_completion).tokens
 We provide three layer of abstraction for our tokenizers:
 
 - [Tekkenizer][mistral_common.tokens.tokenizers.tekken.Tekkenizer] or [SentencePieceTokenizer][mistral_common.tokens.tokenizers.sentencepiece.SentencePieceTokenizer]: raw tokenizers to handle raw data to convert them into ids and vice versa.
-- [InstructTokenizer][mistral_common.tokens.tokenizers.instruct.InstructTokenizer]: instruct tokenizers that wrap the raw tokenizers to add several helper methods for the different tasks (chat completion or FIM). They are versioned.
+- [InstructTokenizer][mistral_common.tokens.tokenizers.base.InstructTokenizer]: instruct tokenizers that wrap the raw tokenizers to add several helper methods for the different tasks (chat completion or FIM). They are versioned.
 - [MistralTokenizer][mistral_common.tokens.tokenizers.mistral.MistralTokenizer]: mistral tokenizers that validate the requests, see [requests section](./requests.md), and call the instruct tokenizers.
 
 For instance, you can directly load the [Tekkenizer][mistral_common.tokens.tokenizers.tekken.Tekkenizer]:

--- a/docs/usage/tools.md
+++ b/docs/usage/tools.md
@@ -102,6 +102,7 @@ from mistral_common.protocol.instruct.tool_calls import (
     Tool,
     ToolCall,
 )
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 request = ChatCompletionRequest(
     messages=[


### PR DESCRIPTION
## Summary

Audited the hand-written docs against the current code and fixed the discrepancies found. The API reference pages auto-generate from docstrings via `docs/gen_api_pages.py`, so only the manual docs had drifted.

## Changes

- **docs/usage/experimental.md** — corrected 5 API routes to match `experimental/app/routers.py`:
  - `/tokenize/request` → `/v1/tokenize/` (header + 2 example URLs; the `/request` suffix does not exist and those calls would 404)
  - `/detokenize/` → `/v1/detokenize/` (header)
  - `/detokenize/string` → `/v1/detokenize/string` (header)
- **docs/usage/install.md** — added the missing `guidance` extra (defined in `pyproject.toml`) to the extras list, individual install command, and combined example.
- **docs/usage/tools.md** — added the missing `from mistral_common.tokens.tokenizers.mistral import MistralTokenizer` import to the "Putting it all together" snippet.
- **docs/usage/tokenizers.md** — fixed a broken cross-reference: `InstructTokenizer` is defined in `base.py`, not `instruct.py`.