### PR TITLE
Deprecate Tokenized.text in favor of tokenizer.decode

### DIFF
--- a/docs/examples/inference.md
+++ b/docs/examples/inference.md
@@ -21,6 +21,7 @@ from mistral_common.protocol.instruct.messages import (
     UserMessage,
 )
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 repo_id = "mistralai/Mistral-Large-Instruct-2411"
@@ -40,7 +41,7 @@ tokenized = tokenizer.encode_chat_completion(request)
 print(tokenized.tokens)
 
 # print text to visually see tokens
-print(tokenized.text)
+print(tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP))
 ```
 
 
@@ -57,6 +58,7 @@ from mistral_common.protocol.instruct.messages import (
     UserMessage,
 )
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 repo_id = "mistralai/Mistral-Small-3.2-24B-Instruct-2506"
@@ -88,7 +90,7 @@ print(tokenized.tokens)
 print(tokenized.images)
 
 # print text to visually see tokens
-print(tokenized.text)
+print(tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP))
 ```
 
 ### Function calling
@@ -100,6 +102,7 @@ from mistral_common.protocol.instruct.messages import (
     UserMessage,
 )
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.protocol.instruct.tool_calls import Function, Tool
 
@@ -138,7 +141,7 @@ tokenized = tokenizer.encode_chat_completion(request)
 print(tokenized.tokens)
 
 # print text to visually see tokens
-print(tokenized.text)
+print(tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP))
 ```
 
 ### Audio
@@ -147,6 +150,7 @@ print(tokenized.text)
 from mistral_common.protocol.instruct.chunk import TextChunk, AudioChunk
 from mistral_common.protocol.instruct.messages import UserMessage, AssistantMessage
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.audio import Audio
 from huggingface_hub import hf_hub_download
@@ -173,12 +177,13 @@ print(tokenized.tokens)
 print(tokenized.audios)
 
 # print text to visually see tokens
-print(tokenized.text)
+print(tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP))
 ```
 
 ## FIM
 
 ```python
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.protocol.fim.request import FIMRequest
 
@@ -195,7 +200,7 @@ tokenized = tokenizer.encode_fim(request)
 print(tokenized.tokens)
 
 # print text to visually see tokens
-print(tokenized.text)
+print(tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP))
 ```
 
 
@@ -204,6 +209,7 @@ print(tokenized.text)
 ```python
 from mistral_common.protocol.transcription.request import TranscriptionRequest
 from mistral_common.tokens.tokenizers.audio import Audio
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 from huggingface_hub import hf_hub_download
@@ -223,7 +229,7 @@ print(tokenized.tokens)
 print(tokenized.audios)
 
 # print text to visually see tokens
-print(tokenized.text)
+print(tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP))
 ```
 
 

--- a/docs/usage/images.md
+++ b/docs/usage/images.md
@@ -63,13 +63,15 @@ tokenizer.encode_chat_completion(
         ],
     )
 )
-# Tokenized(tokens=[1, 3, 10, 10, ...], text='<s>[INST][IMG][IMG][IMG][IMG]...', prefix_ids=None, images=[array[[(0.95238595, 0.95238795, 0.95224484, ...,)]]])
+# Tokenized(tokens=[1, 3, 10, 10, ...], prefix_ids=None, images=[array[[(0.95238595, 0.95238795, 0.95224484, ...,)]]], audios=[])
 ```
 
 The output contains:
 
-- the **text**: the string equivalent of the tokens. The image is represented into a sequence of special `[IMG]` tokens with `[IMG_BREAK]` at regular intervals and `[IMG_END]` at the end. An image is a grid and each `[IMG]` represent a patch, the `IMG_BREAK` tokens the end of a row. The `IMG_END` token is used to mark the end of the image.
-- the **tokens**: identifier used by the model for the text. The special tokens of images are not directly used by the model, but replaced by the features of an image encoder.
+- the **tokens**: identifier used by the model for the text. The image is represented into a sequence of special `[IMG]` tokens with `[IMG_BREAK]` at regular intervals and `[IMG_END]` at the end. An image is a grid and each `[IMG]` represent a patch, the `IMG_BREAK` tokens the end of a row. The `IMG_END` token is used to mark the end of the image. The special tokens of images are not directly used by the model, but replaced by the features of an image encoder.
 - the **prefix_ids**: Used for FIM (Fill-In-the-Middle) tasks, here it is `None`.
 - the **images**: the images normalized as a numpy array.
+- the **audios**: the audios associated with the tokens, here it is empty since there is no audio in the request.
+
+To visualize the tokens as text, decode them with `tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)`.
 

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -212,35 +212,17 @@ class Tokenized(MistralBase):
     prefix_ids: list[int] | None = None
     images: list[np.ndarray] = Field(default_factory=list)
     audios: list[Audio] = Field(default_factory=list)
-    _tokenizer: "InstructTokenizer | None" = PrivateAttr(default=None)
-
-    def __eq__(self, other: object) -> bool:
-        r"""Compares only the public fields, matching pydantic's default equality.
-
-        The private `_tokenizer` back-reference used by the deprecated `text` property is not
-        part of the value and must not affect equality.
-        """
-        if other.__class__ is not self.__class__:
-            return NotImplemented
-        return self.__dict__ == other.__dict__
-
-    def __getstate__(self) -> dict[str, Any]:
-        r"""Strips `_tokenizer` so pickling a `Tokenized` never serializes the tokenizer that produced it."""
-        state = super().__getstate__()
-        private = state.get("__pydantic_private__")
-        if private:
-            state["__pydantic_private__"] = {**private, "_tokenizer": None}
-        return state
+    _text: str | None = PrivateAttr(default=None)
 
     @property
     def text(self) -> str | None:
-        r"""Decodes the token ids into a string using the tokenizer that produced them.
+        r"""The text representation of the tokens, decoded with special tokens kept.
 
         Deprecated: Use `tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)`
         instead. Will be removed in 1.13.0.
 
         Returns:
-            The decoded string, or `None` if this `Tokenized` was not produced by a tokenizer.
+            The decoded string, or `None` if it was not set by the tokenizer that produced this `Tokenized`.
         """
         warn_once(
             key="Tokenized.text",
@@ -251,9 +233,7 @@ class Tokenized(MistralBase):
             category=DeprecationWarning,
             stacklevel=2,
         )
-        if self._tokenizer is None:
-            return None
-        return self._tokenizer.decode(tokens=self.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        return self._text
 
 
 class Tokenizer(ABC):

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -5,9 +5,10 @@ from pathlib import Path
 from typing import Any, Generic, TypeVar
 
 import numpy as np
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, PrivateAttr
 
 from mistral_common.base import MistralBase
+from mistral_common.deprecation import warn_once
 from mistral_common.protocol.fim.request import FIMRequest
 from mistral_common.protocol.instruct.chunk import ContentChunk
 from mistral_common.protocol.instruct.messages import (
@@ -198,20 +199,61 @@ class Tokenized(MistralBase):
 
     Attributes:
         tokens: The token ids.
-        text: The text representation of the tokens.
         prefix_ids: The prefix ids for FIM.
         images: The loaded images associated with the tokens.
+        audios: The loaded audio associated with the tokens.
 
     Examples:
-        >>> tokenized = Tokenized(tokens=[1, 2, 3], text="Hello world", prefix_ids=[1], images=[])
+        >>> tokenized = Tokenized(tokens=[1, 2, 3], prefix_ids=[1], images=[], audios=[])
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
     tokens: list[int]
-    text: str | None = None
     prefix_ids: list[int] | None = None
     images: list[np.ndarray] = Field(default_factory=list)
     audios: list[Audio] = Field(default_factory=list)
+    _tokenizer: "InstructTokenizer | None" = PrivateAttr(default=None)
+
+    def __eq__(self, other: object) -> bool:
+        r"""Compares only the public fields, matching pydantic's default equality.
+
+        The private `_tokenizer` back-reference used by the deprecated `text` property is not
+        part of the value and must not affect equality.
+        """
+        if other.__class__ is not self.__class__:
+            return NotImplemented
+        return self.__dict__ == other.__dict__
+
+    def __getstate__(self) -> dict[str, Any]:
+        r"""Strips `_tokenizer` so pickling a `Tokenized` never serializes the tokenizer that produced it."""
+        state = super().__getstate__()
+        private = state.get("__pydantic_private__")
+        if private:
+            state["__pydantic_private__"] = {**private, "_tokenizer": None}
+        return state
+
+    @property
+    def text(self) -> str | None:
+        r"""Decodes the token ids into a string using the tokenizer that produced them.
+
+        Deprecated: Use `tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)`
+        instead. Will be removed in 1.13.0.
+
+        Returns:
+            The decoded string, or `None` if this `Tokenized` was not produced by a tokenizer.
+        """
+        warn_once(
+            key="Tokenized.text",
+            message=(
+                "`text` property of `Tokenized` will be removed in 1.13.0. To decode the token ids, use "
+                "`tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)`."
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        if self._tokenizer is None:
+            return None
+        return self._tokenizer.decode(tokens=self.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
 
 
 class Tokenizer(ABC):

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -225,14 +225,15 @@ class InstructTokenizerBase(
             if tok is not None:
                 tokens.extend(tok)
 
-        return Tokenized(
+        tokenized = Tokenized(
             tokens=tokens,
             prefix_ids=prefix_ids,
             images=images,
             audios=audios,
-            # TODO: remove once 1.13.0 lands.
-            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
         )
+        # TODO: remove once 1.13.0 lands.
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        return tokenized
 
     def decode(self, tokens: list[int], special_token_policy: SpecialTokenPolicy = SpecialTokenPolicy.IGNORE) -> str:
         r"""Decode tokens to a string.
@@ -622,11 +623,10 @@ class InstructTokenizerV2(
             self.PREFIX,
             *prefix_tokens,
         ]
-        return Tokenized(
-            tokens=tokens
-            # TODO: remove once 1.13.0 lands.
-            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
-        )
+        tokenized = Tokenized(tokens=tokens)
+        # TODO: remove once 1.13.0 lands.
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        return tokenized
 
 
 class InstructTokenizerV3(
@@ -1034,12 +1034,13 @@ class InstructTokenizerV7(InstructTokenizerV3):
             tokens += self.tokenizer.encode(language_string, bos=False, eos=False)
 
         tokens.append(self.TRANSCRIBE)
-        return Tokenized(
+        tokenized = Tokenized(
             tokens=tokens,
             audios=audio,
-            # TODO: remove once 1.13.0 lands.
-            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
         )
+        # TODO: remove once 1.13.0 lands.
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        return tokenized
 
     def _encode_audio(self, audio: str | bytes, transcription_delay_ms: float | None = None) -> Tokenized:
         assert self.audio_encoder is not None, (
@@ -1100,12 +1101,13 @@ class InstructTokenizerV7(InstructTokenizerV3):
         else:
             raise ValueError(f"Request must be in streaming mode, got {request.streaming=}")
 
-        return Tokenized(
+        tokenized = Tokenized(
             tokens=tokens,
             audios=audios,
-            # TODO: remove once 1.13.0 lands.
-            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
         )
+        # TODO: remove once 1.13.0 lands.
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        return tokenized
 
     @classmethod
     def validate_messages(cls, messages: list[UATS]) -> None:

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -225,15 +225,14 @@ class InstructTokenizerBase(
             if tok is not None:
                 tokens.extend(tok)
 
-        tokenized = Tokenized(
+        return Tokenized(
             tokens=tokens,
             prefix_ids=prefix_ids,
             images=images,
             audios=audios,
+            # TODO: remove once 1.13.0 lands.
+            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
         )
-        # TODO: remove once 1.13.0 lands.
-        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
-        return tokenized
 
     def decode(self, tokens: list[int], special_token_policy: SpecialTokenPolicy = SpecialTokenPolicy.IGNORE) -> str:
         r"""Decode tokens to a string.
@@ -623,10 +622,11 @@ class InstructTokenizerV2(
             self.PREFIX,
             *prefix_tokens,
         ]
-        tokenized = Tokenized(tokens=tokens)
-        # TODO: remove once 1.13.0 lands.
-        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
-        return tokenized
+        return Tokenized(
+            tokens=tokens
+            # TODO: remove once 1.13.0 lands.
+            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
+        )
 
 
 class InstructTokenizerV3(
@@ -1034,10 +1034,12 @@ class InstructTokenizerV7(InstructTokenizerV3):
             tokens += self.tokenizer.encode(language_string, bos=False, eos=False)
 
         tokens.append(self.TRANSCRIBE)
-        tokenized = Tokenized(tokens=tokens, audios=audio)
-        # TODO: remove once 1.13.0 lands.
-        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
-        return tokenized
+        return Tokenized(
+            tokens=tokens,
+            audios=audio,
+            # TODO: remove once 1.13.0 lands.
+            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
+        )
 
     def _encode_audio(self, audio: str | bytes, transcription_delay_ms: float | None = None) -> Tokenized:
         assert self.audio_encoder is not None, (
@@ -1098,13 +1100,13 @@ class InstructTokenizerV7(InstructTokenizerV3):
         else:
             raise ValueError(f"Request must be in streaming mode, got {request.streaming=}")
 
-        tokenized = Tokenized(
+        return Tokenized(
             tokens=tokens,
             audios=audios,
+            # TODO: remove once 1.13.0 lands.
+            _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
         )
-        # TODO: remove once 1.13.0 lands.
-        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
-        return tokenized
+
 
     @classmethod
     def validate_messages(cls, messages: list[UATS]) -> None:

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -1107,7 +1107,6 @@ class InstructTokenizerV7(InstructTokenizerV3):
             _text=self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP),
         )
 
-
     @classmethod
     def validate_messages(cls, messages: list[UATS]) -> None:
         r"""Validates that system prompts and audio chunks are not used together in v7."""

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -232,7 +232,7 @@ class InstructTokenizerBase(
             audios=audios,
         )
         # TODO: remove once 1.13.0 lands.
-        tokenized._tokenizer = self
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         return tokenized
 
     def decode(self, tokens: list[int], special_token_policy: SpecialTokenPolicy = SpecialTokenPolicy.IGNORE) -> str:
@@ -625,7 +625,7 @@ class InstructTokenizerV2(
         ]
         tokenized = Tokenized(tokens=tokens)
         # TODO: remove once 1.13.0 lands.
-        tokenized._tokenizer = self
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         return tokenized
 
 
@@ -1036,7 +1036,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
         tokens.append(self.TRANSCRIBE)
         tokenized = Tokenized(tokens=tokens, audios=audio)
         # TODO: remove once 1.13.0 lands.
-        tokenized._tokenizer = self
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         return tokenized
 
     def _encode_audio(self, audio: str | bytes, transcription_delay_ms: float | None = None) -> Tokenized:
@@ -1103,7 +1103,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
             audios=audios,
         )
         # TODO: remove once 1.13.0 lands.
-        tokenized._tokenizer = self
+        tokenized._text = self.decode(tokens=tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         return tokenized
 
     @classmethod

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -225,13 +225,15 @@ class InstructTokenizerBase(
             if tok is not None:
                 tokens.extend(tok)
 
-        return Tokenized(
+        tokenized = Tokenized(
             tokens=tokens,
-            text=self.decode(tokens, special_token_policy=SpecialTokenPolicy.KEEP),
             prefix_ids=prefix_ids,
             images=images,
             audios=audios,
         )
+        # TODO: remove once 1.13.0 lands.
+        tokenized._tokenizer = self
+        return tokenized
 
     def decode(self, tokens: list[int], special_token_policy: SpecialTokenPolicy = SpecialTokenPolicy.IGNORE) -> str:
         r"""Decode tokens to a string.
@@ -621,7 +623,10 @@ class InstructTokenizerV2(
             self.PREFIX,
             *prefix_tokens,
         ]
-        return Tokenized(tokens=tokens, text=self.decode(tokens, special_token_policy=SpecialTokenPolicy.KEEP))
+        tokenized = Tokenized(tokens=tokens)
+        # TODO: remove once 1.13.0 lands.
+        tokenized._tokenizer = self
+        return tokenized
 
 
 class InstructTokenizerV3(
@@ -1029,7 +1034,10 @@ class InstructTokenizerV7(InstructTokenizerV3):
             tokens += self.tokenizer.encode(language_string, bos=False, eos=False)
 
         tokens.append(self.TRANSCRIBE)
-        return Tokenized(tokens=tokens, text=self.tokenizer._to_string(tokens), audios=audio)
+        tokenized = Tokenized(tokens=tokens, audios=audio)
+        # TODO: remove once 1.13.0 lands.
+        tokenized._tokenizer = self
+        return tokenized
 
     def _encode_audio(self, audio: str | bytes, transcription_delay_ms: float | None = None) -> Tokenized:
         assert self.audio_encoder is not None, (
@@ -1090,11 +1098,13 @@ class InstructTokenizerV7(InstructTokenizerV3):
         else:
             raise ValueError(f"Request must be in streaming mode, got {request.streaming=}")
 
-        return Tokenized(
+        tokenized = Tokenized(
             tokens=tokens,
-            text=self.decode(tokens, special_token_policy=SpecialTokenPolicy.KEEP),
             audios=audios,
         )
+        # TODO: remove once 1.13.0 lands.
+        tokenized._tokenizer = self
+        return tokenized
 
     @classmethod
     def validate_messages(cls, messages: list[UATS]) -> None:

--- a/tests/integrations/chat_templates/helpers.py
+++ b/tests/integrations/chat_templates/helpers.py
@@ -22,7 +22,7 @@ from mistral_common.integrations.chat_templates.template_generator import Templa
 from mistral_common.protocol.instruct.request import ChatCompletionRequest, ReasoningEffort
 from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.audio import Audio
-from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, TokenizerVersion
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, ModelSettingsBuilder
 from tests.test_tekken import get_special_tokens
@@ -119,7 +119,8 @@ def encode_mistral_common(mistral_tokenizer: MistralTokenizer, chat_request: Cha
     with the Jinja template rendering. Token ID comparison is handled
     separately via `encode_hf_tokens`.
     """
-    mistral_encoded = str(mistral_tokenizer.encode_chat_completion(chat_request).text)
+    encoded = mistral_tokenizer.encode_chat_completion(chat_request)
+    mistral_encoded = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     # Collapse each image token sequence ([IMG]...[IMG_BREAK]...[IMG_END]) into a single [IMG].
     # Each sequence has exactly one [IMG_END], so replacing inner tokens and converting [IMG_END]
     # preserves one [IMG] per image (important for multi-image inputs).

--- a/tests/integrations/chat_templates/helpers.py
+++ b/tests/integrations/chat_templates/helpers.py
@@ -22,10 +22,11 @@ from mistral_common.integrations.chat_templates.template_generator import Templa
 from mistral_common.protocol.instruct.request import ChatCompletionRequest, ReasoningEffort
 from mistral_common.protocol.instruct.validator import ValidationMode
 from mistral_common.tokens.tokenizers.audio import Audio
-from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, TokenizerVersion
+from mistral_common.tokens.tokenizers.base import TokenizerVersion
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, ModelSettingsBuilder
 from tests.test_tekken import get_special_tokens
+from tests.utils import decode_keep
 
 # Golden template files live in the data/ tree (outside src/).
 _GOLDEN_DIR = Path(__file__).parent.parent.parent / "data" / "chat_templates"
@@ -120,7 +121,7 @@ def encode_mistral_common(mistral_tokenizer: MistralTokenizer, chat_request: Cha
     separately via `encode_hf_tokens`.
     """
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    mistral_encoded = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    mistral_encoded = decode_keep(mistral_tokenizer, encoded)
     # Collapse each image token sequence ([IMG]...[IMG_BREAK]...[IMG_END]) into a single [IMG].
     # Each sequence has exactly one [IMG_END], so replacing inner tokens and converting [IMG_END]
     # preserves one [IMG] per image (important for multi-image inputs).

--- a/tests/test_fim_tokenizer.py
+++ b/tests/test_fim_tokenizer.py
@@ -1,7 +1,8 @@
 import pytest
 
-from mistral_common.tokens.tokenizers.base import FIMRequest, SpecialTokenPolicy
+from mistral_common.tokens.tokenizers.base import FIMRequest
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from tests.utils import decode_keep
 
 
 @pytest.fixture()
@@ -11,5 +12,5 @@ def tokenizer() -> MistralTokenizer:
 
 def test_encode_fim(tokenizer: MistralTokenizer) -> None:
     tokenized = tokenizer.encode_fim(FIMRequest(prompt="def f(", suffix="return a + b"))
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>[SUFFIX]return▁a▁+▁b[PREFIX]▁def▁f("

--- a/tests/test_fim_tokenizer.py
+++ b/tests/test_fim_tokenizer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mistral_common.tokens.tokenizers.base import FIMRequest
+from mistral_common.tokens.tokenizers.base import FIMRequest, SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 
@@ -11,4 +11,5 @@ def tokenizer() -> MistralTokenizer:
 
 def test_encode_fim(tokenizer: MistralTokenizer) -> None:
     tokenized = tokenizer.encode_fim(FIMRequest(prompt="def f(", suffix="return a + b"))
-    assert tokenized.text == "<s>[SUFFIX]return▁a▁+▁b[PREFIX]▁def▁f("
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == "<s>[SUFFIX]return▁a▁+▁b[PREFIX]▁def▁f("

--- a/tests/test_integration_samples.py
+++ b/tests/test_integration_samples.py
@@ -6,8 +6,8 @@ import pytest
 
 from mistral_common.protocol.instruct.messages import ChatMessage
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
-from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from tests.utils import decode_keep
 
 
 @pytest.fixture()
@@ -70,6 +70,6 @@ def test_samples(sample: dict[str, Any], version: int, samples_dir: Path) -> Non
     )
     chat_completion_request = ChatCompletionRequest[ChatMessage].model_validate_json(chat_completion_string)
     tokenized = mistral_tokenizer.encode_chat_completion(chat_completion_request)
-    decoded_text = mistral_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    decoded_text = decode_keep(mistral_tokenizer, tokenized)
     assert decoded_text == text
     assert tokenized.tokens == tokens

--- a/tests/test_integration_samples.py
+++ b/tests/test_integration_samples.py
@@ -6,6 +6,7 @@ import pytest
 
 from mistral_common.protocol.instruct.messages import ChatMessage
 from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 
@@ -69,5 +70,6 @@ def test_samples(sample: dict[str, Any], version: int, samples_dir: Path) -> Non
     )
     chat_completion_request = ChatCompletionRequest[ChatMessage].model_validate_json(chat_completion_string)
     tokenized = mistral_tokenizer.encode_chat_completion(chat_completion_request)
-    assert tokenized.text == text
+    decoded_text = mistral_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert decoded_text == text
     assert tokenized.tokens == tokens

--- a/tests/test_tokenize_v1.py
+++ b/tests/test_tokenize_v1.py
@@ -3,8 +3,9 @@ import pytest
 from mistral_common.exceptions import InvalidAssistantMessageException, InvalidMessageStructureException
 from mistral_common.protocol.instruct.messages import AssistantMessage, UserMessage
 from mistral_common.protocol.instruct.request import InstructRequest
-from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy
+from mistral_common.tokens.tokenizers.base import InstructTokenizer
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from tests.utils import decode_keep
 
 
 @pytest.fixture()
@@ -24,7 +25,7 @@ def test_normal(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>▁[INST]▁a▁[/INST]▁b</s>▁[INST]▁c▁[/INST]▁d</s>"
     assert tokens == [
         1,
@@ -54,7 +55,7 @@ def test_normal(tokenizer: InstructTokenizer) -> None:
 def test_system_singleturn(tokenizer: InstructTokenizer) -> None:
     tokenized = tokenizer.encode_instruct(InstructRequest(messages=[UserMessage(content="a")], system_prompt="SYSTEM"))
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>▁[INST]▁SYSTEM<0x0A><0x0A>a▁[/INST]"
     assert tokens == [1, 733, 16289, 28793, 17121, 22526, 13, 13, 28708, 733, 28748, 16289, 28793]
     assert tokenizer.tokenizer.decode(tokens) == "[INST] SYSTEM\n\na [/INST]"
@@ -73,7 +74,7 @@ def test_system_multiturn(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>▁[INST]▁SYSTEM<0x0A><0x0A>a▁[/INST]▁b</s>▁[INST]▁c▁[/INST]▁d</s>"
     assert tokens == [
         1,
@@ -120,7 +121,7 @@ def test_continue_final_message(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>▁[INST]▁SYSTEM<0x0A><0x0A>a▁[/INST]▁b</s>▁[INST]▁c▁[/INST]▁d"
     assert tokens == [
         1,

--- a/tests/test_tokenize_v1.py
+++ b/tests/test_tokenize_v1.py
@@ -3,7 +3,7 @@ import pytest
 from mistral_common.exceptions import InvalidAssistantMessageException, InvalidMessageStructureException
 from mistral_common.protocol.instruct.messages import AssistantMessage, UserMessage
 from mistral_common.protocol.instruct.request import InstructRequest
-from mistral_common.tokens.tokenizers.base import InstructTokenizer
+from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 
@@ -23,7 +23,8 @@ def test_normal(tokenizer: InstructTokenizer) -> None:
             ]
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>▁[INST]▁a▁[/INST]▁b</s>▁[INST]▁c▁[/INST]▁d</s>"
     assert tokens == [
         1,
@@ -52,7 +53,8 @@ def test_normal(tokenizer: InstructTokenizer) -> None:
 
 def test_system_singleturn(tokenizer: InstructTokenizer) -> None:
     tokenized = tokenizer.encode_instruct(InstructRequest(messages=[UserMessage(content="a")], system_prompt="SYSTEM"))
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>▁[INST]▁SYSTEM<0x0A><0x0A>a▁[/INST]"
     assert tokens == [1, 733, 16289, 28793, 17121, 22526, 13, 13, 28708, 733, 28748, 16289, 28793]
     assert tokenizer.tokenizer.decode(tokens) == "[INST] SYSTEM\n\na [/INST]"
@@ -70,7 +72,8 @@ def test_system_multiturn(tokenizer: InstructTokenizer) -> None:
             system_prompt="SYSTEM",
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>▁[INST]▁SYSTEM<0x0A><0x0A>a▁[/INST]▁b</s>▁[INST]▁c▁[/INST]▁d</s>"
     assert tokens == [
         1,
@@ -116,7 +119,8 @@ def test_continue_final_message(tokenizer: InstructTokenizer) -> None:
             continue_final_message=True,
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>▁[INST]▁SYSTEM<0x0A><0x0A>a▁[/INST]▁b</s>▁[INST]▁c▁[/INST]▁d"
     assert tokens == [
         1,

--- a/tests/test_tokenize_v2.py
+++ b/tests/test_tokenize_v2.py
@@ -7,7 +7,7 @@ from mistral_common.protocol.instruct.chunk import TextChunk
 from mistral_common.protocol.instruct.messages import AssistantMessage, ToolMessage, UserMessage
 from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
-from mistral_common.tokens.tokenizers.base import InstructTokenizer
+from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 
@@ -27,7 +27,8 @@ def test_normal(tokenizer: InstructTokenizer) -> None:
             ]
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>[INST]▁a[/INST]▁b</s>[INST]▁c[/INST]▁d</s>"
     assert tokens == [1, 3, 1032, 4, 1055, 2, 3, 1045, 4, 1049, 2]
 
@@ -39,7 +40,8 @@ def test_tools_singleturn(tokenizer: InstructTokenizer) -> None:
             available_tools=[Tool(function=Function(name="tool1", description="1", parameters={}))],
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         '<s>[AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"tool1",▁"description":▁"1",▁"parameters":▁{}}}][/AVAILABLE_TOOLS][INST]▁a[/INST]'
     )  # NOTE THE SPACE
@@ -63,7 +65,8 @@ def test_tools_multiturn(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         "<s>[INST]▁a[/INST]▁b</s>"
         '[AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"tool1",▁"description":▁"1",▁"parameters":▁{}}}'
@@ -89,7 +92,8 @@ def test_tools_multiturn(tokenizer: InstructTokenizer) -> None:
 
 def test_system_singleturn(tokenizer: InstructTokenizer) -> None:
     tokenized = tokenizer.encode_instruct(InstructRequest(messages=[UserMessage(content="a")], system_prompt="SYSTEM"))
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>[INST]▁SYSTEM<0x0A><0x0A>a[/INST]"  # NOTE THE SPACE
     assert tokens == [1, 3, 17889, 23294, 781, 781, 29476, 4]
     assert tokenizer.tokenizer.decode(tokens) == "SYSTEM\n\na"
@@ -107,7 +111,8 @@ def test_system_multiturn(tokenizer: InstructTokenizer) -> None:
             system_prompt="SYSTEM",
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>[INST]▁a[/INST]▁b</s>[INST]▁SYSTEM<0x0A><0x0A>c[/INST]▁d</s>"
     assert tokens == [
         1,
@@ -143,7 +148,8 @@ def test_continue_final_message(tokenizer: InstructTokenizer) -> None:
             continue_final_message=True,
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == "<s>[INST]▁a[/INST]▁b</s>[INST]▁SYSTEM<0x0A><0x0A>c[/INST]▁d"
     assert tokens == [
         1,
@@ -204,7 +210,8 @@ def test_system_tools_multiturn(tokenizer: InstructTokenizer) -> None:
             system_prompt="SYSTEM",
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         '<s>[INST]▁a[/INST]▁b</s>[AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"tool1",▁"description":▁"1",▁"parameters":▁{}}}][/AVAILABLE_TOOLS][INST]▁SYSTEM<0x0A><0x0A>c[/INST]▁d</s>'
     )
@@ -225,7 +232,7 @@ def test_tool_response(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         '<s>[INST]▁a[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁"d"}][/TOOL_RESULTS]'
     )
@@ -239,7 +246,7 @@ def test_tool_response(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         '<s>[INST]▁a[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁{"a":▁1}}][/TOOL_RESULTS]'
     )
@@ -253,7 +260,7 @@ def test_tool_response(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         '<s>[INST]▁a[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁"d{\\"a\\":▁1}"}][/TOOL_RESULTS]'
     )
@@ -273,7 +280,7 @@ def test_tool_message_multiple_shots_without_history(tokenizer: InstructTokenize
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         '<s>[INST]▁a[/INST]▁e</s>[INST]▁f[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁"d"}][/TOOL_RESULTS]'
     )

--- a/tests/test_tokenize_v2.py
+++ b/tests/test_tokenize_v2.py
@@ -7,8 +7,9 @@ from mistral_common.protocol.instruct.chunk import TextChunk
 from mistral_common.protocol.instruct.messages import AssistantMessage, ToolMessage, UserMessage
 from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
-from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy
+from mistral_common.tokens.tokenizers.base import InstructTokenizer
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from tests.utils import decode_keep
 
 
 @pytest.fixture()
@@ -28,7 +29,7 @@ def test_normal(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>[INST]▁a[/INST]▁b</s>[INST]▁c[/INST]▁d</s>"
     assert tokens == [1, 3, 1032, 4, 1055, 2, 3, 1045, 4, 1049, 2]
 
@@ -41,7 +42,7 @@ def test_tools_singleturn(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         '<s>[AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"tool1",▁"description":▁"1",▁"parameters":▁{}}}][/AVAILABLE_TOOLS][INST]▁a[/INST]'
     )  # NOTE THE SPACE
@@ -66,7 +67,7 @@ def test_tools_multiturn(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         "<s>[INST]▁a[/INST]▁b</s>"
         '[AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"tool1",▁"description":▁"1",▁"parameters":▁{}}}'
@@ -93,7 +94,7 @@ def test_tools_multiturn(tokenizer: InstructTokenizer) -> None:
 def test_system_singleturn(tokenizer: InstructTokenizer) -> None:
     tokenized = tokenizer.encode_instruct(InstructRequest(messages=[UserMessage(content="a")], system_prompt="SYSTEM"))
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>[INST]▁SYSTEM<0x0A><0x0A>a[/INST]"  # NOTE THE SPACE
     assert tokens == [1, 3, 17889, 23294, 781, 781, 29476, 4]
     assert tokenizer.tokenizer.decode(tokens) == "SYSTEM\n\na"
@@ -112,7 +113,7 @@ def test_system_multiturn(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>[INST]▁a[/INST]▁b</s>[INST]▁SYSTEM<0x0A><0x0A>c[/INST]▁d</s>"
     assert tokens == [
         1,
@@ -149,7 +150,7 @@ def test_continue_final_message(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>[INST]▁a[/INST]▁b</s>[INST]▁SYSTEM<0x0A><0x0A>c[/INST]▁d"
     assert tokens == [
         1,
@@ -211,7 +212,7 @@ def test_system_tools_multiturn(tokenizer: InstructTokenizer) -> None:
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         '<s>[INST]▁a[/INST]▁b</s>[AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"tool1",▁"description":▁"1",▁"parameters":▁{}}}][/AVAILABLE_TOOLS][INST]▁SYSTEM<0x0A><0x0A>c[/INST]▁d</s>'
     )
@@ -232,7 +233,7 @@ def test_tool_response(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         '<s>[INST]▁a[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁"d"}][/TOOL_RESULTS]'
     )
@@ -246,7 +247,7 @@ def test_tool_response(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         '<s>[INST]▁a[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁{"a":▁1}}][/TOOL_RESULTS]'
     )
@@ -260,7 +261,7 @@ def test_tool_response(tokenizer: InstructTokenizer) -> None:
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         '<s>[INST]▁a[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁"d{\\"a\\":▁1}"}][/TOOL_RESULTS]'
     )
@@ -280,7 +281,7 @@ def test_tool_message_multiple_shots_without_history(tokenizer: InstructTokenize
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         '<s>[INST]▁a[/INST]▁e</s>[INST]▁f[/INST][TOOL_CALLS]▁[{"name":▁"b",▁"arguments":▁{}}]</s>[TOOL_RESULTS]▁[{"name":▁"b",▁"content":▁"d"}][/TOOL_RESULTS]'
     )

--- a/tests/test_tokenize_v3.py
+++ b/tests/test_tokenize_v3.py
@@ -100,7 +100,8 @@ def test_tools_singleturn(
             available_tools=[Tool(function=Function(name="tool1", description="1", parameters={}))],
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[AVAILABLE_TOOLS]{special_ws}["
         f'{{"type":{ws}"function",{ws}"function":{ws}{{"name":{ws}"tool1",{ws}"description":{ws}"1",{ws}"parameters":{ws}{{}}}}}}]'
@@ -159,7 +160,8 @@ def test_tools_multiturn(
             ],
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]{special_ws}b</s>[AVAILABLE_TOOLS]{special_ws}["
         f'{{"type":{ws}"function",{ws}"function":{ws}{{"name":{ws}"tool1",{ws}"description":{ws}"1",{ws}"parameters":{ws}{{}}}}}},'
@@ -219,7 +221,8 @@ def test_system_tools_multiturn(
             system_prompt="SYSTEM",
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]{special_ws}b</s>[AVAILABLE_TOOLS]{special_ws}["
         f'{{"type":{ws}"function",{ws}"function":{ws}{{"name":{ws}"tool1",{ws}"description":{ws}"1",{ws}"parameters":{ws}{{}}}}}}]'
@@ -264,7 +267,8 @@ def test_continue_final_message(
             continue_final_message=True,
         )
     )
-    tokens, text = tokenized.tokens, tokenized.text
+    tokens = tokenized.tokens
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]{special_ws}b</s>[INST]{special_ws}SYSTEM{new_line}c[/INST]{special_ws}d"
     )
@@ -329,7 +333,7 @@ def test_tool_message(tokenizer: InstructTokenizer, special_ws: str, ws: str) ->
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f'<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}'
         f'"arguments":{ws}{{}},{ws}"id":{ws}"123456789"}}]</s>[TOOL_RESULTS]{special_ws}'
@@ -351,7 +355,7 @@ def test_tool_message(tokenizer: InstructTokenizer, special_ws: str, ws: str) ->
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}["
         f'{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"123456789"}}]</s>[TOOL_RESULTS]{special_ws}'
@@ -373,7 +377,7 @@ def test_tool_message(tokenizer: InstructTokenizer, special_ws: str, ws: str) ->
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}["
         f'{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"123456789"}}]</s>[TOOL_RESULTS]{special_ws}'
@@ -407,7 +411,7 @@ def test_tool_message_no_id_fine_tuning_ok(tokenizer: InstructTokenizer, special
                 ],
             )
         )
-        _, text = tokenized.tokens, tokenized.text
+        text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         assert (
             text
             == f'<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}"arguments":{ws}{{}}}}]</s>'
@@ -443,7 +447,7 @@ def test_tool_message_multiple_shots_with_history(tokenizer: InstructTokenizer, 
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]"
         f'[TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"0"}}]</s>[TOOL_RESULTS]{special_ws}{{"content":{ws}"d",{ws}"call_id":{ws}"0"}}[/TOOL_RESULTS]'  # noqa: E501
@@ -485,7 +489,7 @@ def test_tool_message_multiple_calls(tokenizer: InstructTokenizer, special_ws: s
             ],
         )
     )
-    _, text = tokenized.tokens, tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]"
         f'[TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"0"}},{ws}{{"name":{ws}"q",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"1"}}]</s>'

--- a/tests/test_tokenize_v3.py
+++ b/tests/test_tokenize_v3.py
@@ -16,6 +16,7 @@ from mistral_common.tokens.tokenizers.sentencepiece import (
     is_sentencepiece,
 )
 from mistral_common.tokens.tokenizers.tekken import SpecialTokenPolicy, Tekkenizer
+from tests.utils import decode_keep
 
 TEKKEN_SPECIAL_WHITESPACE = ""
 TEKKEN_WHITESPACE = " "
@@ -101,7 +102,7 @@ def test_tools_singleturn(
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[AVAILABLE_TOOLS]{special_ws}["
         f'{{"type":{ws}"function",{ws}"function":{ws}{{"name":{ws}"tool1",{ws}"description":{ws}"1",{ws}"parameters":{ws}{{}}}}}}]'
@@ -161,7 +162,7 @@ def test_tools_multiturn(
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]{special_ws}b</s>[AVAILABLE_TOOLS]{special_ws}["
         f'{{"type":{ws}"function",{ws}"function":{ws}{{"name":{ws}"tool1",{ws}"description":{ws}"1",{ws}"parameters":{ws}{{}}}}}},'
@@ -222,7 +223,7 @@ def test_system_tools_multiturn(
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]{special_ws}b</s>[AVAILABLE_TOOLS]{special_ws}["
         f'{{"type":{ws}"function",{ws}"function":{ws}{{"name":{ws}"tool1",{ws}"description":{ws}"1",{ws}"parameters":{ws}{{}}}}}}]'
@@ -268,7 +269,7 @@ def test_continue_final_message(
         )
     )
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]{special_ws}b</s>[INST]{special_ws}SYSTEM{new_line}c[/INST]{special_ws}d"
     )
@@ -333,7 +334,7 @@ def test_tool_message(tokenizer: InstructTokenizer, special_ws: str, ws: str) ->
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f'<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}'
         f'"arguments":{ws}{{}},{ws}"id":{ws}"123456789"}}]</s>[TOOL_RESULTS]{special_ws}'
@@ -355,7 +356,7 @@ def test_tool_message(tokenizer: InstructTokenizer, special_ws: str, ws: str) ->
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}["
         f'{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"123456789"}}]</s>[TOOL_RESULTS]{special_ws}'
@@ -377,7 +378,7 @@ def test_tool_message(tokenizer: InstructTokenizer, special_ws: str, ws: str) ->
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}["
         f'{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"123456789"}}]</s>[TOOL_RESULTS]{special_ws}'
@@ -411,7 +412,7 @@ def test_tool_message_no_id_fine_tuning_ok(tokenizer: InstructTokenizer, special
                 ],
             )
         )
-        text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        text = decode_keep(tokenizer, tokenized)
         assert (
             text
             == f'<s>[INST]{special_ws}a[/INST][TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}"arguments":{ws}{{}}}}]</s>'
@@ -447,7 +448,7 @@ def test_tool_message_multiple_shots_with_history(tokenizer: InstructTokenizer, 
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]"
         f'[TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"0"}}]</s>[TOOL_RESULTS]{special_ws}{{"content":{ws}"d",{ws}"call_id":{ws}"0"}}[/TOOL_RESULTS]'  # noqa: E501
@@ -489,7 +490,7 @@ def test_tool_message_multiple_calls(tokenizer: InstructTokenizer, special_ws: s
             ],
         )
     )
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == (
         f"<s>[INST]{special_ws}a[/INST]"
         f'[TOOL_CALLS]{special_ws}[{{"name":{ws}"b",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"0"}},{ws}{{"name":{ws}"q",{ws}"arguments":{ws}{{}},{ws}"id":{ws}"1"}}]</s>'

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -44,7 +44,7 @@ def test_tokenized_text_property_returns_decoded_text() -> None:
     assert text == expected
 
 
-def test_tokenized_text_property_returns_none_without_tokenizer() -> None:
+def test_tokenized_text_property_returns_none_when_not_produced_by_a_tokenizer() -> None:
     tokenized = Tokenized(tokens=[1, 2, 3])
 
     with pytest.warns(DeprecationWarning, match="`text` property of `Tokenized`"):
@@ -69,39 +69,20 @@ def test_tokenized_text_property_warns_only_once() -> None:
     assert dep_warnings == []
 
 
-def test_tokenized_equality_ignores_tokenizer_backref() -> None:
-    _, tokenized = _make_tokenized()
+def test_tokenized_equality_includes_cached_text() -> None:
+    with_text = Tokenized(tokens=[1, 2, 3])
+    with_text._text = "cached"
+    without_text = Tokenized(tokens=[1, 2, 3])
 
-    assert tokenized == Tokenized(tokens=tokenized.tokens, prefix_ids=tokenized.prefix_ids)
-
-
-def test_tokenized_equality_rejects_subclasses() -> None:
-    class TokenizedSubclass(Tokenized):
-        extra: int = 0
-
-    subclass_instance = TokenizedSubclass(tokens=[1], extra=1)
-    base_instance = Tokenized(tokens=[1])
-
-    assert subclass_instance != base_instance
-    assert base_instance != subclass_instance
+    assert with_text != without_text
 
 
-def test_tokenized_equality_compares_public_fields() -> None:
-    tokenized = Tokenized(tokens=[1, 2], prefix_ids=[1])
-
-    assert tokenized == Tokenized(tokens=[1, 2], prefix_ids=[1])
-    assert tokenized != Tokenized(tokens=[9, 9], prefix_ids=[1])
-    assert tokenized != Tokenized(tokens=[1, 2], prefix_ids=[9])
-    assert tokenized.__eq__("not a Tokenized") is NotImplemented
-    assert tokenized != "not a Tokenized"
-
-
-def test_tokenized_pickle_excludes_tokenizer() -> None:
-    _, tokenized = _make_tokenized()
+def test_tokenized_pickle_roundtrip_preserves_text() -> None:
+    tokenizer, tokenized = _make_tokenized()
+    expected_text = decode_keep(tokenizer, tokenized)
 
     restored = pickle.loads(pickle.dumps(tokenized))
 
-    assert restored._tokenizer is None
     assert restored == tokenized
     with pytest.warns(DeprecationWarning):
-        assert restored.text is None
+        assert restored.text == expected_text

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -8,6 +8,7 @@ from mistral_common.protocol.instruct.messages import UserMessage
 from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy, Tokenized
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+from tests.utils import decode_keep
 
 
 def test_special_token_policy_backward_compatibility() -> None:
@@ -35,7 +36,7 @@ def _make_tokenized() -> tuple[InstructTokenizer, Tokenized]:
 
 def test_tokenized_text_property_returns_decoded_text() -> None:
     tokenizer, tokenized = _make_tokenized()
-    expected = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    expected = decode_keep(tokenizer, tokenized)
 
     with pytest.warns(DeprecationWarning, match="`text` property of `Tokenized`"):
         text = tokenized.text

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -1,6 +1,13 @@
+import pickle
+import warnings
+
 import pytest
 
-from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
+import mistral_common.deprecation
+from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.instruct.request import InstructRequest
+from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy, Tokenized
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 
 
 def test_special_token_policy_backward_compatibility() -> None:
@@ -12,3 +19,88 @@ def test_special_token_policy_backward_compatibility() -> None:
         SpecialTokenPolicy(3)
     with pytest.raises(ValueError, match=r"'invalid' is not a valid SpecialTokenPolicy"):
         SpecialTokenPolicy("invalid")
+
+
+@pytest.fixture(autouse=True)
+def _clear_text_tokenized_warning() -> None:
+    mistral_common.deprecation._warned_keys.discard("Tokenized.text")
+
+
+def _make_tokenized() -> tuple[InstructTokenizer, Tokenized]:
+    tokenizer = MistralTokenizer.v3().instruct_tokenizer
+    tokenized = tokenizer.encode_instruct(InstructRequest(messages=[UserMessage(content="a")]))
+    assert isinstance(tokenized, Tokenized)
+    return tokenizer, tokenized
+
+
+def test_tokenized_text_property_returns_decoded_text() -> None:
+    tokenizer, tokenized = _make_tokenized()
+    expected = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+
+    with pytest.warns(DeprecationWarning, match="`text` property of `Tokenized`"):
+        text = tokenized.text
+
+    assert text == expected
+
+
+def test_tokenized_text_property_returns_none_without_tokenizer() -> None:
+    tokenized = Tokenized(tokens=[1, 2, 3])
+
+    with pytest.warns(DeprecationWarning, match="`text` property of `Tokenized`"):
+        text = tokenized.text
+
+    assert text is None
+
+
+def test_tokenized_text_property_warns_only_once() -> None:
+    _, tokenized = _make_tokenized()
+
+    with pytest.warns(DeprecationWarning, match="`text` property of `Tokenized`"):
+        tokenized.text
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # Accessing `text` again on the same instance, and on a different one, must not warn again.
+        tokenized.text
+        _make_tokenized()[1].text
+
+    dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep_warnings == []
+
+
+def test_tokenized_equality_ignores_tokenizer_backref() -> None:
+    _, tokenized = _make_tokenized()
+
+    assert tokenized == Tokenized(tokens=tokenized.tokens, prefix_ids=tokenized.prefix_ids)
+
+
+def test_tokenized_equality_rejects_subclasses() -> None:
+    class TokenizedSubclass(Tokenized):
+        extra: int = 0
+
+    subclass_instance = TokenizedSubclass(tokens=[1], extra=1)
+    base_instance = Tokenized(tokens=[1])
+
+    assert subclass_instance != base_instance
+    assert base_instance != subclass_instance
+
+
+def test_tokenized_equality_compares_public_fields() -> None:
+    tokenized = Tokenized(tokens=[1, 2], prefix_ids=[1])
+
+    assert tokenized == Tokenized(tokens=[1, 2], prefix_ids=[1])
+    assert tokenized != Tokenized(tokens=[9, 9], prefix_ids=[1])
+    assert tokenized != Tokenized(tokens=[1, 2], prefix_ids=[9])
+    assert tokenized.__eq__("not a Tokenized") is NotImplemented
+    assert tokenized != "not a Tokenized"
+
+
+def test_tokenized_pickle_excludes_tokenizer() -> None:
+    _, tokenized = _make_tokenized()
+
+    restored = pickle.loads(pickle.dumps(tokenized))
+
+    assert restored._tokenizer is None
+    assert restored == tokenized
+    with pytest.warns(DeprecationWarning):
+        assert restored.text is None

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -206,7 +206,8 @@ def test_end_to_end_v13(
     # This does validation, normalization and encoding
     tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
     assert isinstance(tokenized_v13, Tokenized)
-    assert tokenized_v13.text == EXPECTED_TEXT_V13, tokenized_v13.text
+    text = mistral_tokenizer_v13.decode(tokens=tokenized_v13.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == EXPECTED_TEXT_V13, text
 
 
 def test_end_to_end_v13_wrong_order(
@@ -231,7 +232,8 @@ def test_end_to_end_v13_wrong_order(
     # This does validation, normalization and encoding
     tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
     assert isinstance(tokenized_v13, Tokenized)
-    assert tokenized_v13.text == EXPECTED_TEXT_V13_FROM_WRONG_ORDER, tokenized_v13.text
+    text = mistral_tokenizer_v13.decode(tokens=tokenized_v13.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == EXPECTED_TEXT_V13_FROM_WRONG_ORDER, text
 
 
 def test_encode_tool_message(v13_tekkenizer: InstructTokenizerV13) -> None:
@@ -395,7 +397,8 @@ def test_encode_chat_completion_request_with_sp_and_audio(
         instruct_tokenizer=v13_tekkenizer_audio, validator=validator, request_normalizer=request_normalizer
     )
     encoded = mistral_tokenizer_v13.encode_chat_completion(ChatCompletionRequest(messages=messages))
-    assert encoded.text == "<s>[SYSTEM_PROMPT]hello[/SYSTEM_PROMPT][INST][BEGIN_AUDIO][AUDIO][AUDIO][/INST]"
+    text = mistral_tokenizer_v13.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == "<s>[SYSTEM_PROMPT]hello[/SYSTEM_PROMPT][INST][BEGIN_AUDIO][AUDIO][AUDIO][/INST]"
     assert len(encoded.audios) == 1
 
 

--- a/tests/test_tokenizer_v13.py
+++ b/tests/test_tokenizer_v13.py
@@ -25,6 +25,7 @@ from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.tekken import SpecialTokenPolicy, Tekkenizer
 from tests.fixtures.audio import get_dummy_audio_chunk, get_dummy_audio_url_chunk
 from tests.test_tekken import get_special_tokens, quick_vocab
+from tests.utils import decode_keep
 
 
 @pytest.fixture(scope="module")
@@ -206,7 +207,7 @@ def test_end_to_end_v13(
     # This does validation, normalization and encoding
     tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
     assert isinstance(tokenized_v13, Tokenized)
-    text = mistral_tokenizer_v13.decode(tokens=tokenized_v13.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(mistral_tokenizer_v13, tokenized_v13)
     assert text == EXPECTED_TEXT_V13, text
 
 
@@ -232,7 +233,7 @@ def test_end_to_end_v13_wrong_order(
     # This does validation, normalization and encoding
     tokenized_v13 = mistral_tokenizer_v13.encode_chat_completion(chat_completion_request)
     assert isinstance(tokenized_v13, Tokenized)
-    text = mistral_tokenizer_v13.decode(tokens=tokenized_v13.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(mistral_tokenizer_v13, tokenized_v13)
     assert text == EXPECTED_TEXT_V13_FROM_WRONG_ORDER, text
 
 
@@ -397,7 +398,7 @@ def test_encode_chat_completion_request_with_sp_and_audio(
         instruct_tokenizer=v13_tekkenizer_audio, validator=validator, request_normalizer=request_normalizer
     )
     encoded = mistral_tokenizer_v13.encode_chat_completion(ChatCompletionRequest(messages=messages))
-    text = mistral_tokenizer_v13.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(mistral_tokenizer_v13, encoded)
     assert text == "<s>[SYSTEM_PROMPT]hello[/SYSTEM_PROMPT][INST][BEGIN_AUDIO][AUDIO][AUDIO][/INST]"
     assert len(encoded.audios) == 1
 

--- a/tests/test_tokenizer_v15.py
+++ b/tests/test_tokenizer_v15.py
@@ -30,7 +30,7 @@ from mistral_common.protocol.instruct.request import (
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.protocol.instruct.validator import ValidationMode, get_validator
 from mistral_common.tokens.tokenizers.audio import AudioConfig, AudioEncoder, AudioSpectrogramConfig, SpecialAudioIDs
-from mistral_common.tokens.tokenizers.base import SpecialTokens, TokenizerVersion
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, SpecialTokens, TokenizerVersion
 from mistral_common.tokens.tokenizers.image import ImageConfig, ImageEncoder, SpecialImageIDs
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV15
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
@@ -352,7 +352,8 @@ def test_tools_and_reasoning_effort(
         settings=ModelSettings(reasoning_effort=ReasoningEffort.high),
     )
     tokenized = v15_tekkenizer.encode_instruct(request)
-    assert tokenized.text == EXPECTED_TEXT_V15, tokenized.text
+    text = v15_tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == EXPECTED_TEXT_V15, text
 
 
 def test_no_tools_and_reasoning_effort(v15_tekkenizer: InstructTokenizerV15, messages: list[ChatMessage]) -> None:
@@ -361,7 +362,8 @@ def test_no_tools_and_reasoning_effort(v15_tekkenizer: InstructTokenizerV15, mes
     )
     tokenized = v15_tekkenizer.encode_instruct(request)
     expected_text_no_tools = EXPECTED_TEXT_V15_NO_TOOLS.replace("high", "none")
-    assert tokenized.text == expected_text_no_tools, tokenized.text
+    text = v15_tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == expected_text_no_tools, text
 
 
 def test_no_settings_does_not_encode_model_settings(
@@ -369,7 +371,8 @@ def test_no_settings_does_not_encode_model_settings(
 ) -> None:
     request: InstructRequest = InstructRequest(messages=messages, available_tools=None, settings=ModelSettings.none())
     tokenized = v15_tekkenizer_no_reasoning.encode_instruct(request)
-    assert "[MODEL_SETTINGS]" not in (tokenized.text or "")
+    text = v15_tekkenizer_no_reasoning.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert "[MODEL_SETTINGS]" not in text
 
 
 def test_system_think_chunk_raises_v15(v15_tekkenizer: InstructTokenizerV15) -> None:
@@ -426,7 +429,8 @@ def test_encode_ignore_one_model_settings(
     tokenizer_v15 = get_v15_mistral_tokenizer(builder)
     request = ChatCompletionRequest(messages=messages, reasoning_effort=reasoning_effort)  # type: ignore[arg-type]
     tokenized = tokenizer_v15.encode_chat_completion(request)
-    assert "[MODEL_SETTINGS]" not in (tokenized.text or "")
+    text = tokenizer_v15.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert "[MODEL_SETTINGS]" not in text
 
 
 @pytest.mark.parametrize("reasoning_effort", [None, *list(ReasoningEffort)])
@@ -436,7 +440,7 @@ def test_end_to_end_with_default(messages: list[ChatMessage], reasoning_effort: 
     tokenizer_v15 = get_v15_mistral_tokenizer(builder)
     request = ChatCompletionRequest(messages=messages, reasoning_effort=reasoning_effort)
     tokenized = tokenizer_v15.encode_chat_completion(request)
-    text = tokenized.text or ""
+    text = tokenizer_v15.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     if reasoning_effort == ReasoningEffort.high:
         assert '[MODEL_SETTINGS]{"reasoning_effort": "high"}[/MODEL_SETTINGS]' in text
     else:
@@ -453,7 +457,7 @@ def test_end_to_end_no_default(messages: list[ChatMessage], reasoning_effort: Re
     tokenizer_v15 = get_v15_mistral_tokenizer(builder)
     request = ChatCompletionRequest(messages=messages, reasoning_effort=reasoning_effort)
     tokenized = tokenizer_v15.encode_chat_completion(request)
-    text = tokenized.text or ""
+    text = tokenizer_v15.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
     if reasoning_effort == ReasoningEffort.high:
         assert '[MODEL_SETTINGS]{"reasoning_effort": "high"}[/MODEL_SETTINGS]' in text
     elif reasoning_effort == ReasoningEffort.none:
@@ -500,7 +504,8 @@ def test_encode_chat_completion_with_multimodal_tool(
         tools=[Tool(function=Function(name="fn", description="test", parameters={}))],
     )
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    assert encoded.text == expected_text, encoded.text
+    text = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == expected_text, text
     assert len(encoded.audios) == expected_audios
     assert len(encoded.images) == expected_images
 
@@ -524,7 +529,8 @@ def test_encode_chat_completion_with_multimodal_system(
         ],
     )
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    assert encoded.text == expected_text, encoded.text
+    text = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == expected_text, text
     assert len(encoded.audios) == expected_audios
     assert len(encoded.images) == expected_images
 
@@ -547,6 +553,7 @@ def test_encode_chat_completion_with_multimodal_user(
         ],
     )
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    assert encoded.text == expected_text, encoded.text
+    text = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == expected_text, text
     assert len(encoded.audios) == expected_audios
     assert len(encoded.images) == expected_images

--- a/tests/test_tokenizer_v15.py
+++ b/tests/test_tokenizer_v15.py
@@ -30,7 +30,7 @@ from mistral_common.protocol.instruct.request import (
 from mistral_common.protocol.instruct.tool_calls import Function, FunctionCall, Tool, ToolCall
 from mistral_common.protocol.instruct.validator import ValidationMode, get_validator
 from mistral_common.tokens.tokenizers.audio import AudioConfig, AudioEncoder, AudioSpectrogramConfig, SpecialAudioIDs
-from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, SpecialTokens, TokenizerVersion
+from mistral_common.tokens.tokenizers.base import SpecialTokens, TokenizerVersion
 from mistral_common.tokens.tokenizers.image import ImageConfig, ImageEncoder, SpecialImageIDs
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV15
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
@@ -38,6 +38,7 @@ from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder,
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 from tests.fixtures.audio import get_dummy_audio_chunk, get_dummy_audio_url_chunk
 from tests.test_tekken import get_special_tokens, quick_vocab
+from tests.utils import decode_keep
 
 EXPECTED_TEXT_V15: str = (
     r"<s>[SYSTEM_PROMPT]S[/SYSTEM_PROMPT]"
@@ -352,7 +353,7 @@ def test_tools_and_reasoning_effort(
         settings=ModelSettings(reasoning_effort=ReasoningEffort.high),
     )
     tokenized = v15_tekkenizer.encode_instruct(request)
-    text = v15_tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(v15_tekkenizer, tokenized)
     assert text == EXPECTED_TEXT_V15, text
 
 
@@ -362,7 +363,7 @@ def test_no_tools_and_reasoning_effort(v15_tekkenizer: InstructTokenizerV15, mes
     )
     tokenized = v15_tekkenizer.encode_instruct(request)
     expected_text_no_tools = EXPECTED_TEXT_V15_NO_TOOLS.replace("high", "none")
-    text = v15_tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(v15_tekkenizer, tokenized)
     assert text == expected_text_no_tools, text
 
 
@@ -371,7 +372,7 @@ def test_no_settings_does_not_encode_model_settings(
 ) -> None:
     request: InstructRequest = InstructRequest(messages=messages, available_tools=None, settings=ModelSettings.none())
     tokenized = v15_tekkenizer_no_reasoning.encode_instruct(request)
-    text = v15_tekkenizer_no_reasoning.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(v15_tekkenizer_no_reasoning, tokenized)
     assert "[MODEL_SETTINGS]" not in text
 
 
@@ -429,7 +430,7 @@ def test_encode_ignore_one_model_settings(
     tokenizer_v15 = get_v15_mistral_tokenizer(builder)
     request = ChatCompletionRequest(messages=messages, reasoning_effort=reasoning_effort)  # type: ignore[arg-type]
     tokenized = tokenizer_v15.encode_chat_completion(request)
-    text = tokenizer_v15.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer_v15, tokenized)
     assert "[MODEL_SETTINGS]" not in text
 
 
@@ -440,7 +441,7 @@ def test_end_to_end_with_default(messages: list[ChatMessage], reasoning_effort: 
     tokenizer_v15 = get_v15_mistral_tokenizer(builder)
     request = ChatCompletionRequest(messages=messages, reasoning_effort=reasoning_effort)
     tokenized = tokenizer_v15.encode_chat_completion(request)
-    text = tokenizer_v15.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer_v15, tokenized)
     if reasoning_effort == ReasoningEffort.high:
         assert '[MODEL_SETTINGS]{"reasoning_effort": "high"}[/MODEL_SETTINGS]' in text
     else:
@@ -457,7 +458,7 @@ def test_end_to_end_no_default(messages: list[ChatMessage], reasoning_effort: Re
     tokenizer_v15 = get_v15_mistral_tokenizer(builder)
     request = ChatCompletionRequest(messages=messages, reasoning_effort=reasoning_effort)
     tokenized = tokenizer_v15.encode_chat_completion(request)
-    text = tokenizer_v15.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer_v15, tokenized)
     if reasoning_effort == ReasoningEffort.high:
         assert '[MODEL_SETTINGS]{"reasoning_effort": "high"}[/MODEL_SETTINGS]' in text
     elif reasoning_effort == ReasoningEffort.none:
@@ -504,7 +505,7 @@ def test_encode_chat_completion_with_multimodal_tool(
         tools=[Tool(function=Function(name="fn", description="test", parameters={}))],
     )
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    text = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(mistral_tokenizer, encoded)
     assert text == expected_text, text
     assert len(encoded.audios) == expected_audios
     assert len(encoded.images) == expected_images
@@ -529,7 +530,7 @@ def test_encode_chat_completion_with_multimodal_system(
         ],
     )
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    text = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(mistral_tokenizer, encoded)
     assert text == expected_text, text
     assert len(encoded.audios) == expected_audios
     assert len(encoded.images) == expected_images
@@ -553,7 +554,7 @@ def test_encode_chat_completion_with_multimodal_user(
         ],
     )
     encoded = mistral_tokenizer.encode_chat_completion(chat_request)
-    text = mistral_tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(mistral_tokenizer, encoded)
     assert text == expected_text, text
     assert len(encoded.audios) == expected_audios
     assert len(encoded.images) == expected_images

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -123,7 +123,7 @@ def test_tokenize_empty_content_assistant_message(spm_tokenizer: InstructTokeniz
                     spm_tokenizer.encode_instruct(instruct_request)
             else:
                 tokenized = spm_tokenizer.encode_instruct(instruct_request)
-                assert tokenized == Tokenized(
+                expected = Tokenized(
                     tokens=[
                         1,
                         5,
@@ -162,7 +162,8 @@ def test_tokenize_empty_content_assistant_message(spm_tokenizer: InstructTokeniz
                         29561,
                     ],
                 )
-                assert decode_keep(spm_tokenizer, tokenized) == '<s>[TOOL_CALLS]▁[{"name":▁"test_fn",▁"arguments":▁{}}]'
+                expected._text = '<s>[TOOL_CALLS]▁[{"name":▁"test_fn",▁"arguments":▁{}}]'
+                assert tokenized == expected
 
 
 def test_tokenize_assistant_message_continue_final_message(spm_tokenizer: InstructTokenizerV7) -> None:

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -30,7 +30,6 @@ from mistral_common.protocol.instruct.validator import (
 from mistral_common.tokens.tokenizers.base import (
     InstructRequest,
     InstructTokenizer,
-    SpecialTokenPolicy,
     Tokenized,
     TokenizerVersion,
 )
@@ -40,6 +39,7 @@ from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 from tests.test_tekken import quick_vocab
 from tests.test_tokenizer_v7_audio import get_tekkenizer_with_audio
+from tests.utils import decode_keep
 
 
 @pytest.fixture
@@ -106,7 +106,7 @@ def test_tokenize_assistant_message(spm_tokenizer: InstructTokenizerV7) -> None:
         9,  # [/TOOL_RESULTS]
     ]
     assert (
-        spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        decode_keep(spm_tokenizer, tokenized)
         == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST]▁b</s>[TOOL_RESULTS]▁b[TOOL_CONTENT]▁f[/TOOL_RESULTS]"  # noqa
     )
 
@@ -162,10 +162,7 @@ def test_tokenize_empty_content_assistant_message(spm_tokenizer: InstructTokeniz
                         29561,
                     ],
                 )
-                assert (
-                    spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
-                    == '<s>[TOOL_CALLS]▁[{"name":▁"test_fn",▁"arguments":▁{}}]'
-                )
+                assert decode_keep(spm_tokenizer, tokenized) == '<s>[TOOL_CALLS]▁[{"name":▁"test_fn",▁"arguments":▁{}}]'
 
 
 def test_tokenize_assistant_message_continue_final_message(spm_tokenizer: InstructTokenizerV7) -> None:
@@ -197,10 +194,7 @@ def test_tokenize_assistant_message_continue_final_message(spm_tokenizer: Instru
         4,  # end_inst
         1055,  # b
     ]
-    assert (
-        spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
-        == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST]▁b"
-    )
+    assert decode_keep(spm_tokenizer, tokenized) == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST]▁b"
 
     with pytest.raises(
         InvalidMessageStructureException, match="Cannot continue final message if it is not an assistant message"
@@ -309,7 +303,7 @@ def test_encode_spm(spm_tokenizer: InstructTokenizerV7, messages: list[ChatMessa
         )
     )
 
-    text = spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(spm_tokenizer, tokenized)
     assert text == expected_text, f"{text} != {expected_text}"
 
 
@@ -351,7 +345,7 @@ def test_encode_chat_completion() -> None:
     assert len(encoded.images) == 1
     assert encoded.images[0].shape == (3, 16, 16)
     assert (
-        tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        decode_keep(tokenizer, encoded)
         == '<s>[SYSTEM_PROMPT]▁a[/SYSTEM_PROMPT][AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"t",▁"description":▁"",▁"parameters":▁{"type":▁"object",▁"properties":▁{"g":▁{"type":▁"string"},▁"h":▁{"type":▁"string"}}}}}][/AVAILABLE_TOOLS][INST][IMG][IMG_END]▁a[/INST]▁b</s>[TOOL_RESULTS]▁123456789[TOOL_CONTENT]▁f[/TOOL_RESULTS]'  # noqa
     )
 
@@ -437,7 +431,7 @@ def test_truncation(
     tokenizer: InstructTokenizer = request.getfixturevalue(tekkenizer)
 
     tokenized = tokenizer.encode_instruct(InstructRequest(messages=messages, truncate_at_max_tokens=15))
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == truncated_text, f"{text} != {truncated_text}"
 
 
@@ -512,7 +506,7 @@ def test_assistant_tool_call_and_content(request: pytest.FixtureRequest, tekkeni
     )
     tokenized = tokenizer.encode_instruct(instruct_request)
     tokens = tokenized.tokens
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
 
     assert text == (
         '<s>[AVAILABLE_TOOLS][{"type": "function", "function": '

--- a/tests/test_tokenizer_v7.py
+++ b/tests/test_tokenizer_v7.py
@@ -27,7 +27,13 @@ from mistral_common.protocol.instruct.validator import (
     MistralRequestValidatorV5,
     ValidationMode,
 )
-from mistral_common.tokens.tokenizers.base import InstructRequest, InstructTokenizer, Tokenized, TokenizerVersion
+from mistral_common.tokens.tokenizers.base import (
+    InstructRequest,
+    InstructTokenizer,
+    SpecialTokenPolicy,
+    Tokenized,
+    TokenizerVersion,
+)
 from mistral_common.tokens.tokenizers.image import ImageEncoder
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV7
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
@@ -100,7 +106,7 @@ def test_tokenize_assistant_message(spm_tokenizer: InstructTokenizerV7) -> None:
         9,  # [/TOOL_RESULTS]
     ]
     assert (
-        tokenized.text
+        spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST]▁b</s>[TOOL_RESULTS]▁b[TOOL_CONTENT]▁f[/TOOL_RESULTS]"  # noqa
     )
 
@@ -116,7 +122,8 @@ def test_tokenize_empty_content_assistant_message(spm_tokenizer: InstructTokeniz
                 with pytest.raises(TokenizerException, match="Invalid assistant message:"):
                     spm_tokenizer.encode_instruct(instruct_request)
             else:
-                assert spm_tokenizer.encode_instruct(instruct_request) == Tokenized(
+                tokenized = spm_tokenizer.encode_instruct(instruct_request)
+                assert tokenized == Tokenized(
                     tokens=[
                         1,
                         5,
@@ -136,7 +143,6 @@ def test_tokenize_empty_content_assistant_message(spm_tokenizer: InstructTokeniz
                         1743,
                         29561,
                     ],
-                    text='<s>[TOOL_CALLS]▁[{"name":▁"test_fn",▁"arguments":▁{}}]',
                     prefix_ids=[
                         5,
                         1501,
@@ -155,6 +161,10 @@ def test_tokenize_empty_content_assistant_message(spm_tokenizer: InstructTokeniz
                         1743,
                         29561,
                     ],
+                )
+                assert (
+                    spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+                    == '<s>[TOOL_CALLS]▁[{"name":▁"test_fn",▁"arguments":▁{}}]'
                 )
 
 
@@ -187,7 +197,10 @@ def test_tokenize_assistant_message_continue_final_message(spm_tokenizer: Instru
         4,  # end_inst
         1055,  # b
     ]
-    assert tokenized.text == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST]▁b"
+    assert (
+        spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        == "<s>[INST][IMG][IMG][IMG_BREAK][IMG][IMG][IMG_END]▁a[/INST]▁b"
+    )
 
     with pytest.raises(
         InvalidMessageStructureException, match="Cannot continue final message if it is not an assistant message"
@@ -296,7 +309,8 @@ def test_encode_spm(spm_tokenizer: InstructTokenizerV7, messages: list[ChatMessa
         )
     )
 
-    assert tokenized.text == expected_text, f"{tokenized.text} != {expected_text}"
+    text = spm_tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == expected_text, f"{text} != {expected_text}"
 
 
 def test_encode_chat_completion() -> None:
@@ -337,7 +351,7 @@ def test_encode_chat_completion() -> None:
     assert len(encoded.images) == 1
     assert encoded.images[0].shape == (3, 16, 16)
     assert (
-        encoded.text
+        tokenizer.decode(tokens=encoded.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
         == '<s>[SYSTEM_PROMPT]▁a[/SYSTEM_PROMPT][AVAILABLE_TOOLS]▁[{"type":▁"function",▁"function":▁{"name":▁"t",▁"description":▁"",▁"parameters":▁{"type":▁"object",▁"properties":▁{"g":▁{"type":▁"string"},▁"h":▁{"type":▁"string"}}}}}][/AVAILABLE_TOOLS][INST][IMG][IMG_END]▁a[/INST]▁b</s>[TOOL_RESULTS]▁123456789[TOOL_CONTENT]▁f[/TOOL_RESULTS]'  # noqa
     )
 
@@ -423,7 +437,8 @@ def test_truncation(
     tokenizer: InstructTokenizer = request.getfixturevalue(tekkenizer)
 
     tokenized = tokenizer.encode_instruct(InstructRequest(messages=messages, truncate_at_max_tokens=15))
-    assert tokenized.text == truncated_text, f"{tokenized.text} != {truncated_text}"
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == truncated_text, f"{text} != {truncated_text}"
 
 
 @pytest.mark.parametrize(
@@ -497,7 +512,7 @@ def test_assistant_tool_call_and_content(request: pytest.FixtureRequest, tekkeni
     )
     tokenized = tokenizer.encode_instruct(instruct_request)
     tokens = tokenized.tokens
-    text = tokenized.text
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
 
     assert text == (
         '<s>[AVAILABLE_TOOLS][{"type": "function", "function": '

--- a/tests/test_tokenizer_v7_audio.py
+++ b/tests/test_tokenizer_v7_audio.py
@@ -29,7 +29,6 @@ from mistral_common.tokens.tokenizers.audio import (
 )
 from mistral_common.tokens.tokenizers.base import (
     InstructRequest,
-    SpecialTokenPolicy,
     SpecialTokens,
     TokenizerVersion,
 )
@@ -39,6 +38,7 @@ from mistral_common.tokens.tokenizers.instruct import (
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 from tests.test_tekken import get_special_tokens, quick_vocab
+from tests.utils import decode_keep
 
 
 def get_tekkenizer_with_audio() -> InstructTokenizerV7:
@@ -200,7 +200,7 @@ def test_tokenize_user_assistant_message(tekkenizer: InstructTokenizerV7) -> Non
         200,  # "d"
         EOS,
     ]
-    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tekkenizer, tokenized)
     assert text == ("<s>[INST]a[BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]c b d</s>")
     assert len(tokenized.audios) == 1
     base64_str = audio_chunk.input_audio
@@ -239,7 +239,7 @@ def test_tokenize_user_message(tekkenizer: InstructTokenizerV7, audio_first: boo
             197,  # "a"
             END_INST,
         ]
-        text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        text = decode_keep(tekkenizer, tokenized)
         assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "a[/INST]")
     else:
         assert tokenized.tokens == [
@@ -249,7 +249,7 @@ def test_tokenize_user_message(tekkenizer: InstructTokenizerV7, audio_first: boo
             *audio_toks,
             END_INST,
         ]
-        text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        text = decode_keep(tekkenizer, tokenized)
         assert text == ("<s>[INST]a[BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]")
     assert len(tokenized.audios) == 1
     base64_str = audio_chunk.input_audio
@@ -398,7 +398,7 @@ def test_tokenize_audio_url_chunk(
     assert tokenized.audios[0].sampling_rate == 24000
     assert tokenized.audios[0].format == "wav"
     assert tokenized.audios[0].audio_array.shape == (24000,)
-    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tekkenizer, tokenized)
     assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * (len(audio_toks) - 1) + "[/INST]c b d</s>")
     assert tokenized.tokens == [
         BOS,

--- a/tests/test_tokenizer_v7_audio.py
+++ b/tests/test_tokenizer_v7_audio.py
@@ -29,6 +29,7 @@ from mistral_common.tokens.tokenizers.audio import (
 )
 from mistral_common.tokens.tokenizers.base import (
     InstructRequest,
+    SpecialTokenPolicy,
     SpecialTokens,
     TokenizerVersion,
 )
@@ -199,7 +200,8 @@ def test_tokenize_user_assistant_message(tekkenizer: InstructTokenizerV7) -> Non
         200,  # "d"
         EOS,
     ]
-    assert tokenized.text == ("<s>[INST]a[BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]c b d</s>")
+    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == ("<s>[INST]a[BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]c b d</s>")
     assert len(tokenized.audios) == 1
     base64_str = audio_chunk.input_audio
     assert isinstance(base64_str, str)
@@ -237,7 +239,8 @@ def test_tokenize_user_message(tekkenizer: InstructTokenizerV7, audio_first: boo
             197,  # "a"
             END_INST,
         ]
-        assert tokenized.text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "a[/INST]")
+        text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "a[/INST]")
     else:
         assert tokenized.tokens == [
             BOS,
@@ -246,7 +249,8 @@ def test_tokenize_user_message(tekkenizer: InstructTokenizerV7, audio_first: boo
             *audio_toks,
             END_INST,
         ]
-        assert tokenized.text == ("<s>[INST]a[BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]")
+        text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+        assert text == ("<s>[INST]a[BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]")
     assert len(tokenized.audios) == 1
     base64_str = audio_chunk.input_audio
     assert isinstance(base64_str, str)
@@ -394,7 +398,8 @@ def test_tokenize_audio_url_chunk(
     assert tokenized.audios[0].sampling_rate == 24000
     assert tokenized.audios[0].format == "wav"
     assert tokenized.audios[0].audio_array.shape == (24000,)
-    assert tokenized.text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * (len(audio_toks) - 1) + "[/INST]c b d</s>")
+    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * (len(audio_toks) - 1) + "[/INST]c b d</s>")
     assert tokenized.tokens == [
         BOS,
         BEGIN_INST,

--- a/tests/test_tokenizer_v7_audio_streaming.py
+++ b/tests/test_tokenizer_v7_audio_streaming.py
@@ -24,6 +24,7 @@ from mistral_common.tokens.tokenizers.mistral import (
 )
 from mistral_common.tokens.tokenizers.tekken import SpecialTokenInfo, Tekkenizer
 from tests.test_tekken import get_special_tokens, quick_vocab
+from tests.utils import decode_keep
 
 _audio_spectrogram_config = {
     "num_mel_bins": 128,
@@ -153,7 +154,7 @@ def test_tokenize_streaming_request(
     BOS = tokenizer.tokenizer.get_special_token(SpecialTokens.bos.value)
     STREAMING_PAD = tokenizer.tokenizer.get_special_token(SpecialTokens.streaming_pad.value)
     assert tokenized.tokens == ([BOS] + delay_n_tokens * [STREAMING_PAD]), f"{tokenized.tokens}"
-    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tokenizer, tokenized)
     assert text == "<s>" + delay_n_tokens * "[STREAMING_PAD]"
 
     if mode == StreamingMode.OFFLINE:

--- a/tests/test_tokenizer_v7_audio_streaming.py
+++ b/tests/test_tokenizer_v7_audio_streaming.py
@@ -153,7 +153,8 @@ def test_tokenize_streaming_request(
     BOS = tokenizer.tokenizer.get_special_token(SpecialTokens.bos.value)
     STREAMING_PAD = tokenizer.tokenizer.get_special_token(SpecialTokens.streaming_pad.value)
     assert tokenized.tokens == ([BOS] + delay_n_tokens * [STREAMING_PAD]), f"{tokenized.tokens}"
-    assert tokenized.text == "<s>" + delay_n_tokens * "[STREAMING_PAD]"
+    text = tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == "<s>" + delay_n_tokens * "[STREAMING_PAD]"
 
     if mode == StreamingMode.OFFLINE:
         rounded_duration = math.ceil(duration / (config.frame_duration_ms / 1000)) * (config.frame_duration_ms / 1000)

--- a/tests/test_tokenizer_v7_audio_transcribe.py
+++ b/tests/test_tokenizer_v7_audio_transcribe.py
@@ -6,6 +6,7 @@ from mistral_common.protocol.transcription.request import TranscriptionRequest
 from mistral_common.tokens.tokenizers.audio import (
     Audio,
 )
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerV7,
 )
@@ -48,7 +49,8 @@ def test_tokenize_transcribe(tekkenizer: InstructTokenizerV7) -> None:
         END_INST,
         TRANSCRIBE,
     ]
-    assert tokenized.text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST][TRANSCRIBE]")
+    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST][TRANSCRIBE]")
     assert len(tokenized.audios) == 1
     base64_audio = request.audio
     assert isinstance(base64_audio, str)
@@ -82,7 +84,8 @@ def test_tokenize_transcribe_with_lang(tekkenizer: InstructTokenizerV7) -> None:
         210,
         TRANSCRIBE,
     ]
-    assert tokenized.text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]lang:en[TRANSCRIBE]")
+    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]lang:en[TRANSCRIBE]")
     assert len(tokenized.audios) == 1
     base64_audio = request.audio
     assert isinstance(base64_audio, str)

--- a/tests/test_tokenizer_v7_audio_transcribe.py
+++ b/tests/test_tokenizer_v7_audio_transcribe.py
@@ -6,7 +6,6 @@ from mistral_common.protocol.transcription.request import TranscriptionRequest
 from mistral_common.tokens.tokenizers.audio import (
     Audio,
 )
-from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerV7,
 )
@@ -15,6 +14,7 @@ from tests.test_tokenizer_v7_audio import (
     _get_specials,
     get_tekkenizer_with_audio,
 )
+from tests.utils import decode_keep
 
 
 @pytest.fixture(scope="session")
@@ -49,7 +49,7 @@ def test_tokenize_transcribe(tekkenizer: InstructTokenizerV7) -> None:
         END_INST,
         TRANSCRIBE,
     ]
-    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tekkenizer, tokenized)
     assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST][TRANSCRIBE]")
     assert len(tokenized.audios) == 1
     base64_audio = request.audio
@@ -84,7 +84,7 @@ def test_tokenize_transcribe_with_lang(tekkenizer: InstructTokenizerV7) -> None:
         210,
         TRANSCRIBE,
     ]
-    text = tekkenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)
+    text = decode_keep(tekkenizer, tokenized)
     assert text == ("<s>[INST][BEGIN_AUDIO]" + "[AUDIO]" * num_expected_frames + "[/INST]lang:en[TRANSCRIBE]")
     assert len(tokenized.audios) == 1
     base64_audio = request.audio

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy, Tokenized
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+
+
+def decode_keep(tokenizer: InstructTokenizer | MistralTokenizer, tokenized: Tokenized) -> str:
+    r"""Decode `tokenized.tokens` back to text, keeping special tokens.
+
+    Args:
+        tokenizer: The tokenizer that produced `tokenized`.
+        tokenized: The tokenized result to decode.
+
+    Returns:
+        The decoded string, including special tokens.
+    """
+    return tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)


### PR DESCRIPTION
## What

Deprecates `Tokenized.text` (now a property backed by a private `_text` cache) in favor of `tokenizer.decode(tokens=tokenized.tokens, special_token_policy=SpecialTokenPolicy.KEEP)`, migrates every internal call site off the removed field, and adds regression coverage plus a shared test helper.

## Why

`text` was a plain field on `Tokenized` that got eagerly computed and stored on every encode call, even when callers never touched it. Making it a deprecated property (still eagerly decoded into a private cache at construction, exactly like the old field) lets us warn callers on access during the deprecation window without changing behavior; once the property is fully removed in 1.13.0, the eager decode cost goes away too.

An earlier version of this change kept a live back-reference to the tokenizer instead and decoded lazily, to also avoid the eager-decode cost during the deprecation window. That added real complexity for no real payoff: a custom `__eq__` (to keep equality from comparing tokenizer instances), a `__getstate__` override (to keep the tokenizer out of pickled payloads), and four call sites that had to remember to wire up the backref (three didn't, silently turning `None` into a raised exception on `encode_speech_request`). Caching the decoded string instead removes all of that: strings pickle trivially, equality works out of the box, and every construction site just needs one line, matching what it already did before this deprecation.

## Behavior

- `Tokenized.text` still returns the same decoded string it always did, but now warns once (`DeprecationWarning`) per process, and returns `None` for a `Tokenized` where the decoded text was never cached (matching the original field's default and every call site's prior behavior, including the ones that never set `text` on `main`).
- `Tokenized` equality is plain pydantic default equality (no custom `__eq__`): it now also compares the cached `_text`, which is fine since it's cheap and deterministic for a given `tokens`.

## Tests

- `tests/test_tokenizer_base.py`: coverage for the deprecated `text` property (decodes correctly, returns `None` when not cached, warns exactly once, participates in equality) and that pickling round-trips `_text` correctly (unlike the tokenizer-backref approach, nothing needs to be stripped).
- `tests/utils.py`: new `decode_keep(tokenizer, tokenized)` helper collapsing ~40 repeated `tokenizer.decode(tokens=..., special_token_policy=SpecialTokenPolicy.KEEP)` call sites across the suite.
- Every existing test/doc call site that used `tokenized.text`/`encoded.text` migrated to the new helper (one equality assert also updated since `Tokenized(..., text=...)` is no longer a valid constructor call).
- Full suite (`1425 passed, 17 skipped`), `ruff check`, `ruff format --check`, `mypy`, and doctests all pass.

## Notes

`tests/utils.py` is a plain helper module (not `test_utils.py`, so pytest won't collect it as tests). Heads up: the in-progress `test-refactor-pr2-instruct` branch documents a planned `tests.utils.regenerate_registry` *package* — if that branch lands first, `tests/utils.py` (a file) will need to be reconciled with `tests/utils/` (a directory) at merge time.
