### PR TITLE
fix(packaging): point `license-files` at LICENCE (the actual file)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.11.7"
 description = "Mistral-common is a library of common utilities for Mistral AI."
 authors = [{name = "Mistral AI", email = "oss@mistral.ai"}]
 license = "Apache-2.0"
-license-files = ["LICENSE"] 
+license-files = ["LICENCE"] 
 readme = "README.md"
 requires-python = ">=3.10.0,<3.15"
 


### PR DESCRIPTION
The repository's license file is spelled **`LICENCE`** (British), and `pyproject.toml` links to `./LICENCE`. But the packaging metadata points at a non-existent `LICENSE`:

```toml
license-files = ["LICENSE"]
```

There is no `LICENSE` file in the tree — only `LICENCE`. Because `license-files` is set explicitly, it **overrides** setuptools' default `LICEN[CS]E*` glob, so `LICENCE` is not matched. Building the distribution:

```
$ python -m build --wheel
SetuptoolsDeprecationWarning: ... Pattern 'LICENSE' did not match any files
```

and the resulting wheel `METADATA` has **no `License-File:`** entry (and no `licenses/` dir) — the license text is silently dropped from published artifacts. Pointing `license-files` at `LICENCE` restores it. One-token fix.