### PR TITLE
Set reference audio filename for speech multipart uploads

### DIFF
--- a/src/mistral_common/protocol/speech/request.py
+++ b/src/mistral_common/protocol/speech/request.py
@@ -55,6 +55,7 @@ class SpeechRequest(BaseCompletionRequest):
                 sf.write(buffer, audio.audio_array, audio.sampling_rate, format=audio.format)
                 buffer.seek(0)
 
+            # OpenAI's client uses the filename extension from .name to set the Content-Type.
             buffer.name = f"audio.{fmt}"
             openai_request["ref_audio"] = buffer
 

--- a/src/mistral_common/protocol/speech/request.py
+++ b/src/mistral_common/protocol/speech/request.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from mistral_common.imports import assert_soundfile_installed, is_soundfile_installed
 from mistral_common.protocol.base import BaseCompletionRequest
+from mistral_common.protocol.instruct.chunk import _detect_audio_format
 from mistral_common.tokens.tokenizers.audio import Audio
 
 if is_soundfile_installed():
@@ -45,13 +46,16 @@ class SpeechRequest(BaseCompletionRequest):
         if self.ref_audio is not None:
             if isinstance(self.ref_audio, bytes):
                 buffer = io.BytesIO(self.ref_audio)
+                fmt = _detect_audio_format(self.ref_audio)
             else:
                 audio = Audio.from_base64(self.ref_audio)
+                fmt = audio.format.lower()
 
                 buffer = io.BytesIO()
                 sf.write(buffer, audio.audio_array, audio.sampling_rate, format=audio.format)
                 buffer.seek(0)
 
+            buffer.name = f"audio.{fmt}"
             openai_request["ref_audio"] = buffer
 
         openai_request["seed"] = openai_request.pop("random_seed")

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1248,6 +1248,30 @@ def test_convert_speech_request_from_openai() -> None:
     assert request_voice.voice == "custom-voice-123"
 
 
+@pytest.mark.parametrize("fmt", ["wav", "flac"])
+def test_speech_to_openai_base64_ref_audio_filename(fmt: str) -> None:
+    audio = _make_fake_audio(0.5)
+    request = SpeechRequest(input="Hello world", ref_audio=audio.to_base64(fmt))
+
+    buffer = request.to_openai()["ref_audio"]
+
+    assert isinstance(buffer, io.BytesIO)
+    assert buffer.name == f"audio.{fmt}"
+
+
+@pytest.mark.parametrize("fmt", ["wav", "flac"])
+def test_speech_to_openai_bytes_ref_audio_filename(fmt: str) -> None:
+    audio = _make_fake_audio(0.5)
+    source = io.BytesIO()
+    sf.write(source, audio.audio_array, audio.sampling_rate, format=fmt)
+    request = SpeechRequest(input="Hello world", ref_audio=source.getvalue())
+
+    buffer = request.to_openai()["ref_audio"]
+
+    assert isinstance(buffer, io.BytesIO)
+    assert buffer.name == f"audio.{fmt}"
+
+
 @pytest.mark.parametrize(
     ["voice", "with_ref_audio", "random_seed"],
     [

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1258,6 +1258,9 @@ def test_speech_to_openai_base64_ref_audio_filename(fmt: str) -> None:
     assert isinstance(buffer, io.BytesIO)
     assert buffer.name == f"audio.{fmt}"
 
+    recovered = Audio.from_bytes(buffer.getvalue())
+    assert np.allclose(recovered.audio_array, audio.audio_array, atol=1e-3)
+
 
 @pytest.mark.parametrize("fmt", ["wav", "flac"])
 def test_speech_to_openai_bytes_ref_audio_filename(fmt: str) -> None:
@@ -1270,6 +1273,14 @@ def test_speech_to_openai_bytes_ref_audio_filename(fmt: str) -> None:
 
     assert isinstance(buffer, io.BytesIO)
     assert buffer.name == f"audio.{fmt}"
+
+
+def test_speech_to_openai_bytes_invalid_format() -> None:
+    """Verify that invalid reference audio bytes raise a ValueError."""
+    request = SpeechRequest(input="Hello world", ref_audio=b"not valid audio data")
+
+    with pytest.raises(ValueError, match="Failed to detect audio format"):
+        request.to_openai()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Preserve the detected format of reference audio passed through `SpeechRequest.to_openai()`.
- Name multipart streams `audio.<format>` for both base64 and raw-byte inputs.

## Root cause

`SpeechRequest.to_openai()` returned an unnamed `BytesIO`, so multipart clients defaulted to filename `upload` and `Content-Type: application/octet-stream`. The fix mirrors `TranscriptionRequest` by detecting or preserving the audio format and setting the filename to `audio.<format>`.

## Tests

- 4 focused cases: WAV and FLAC, each as base64 and raw bytes
- 1,145 unit tests passed; 52 doctests passed; 454 integration tests passed
- Full Ruff check, Ruff format check, and mypy check passed

AI assistance was used during investigation and implementation; the behavior, diff, and test results were independently verified before submission.
