### PR TITLE
Allow overriding auto-detected plain thinking support in chat template generation

### DIFF
--- a/scripts/generate_chat_template.py
+++ b/scripts/generate_chat_template.py
@@ -21,7 +21,24 @@ def main() -> None:
     parser.add_argument("--image", action="store_true", help="Enable image support")
     parser.add_argument("--audio", action="store_true", help="Enable audio support")
     parser.add_argument("--thinking", action="store_true", help="Enable thinking support (special tokens)")
-    parser.add_argument("--plain_thinking", action="store_true", help="Enable plain text thinking (<think> tags)")
+    parser.add_argument(
+        "--plain_thinking",
+        action="store_true",
+        help=(
+            "Manual mode: enable plain text thinking (<think> tags). "
+            "Auto-detect mode: force plain text thinking on, overriding the auto-detected heuristic. "
+            "Mutually exclusive with --no_plain_thinking."
+        ),
+    )
+    parser.add_argument(
+        "--no_plain_thinking",
+        action="store_true",
+        help=(
+            "Auto-detect mode: force plain text thinking off, overriding the auto-detected heuristic. "
+            "No effect in manual mode, where plain thinking is already off by default. "
+            "Mutually exclusive with --plain_thinking."
+        ),
+    )
     parser.add_argument("--default_system_prompt", type=str, default=None, help="Default system prompt to embed")
     parser.add_argument("--saving_path", type=str, default="./chat_template.jinja", help="Output path for the template")
     parser.add_argument(
@@ -31,6 +48,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if args.plain_thinking and args.no_plain_thinking:
+        parser.error("--plain_thinking and --no_plain_thinking are mutually exclusive")
+
     if args.tokenizer_file is not None:
         manual_flag_checks: list[tuple[bool, str]] = [
             (args.version is not None, "--version"),
@@ -38,32 +58,45 @@ def main() -> None:
             (args.image, "--image"),
             (args.audio, "--audio"),
             (args.thinking, "--thinking"),
-            (args.plain_thinking, "--plain_thinking"),
         ]
         conflicting = [flag for is_set, flag in manual_flag_checks if is_set]
 
         if conflicting:
             parser.error(f"--tokenizer_file cannot be combined with manual capability flags: {', '.join(conflicting)}")
 
-        template = convert_tokenizer_to_chat_template(
-            tokenizer_file=args.tokenizer_file,
-            system_prompt=args.default_system_prompt,
-            use_special_token_variables=not args.no_special_token_variables,
-        )
+        if args.plain_thinking:
+            plain_thinking_support = True
+        elif args.no_plain_thinking:
+            plain_thinking_support = False
+        else:
+            plain_thinking_support = None
+
+        try:
+            template = convert_tokenizer_to_chat_template(
+                tokenizer_file=args.tokenizer_file,
+                system_prompt=args.default_system_prompt,
+                use_special_token_variables=not args.no_special_token_variables,
+                plain_thinking_support=plain_thinking_support,
+            )
+        except ValueError as e:
+            parser.error(str(e))
     else:
         if args.version is None:
             parser.error("--version is required when --tokenizer_file is not provided")
 
-        template = generate_chat_template(
-            spm=args.spm,
-            tokenizer_version=TokenizerVersion(args.version),
-            image_support=args.image,
-            audio_support=args.audio,
-            thinking_support=args.thinking,
-            default_system_prompt=args.default_system_prompt,
-            plain_thinking_support=args.plain_thinking,
-            use_special_token_variables=not args.no_special_token_variables,
-        )
+        try:
+            template = generate_chat_template(
+                spm=args.spm,
+                tokenizer_version=TokenizerVersion(args.version),
+                image_support=args.image,
+                audio_support=args.audio,
+                thinking_support=args.thinking,
+                default_system_prompt=args.default_system_prompt,
+                plain_thinking_support=args.plain_thinking,
+                use_special_token_variables=not args.no_special_token_variables,
+            )
+        except ValueError as e:
+            parser.error(str(e))
 
     with open(args.saving_path, "w", encoding="utf-8") as f:
         f.write(template)

--- a/src/mistral_common/integrations/chat_templates/chat_templates.py
+++ b/src/mistral_common/integrations/chat_templates/chat_templates.py
@@ -70,6 +70,7 @@ def convert_tokenizer_to_chat_template(
     tokenizer_file: str | Path,
     system_prompt: str | None = None,
     use_special_token_variables: bool = True,
+    plain_thinking_support: bool | None = None,
 ) -> str:
     r"""Load a tokenizer file and auto-detect its capabilities to generate a matching chat template.
 
@@ -78,13 +79,26 @@ def convert_tokenizer_to_chat_template(
     and supported modalities, then delegates to `generate_chat_template` with the
     detected flags.
 
-    The `plain_thinking_support` flag is set heuristically: a v11 tokenizer without
-    an audio encoder uses plain `<think>`/`</think>` text tags instead of special
-    `[THINK]`/`[/THINK]` tokens. When audio is present on a v11 tokenizer,
-    `plain_thinking_support` is set to `False` because the two are mutually exclusive.
-    `thinking_support` (special-token thinking) is detected by checking whether both
-    `begin_think` and `end_think` special tokens are registered in the underlying
+    `thinking_support` (special-token thinking) is auto-detected by checking whether
+    both `begin_think` and `end_think` special tokens are registered in the underlying
     tokenizer via its public `is_special` method.
+
+    `plain_thinking_support` cannot be reliably auto-detected: the tokenizer file
+    carries no signal that distinguishes a reasoning v11 model from a non-reasoning
+    one. For example, `mistralai/Magistral-Small-2506` (reasoning, plain
+    `<think>`/`</think>` tags) and `mistralai/Mistral-Small-3.2-24B-Instruct-2506`
+    (non-reasoning) ship `tekken.json` files with identical `config`, `vocab`,
+    `special_tokens` and `multimodal` sections. When left as
+    `None` (the default), the heuristic `version == TokenizerVersion.v11 and not
+    audio_support` is used, which over-triggers on non-reasoning v11 models. Pass
+    `plain_thinking_support=False` to suppress the guess for such a model.
+
+    Passing `plain_thinking_support=True` cannot widen the set of templates that
+    can be produced: `TemplateConfig` only accepts plain thinking on a v11
+    tokenizer without audio, which is exactly the condition under which the
+    heuristic already returns `True`. The value is accepted so callers can state
+    the intent explicitly, but on any other tokenizer it raises rather than
+    forcing the feature on.
 
     Args:
         tokenizer_file: Path to the tokenizer file (tekken JSON or SentencePiece `.model.vX`).
@@ -92,12 +106,17 @@ def convert_tokenizer_to_chat_template(
             When not `None`, maps to `generate_chat_template`'s `default_system_prompt`.
         use_special_token_variables: Whether to emit BOS/EOS as Jinja variable
             references (`bos_token`/`eos_token`) or as literal string values.
+        plain_thinking_support: Override for plain-text thinking chunk support.
+            `None` keeps the auto-detected heuristic, `False` suppresses it, and
+            `True` asserts it for a tokenizer that already qualifies.
 
     Returns:
         The generated Jinja2 chat template string matching the tokenizer's capabilities.
 
     Raises:
         TokenizerException: If the tokenizer file is not recognized or invalid.
+        ValueError: If `plain_thinking_support` is forced to a value incompatible
+            with the detected version, audio support, or thinking support.
     """
     mistral_tokenizer = MistralTokenizer.from_file(tokenizer_file)
     instruct_tokenizer = mistral_tokenizer.instruct_tokenizer
@@ -110,7 +129,8 @@ def convert_tokenizer_to_chat_template(
     thinking_support = tokenizer.is_special(SpecialTokens.begin_think.value) and tokenizer.is_special(
         SpecialTokens.end_think.value
     )
-    plain_thinking_support = version == TokenizerVersion.v11 and not audio_support
+    if plain_thinking_support is None:
+        plain_thinking_support = version == TokenizerVersion.v11 and not audio_support
 
     return generate_chat_template(
         spm=spm,

--- a/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
+++ b/tests/integrations/chat_templates/unit/test_convert_tokenizer.py
@@ -79,6 +79,39 @@ class TestConvertTokenizerToChatTemplate:
         assert "<think>" in result
         assert "[THINK]" not in result
 
+    def test_tekken_v11_plain_thinking_override_false(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v11)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        result = convert_tokenizer_to_chat_template(tokenizer_file=path, plain_thinking_support=False)
+        expected = generate_chat_template(
+            spm=False,
+            tokenizer_version=TokenizerVersion.v11,
+            image_support=False,
+            audio_support=False,
+            thinking_support=False,
+            default_system_prompt=None,
+            plain_thinking_support=False,
+            use_special_token_variables=True,
+        )
+        assert result == expected
+        assert "<think>" not in result
+        assert "[THINK]" not in result
+
+    def test_tekken_v11_plain_thinking_override_true_matches_autodetect(self, tmp_path: Path) -> None:
+        # Forcing `True` cannot widen what is producible: `TemplateConfig` only accepts plain
+        # thinking where the heuristic already returns `True`, so it restates the default.
+        config = TestConfig(version=TokenizerVersion.v11)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        forced = convert_tokenizer_to_chat_template(tokenizer_file=path, plain_thinking_support=True)
+        autodetected = convert_tokenizer_to_chat_template(tokenizer_file=path)
+        assert forced == autodetected
+
+    def test_tekken_v11_plain_thinking_override_true_with_audio_raises(self, tmp_path: Path) -> None:
+        config = TestConfig(version=TokenizerVersion.v11, audio=True)
+        path = _build_tekken_json(config=config, output_dir=tmp_path)
+        with pytest.raises(ValueError, match="Audio and plain thinking support are mutually exclusive"):
+            convert_tokenizer_to_chat_template(tokenizer_file=path, plain_thinking_support=True)
+
     def test_spm_v7(self, tmp_path: Path) -> None:
         config = TestConfig(version=TokenizerVersion.v7, spm=True)
         path = _build_spm_path(config=config, output_dir=tmp_path)

--- a/tests/test_generate_chat_template_cli.py
+++ b/tests/test_generate_chat_template_cli.py
@@ -18,6 +18,14 @@ def tekken_think_v13_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return _build_tekken_json(config=config, output_dir=build_dir)
 
 
+@pytest.fixture(scope="session")
+def tekken_v11_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Path to a plain v11 tekken.json used for auto-detect CLI plain thinking tests."""
+    build_dir = tmp_path_factory.mktemp("tokenizer")
+    config = TestConfig(version=TokenizerVersion.v11)
+    return _build_tekken_json(config=config, output_dir=build_dir)
+
+
 def test_cli_generates_template(tmp_path: Path) -> None:
     """CLI generates a template file with expected content."""
     output_path = tmp_path / "template.jinja"
@@ -305,3 +313,106 @@ def test_autodetect_no_special_token_variables(tmp_path: Path, tekken_think_v13_
     content = output_path.read_text()
     assert "'<s>'" in content
     assert "bos_token" not in content
+
+
+def test_autodetect_with_plain_thinking_flag(tmp_path: Path, tekken_v11_path: Path) -> None:
+    """Auto-detect accepts --plain_thinking, which restates what the heuristic already detects."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_v11_path),
+            "--plain_thinking",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    content = output_path.read_text()
+    assert "<think>" in content
+    assert "[THINK]" not in content
+
+
+def test_autodetect_with_no_plain_thinking_flag(tmp_path: Path, tekken_v11_path: Path) -> None:
+    """Auto-detect + --no_plain_thinking forces plain thinking off, overriding the heuristic."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_v11_path),
+            "--no_plain_thinking",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    content = output_path.read_text()
+    assert "<think>" not in content
+
+
+def test_plain_thinking_and_no_plain_thinking_conflict(tmp_path: Path, tekken_v11_path: Path) -> None:
+    """--plain_thinking and --no_plain_thinking together exit non-zero with a mutual-exclusion error."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_v11_path),
+            "--plain_thinking",
+            "--no_plain_thinking",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "--plain_thinking and --no_plain_thinking are mutually exclusive" in result.stderr
+
+
+def test_manual_mode_no_plain_thinking_is_a_no_op(tmp_path: Path) -> None:
+    """--no_plain_thinking is accepted but inert in manual mode, where plain thinking is off anyway."""
+    with_flag = tmp_path / "with_flag.jinja"
+    without_flag = tmp_path / "without_flag.jinja"
+    for output_path, extra_args in ((with_flag, ["--no_plain_thinking"]), (without_flag, [])):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--version", "v11", *extra_args, "--saving_path", str(output_path)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    assert with_flag.read_text() == without_flag.read_text()
+    assert "<think>" not in with_flag.read_text()
+
+
+def test_autodetect_plain_thinking_incompatible_tokenizer_errors_cleanly(
+    tmp_path: Path, tekken_think_v13_path: Path
+) -> None:
+    """Forcing --plain_thinking on a special-token thinking tokenizer reports a CLI error, not a traceback."""
+    output_path = tmp_path / "template.jinja"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--tokenizer_file",
+            str(tekken_think_v13_path),
+            "--plain_thinking",
+            "--saving_path",
+            str(output_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "Plain thinking support and thinking support are mutually exclusive" in result.stderr
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Problem

`convert_tokenizer_to_chat_template` infers plain-text thinking support with:

```python
plain_thinking_support = version == TokenizerVersion.v11 and not audio_support
```

This over-triggers. Generating a template for `mistralai/Mistral-Small-3.2-24B-Instruct-2506` emits the `<think>`/`</think>` rendering branch even though the model is not a reasoning model, and there was no way to turn it off short of dropping auto-detect and passing every capability flag by hand.

The heuristic cannot be repaired. It exists for `mistralai/Magistral-Small-2506`, the one released v11 model that uses plain `<think>` tags — Magistral 2507/2509 moved to v13 with `[THINK]`/`[/THINK]` special tokens, which *are* detectable via `is_special`. Comparing the two files from the Hub, `Magistral-Small-2506/tekken.json` and `Mistral-Small-3.2-24B-Instruct-2506/tekken.json` have identical `config`, `vocab`, `special_tokens` and `multimodal` sections. Nothing in the tokenizer file separates the reasoning model from the non-reasoning one.

## Change

The default stays as it is — the extra branch is harmless, it only fires on explicit thinking chunks or `reasoning_content`. What is added is a way to opt out.

`convert_tokenizer_to_chat_template` gains `plain_thinking_support: bool | None = None`:

| Value | Behaviour |
| --- | --- |
| `None` (default) | Existing heuristic, unchanged |
| `False` | Suppress it |
| `True` | Restates the default for a tokenizer that already qualifies |

`True` cannot widen what is producible: `TemplateConfig` only accepts plain thinking on a v11 tokenizer without audio, which is exactly when the heuristic already returns `True`. It is accepted so callers can state intent, and it raises on anything else. The docstring says so rather than claiming a forcing power the validation layer refutes.

In `scripts/generate_chat_template.py`, `--plain_thinking` is now usable with `--tokenizer_file` (previously rejected as a conflicting manual flag), `--no_plain_thinking` is added, and the two are mutually exclusive. `--no_plain_thinking` is a no-op in manual mode, where plain thinking is already off.

Both CLI branches now route `ValueError` from the template layer through `parser.error`. Previously an invalid combination printed a raw traceback — pre-existing in manual mode, and newly reachable in auto-detect mode via `--plain_thinking`.

## Behaviour change

None by default. Existing callers of `convert_tokenizer_to_chat_template` get byte-identical output; the new parameter is appended last, so positional calls are unaffected.

## Verification

- Full suite: 1603 passed, 16 skipped.
- `ruff check`, `ruff format --check`, `mypy src scripts`: clean.
- Generated a template for Mistral-Small-3.2 with `--no_plain_thinking` and checked it against `mistral_common.encode_chat_completion` through transformers' `render_jinja_template`. Parity holds for default-system injection, explicit system, tools, tool call + result, single image, multi-image, and consecutive user messages. With plain thinking off, a `thinking` chunk raises and `reasoning_content` is dropped rather than leaked.

New tests cover the `False` override, the `True`-matches-autodetect contract, the `True`-with-audio rejection, both CLI flags under auto-detect, the flag conflict, the manual-mode no-op, and the clean-error path.
