### PR TITLE
chore: trim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,103 +11,27 @@ It encodes requests for Instruct, Transcription or Fill-In-The-Middle (FIM) task
 - Type checker: mypy
 - CI: GitHub Actions
 
-## Project Structure
+## Layout
 
-```
-mistral-common/
-├── src/
-│   └── mistral_common/
-│       ├── guidance/
-│       ├── integrations/
-│       ├── protocol/
-│       ├── tokens/
-│       └── ...
-├── scripts/
-├── tests/
-├── docs/
-├── .github/
-├── .pre-commit-config.yaml
-├── pyproject.toml
-└── README.md
-```
+- `src/mistral_common/protocol/<instruct|fim|transcription|speech>/request.py` — the request
+  types are the entry points for user queries.
+- `src/mistral_common/tokens/tokenizers/` — `mistral.py` normalizes and validates a request, then
+  delegates to `instruct.py`. Backends: `tekken.py` (all recent models) and `sentencepiece.py`.
+- `src/mistral_common/guidance/` — Lark grammars for tool calls, JSON schema and reasoning,
+  built with llguidance from Jinja templates in `guidance/data/`.
+- `src/mistral_common/integrations/chat_templates/` — HuggingFace chat-template generation;
+  public API is `generate_chat_template`.
+- `src/mistral_common/experimental/` — unstable, includes a FastAPI app under `app/`.
 
-### Root-level files in src/mistral_common/
-- `audio.py`: Audio processing utilities including Audio class and mel-scale conversions
-- `base.py`: Base Pydantic model configuration
-- `deprecation.py`: Deprecation utilities (`deprecated_import`, `warn_once`) for emitting one-shot warnings on moved or removed symbols
-- `exceptions.py`: Custom exception classes for the library
-- `image.py`: Image processing utilities including download and serialization
-- `imports.py`: Import utilities and dependency checks
-- `multimodal.py`: Multimodal processing utilities deprecated in favor to `image.py`
+Deprecated shims — re-export only, do not add to them:
 
-### Protocol
-- `src/mistral_common/protocol/`: Protocol handling
-  - `instruct/`: Instruct protocol
-    - `chunk.py`: Chunks content used by messages
-    - `converters.py`: Converter helpers between `ChatCompletionRequest` and `Openai` requests
-    - `messages.py`: Instruct messages definition
-    - `normalize.py`: Normalizers for `ChatCompletionRequest`
-    - `request.py`: Definition of `ChatCompletionRequest`. This is the entry point of user queries for Instruct requests
-    - `tool_calls.py`: Tool calling logic
-    - `validator.py`: Validators for `ChatCompletionRequest`
-  - `fim/`: Fill-in-the-middle protocol
-    - `request.py`: Definition of `FIMRequest`. This is the entry point of user queries for FIM requests
-  - `transcription/`: Transcription protocol
-    - `request.py`: Definition of `TranscriptionRequest`. This is the entry point of user queries for Transcription requests
-  - `speech/`: Speech protocol
-    - `request.py`: Definition of `SpeechRequest`. This is the entry point of user queries for Speech requests
-  - `base.py`: Definition of `BaseCompletionRequest` subclassed by FIM and Instruct requests
-  - `utils.py`: Utility functions
+| Shim | Use instead |
+|---|---|
+| `mistral_common/multimodal.py` | `mistral_common/image.py` |
+| `tokens/tokenizers/multimodal.py` | `tokens/tokenizers/image.py` |
 
-### Tokenization
-- `src/mistral_common/tokens/`: Tokenization
-  - `tokenizers/`: Tokenizer implementations
-    - `audio.py`: Audio processing
-    - `base.py`: Base Tokenizer implementation
-    - `image.py`: Image processing
-    - `instruct.py`: Instruct Tokenizer that encodes requests via Tekken tokenizer
-    - `mistral.py`: Mistral Tokenizer that normalizes and validates requests to pass them to an instruct tokenizer
-    - `model_settings_builder.py`: Builders (`FieldBuilder`, `EnumBuilder`, `ModelSettingsBuilder`) for validating and constructing model settings
-    - `multimodal.py`: deprecated in favor of `image.py`
-    - `sentencepiece.py`: Sentence Piece tokenizer (deprecated)
-    - `tekken.py`: Tekken tokenizer used by all recent models
-    - `utils.py`: Utility functions for the tokenizers
-  - `instruct/`: deprecated in favor of `src/mistral_common/protocol/instruct/request.py`
-
-### Guidance (Grammar)
-- `src/mistral_common/guidance/`: Creates Lark grammars for tool calls, JSON schema and reasoning using llguidance
-  - `grammar_factory.py`: `GrammarFactory` that builds and renders Lark grammars from Jinja templates
-  - `tokenizer.py`: Adapts Tekken tokenizer for llguidance
-  - `data/`: Jinja-templated Lark grammar files for base, thinking (special tokens) and thinking (plain text) modes
-
-### Integrations
-- `src/mistral_common/integrations/`: Third-party framework integrations
-  - `chat_templates/`: Chat template generation for HuggingFace Transformers
-    - `chat_templates.py`: Public API for generating chat templates (`generate_chat_template`)
-    - `template_generator.py`: Core template generation engine with `TemplateConfig` and `build_chat_template`
-
-### Scripts
-- `scripts/generate_chat_template.py`: CLI for generating and saving chat templates
-
-## Experimental
-- `src/mistral_common/experimental/`: Experimental features
-  - `utils.py`: Utility functions
-  - `tools.py`: Tool calls parser
-  - `think.py`: Thinking parser
-  - `app/`: FastAPI application
-    - `routers.py`: API routers
-    - `main.py`: Application entry point
-    - `models.py`: Pydantic models
-
-## Data
-- `src/mistral_common/data/`: Data files for tokenizers
-
-### Other files and directories
-- `tests/`: Test suite
-- `docs/`: Documentation
-- `.github/workflows/`: CI/CD workflows
-- `.pre-commit-config.yaml`: Pre-commit hooks
-- `pyproject.toml`: Project configuration
+`sentencepiece.py` is the legacy backend, not deprecated: it is still the real implementation for
+v1–v7 models. New work targets `tekken.py`.
 
 ## Code Style Guidelines
 
@@ -144,30 +68,14 @@ mistral-common/
 
 ## Development Workflow
 
-1. Set up using uv
-
 ```bash
 uv sync --frozen --all-extras --group dev --python 3.12
 source .venv/bin/activate
 uv run pre-commit install
 ```
 
-2.  Make Changes
-- Follow code style guidelines
-- Write tests for new functionality
-- Update documentation
-- When adding dependencies, modify root `pyproject.toml`, then run `uv lock` followed by `uv sync --frozen`
-- Backward Compatibility: Don't break existing functionality
-
-3. Run linter, formatter (Ruff), type checker (mypy) and tests (pytest), including doctests
-
-### Commit
-- After adding your changes before committing ensure pre-commit is installed or run it manually.
-- Use imperative grammar, start with a verb and be concise.
-
-## Additional Resources
-
-- [Pydantic Documentation](https://docs.pydantic.dev/latest/)
-- [Ruff Documentation](https://docs.astral.sh/ruff/)
-- [Mypy Documentation](https://mypy.readthedocs.io/)
-- [Pytest Documentation](https://docs.pytest.org/)
+- Adding a dependency: edit the root `pyproject.toml`, then `uv lock` and `uv sync --frozen`.
+- Don't break existing functionality; keep backward compatibility.
+- Before committing, run Ruff (lint + format), mypy, and pytest including doctests, and make sure
+  pre-commit has run.
+- Commit messages: imperative, start with a verb, concise.


### PR DESCRIPTION
AGENTS.md was 173 lines, 97 of which (56%) were a hand-maintained listing of the source tree. Most entries restated the filename (`chunk.py`: Chunks content, `audio.py`: Audio processing, `utils.py`: Utility functions) — an agent can read the tree faster than the listing can be kept accurate.

It had already drifted: it documented `src/mistral_common/tokens/instruct/` as deprecated-in-favour-of `protocol/instruct/request.py`, but **that directory no longer exists**.

## Changes

- Replaced the file-by-file listing with a ~20-line `## Layout` section keeping only what isn't cheap to rediscover: where the per-protocol entry points live, that `mistral.py` normalizes/validates then delegates to `instruct.py`, and the two backends.
- Deprecated shims are now a two-row table (`multimodal.py` → `image.py`). Fixed an imprecision: the two `multimodal.py` shims point at *different* `image.py` modules.
- Corrected `sentencepiece.py`: the old text called it "(deprecated)", but there is no module-level deprecation and it is still the real implementation for v1–v7. Now described as the legacy backend.
- Dropped the stale `tokens/instruct/` row.
- Dropped `## Additional Resources` (links to the Pydantic/Ruff/mypy/pytest homepages).
- Condensed `## Development Workflow` prose; kept the setup commands verbatim.

No behavioural rule was removed — Style, Imports, Type Hints, Error Handling and Docstrings are untouched.

173 → 81 lines.