### PR TITLE
Document the Debian package in the install docs

### DIFF
--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -26,6 +26,15 @@ pip install "mistral-common[server]"
 pip install "mistral-common[image,audio,hf-hub,sentencepiece,guidance,server]"
 ```
 
+## Debian
+
+`mistral-common` is packaged for Debian as `python3-mistral-common`:
+```sh
+sudo apt install python3-mistral-common
+```
+
+This package is maintained by the Debian Deep Learning Team, not by Mistral AI, so packaging problems should be reported to Debian. It ships the base library only: none of the optional dependencies above are installed with it, and it may lag behind the latest release on PyPI. The [package page](https://packages.debian.org/sid/python3-mistral-common) lists the version available in each Debian suite.
+
 ## From source
 
 To build it for source, you can clone the repository and install it using [uv](https://github.com/astral-sh/uv) or pip. We recommend using uv for faster and more reliable dependency resolution:


### PR DESCRIPTION
## What

Debian accepted `mistral-common` into the archive as `python3-mistral-common`, so it can be installed with `apt` rather than into a virtual environment. #287 asks for that to be documented.

## Change

Adds a `Debian` section to `docs/usage/install.md`, between `Pip` and `From source`. Docs only, no code.

## Claims in the section, and where they come from

- **Package name and install command** — [packages.debian.org/sid/python3-mistral-common](https://packages.debian.org/sid/python3-mistral-common); binary package `python3-mistral-common`, architecture `all`, source package `python-mistral-common`.
- **"maintained by the Debian Deep Learning Team, not by Mistral AI"** — the [tracker page](https://tracker.debian.org/pkg/python-mistral-common) lists that team as maintainer, with Mathieu Baudier, who opened #287, as uploader. The note is there so that packaging problems are reported to Debian rather than to this repository.
- **"ships the base library only"** — the package's `Depends` are `python3-jsonschema`, `python3-numpy`, `python3-pil`, `python3-pydantic`, `python3-pydantic-extra-types`, `python3-requests`, `python3-tiktoken` and `python3-typing-extensions`. That is exactly the `dependencies` list in `pyproject.toml`. None of `opencv-python-headless`, `soundfile`, `soxr`, `sentencepiece`, `llguidance`, `huggingface-hub` or `fastapi` is pulled in, so none of the extras are covered.

No version number and no suite name is written into the docs, because both move. The section links to the package page instead.

## One thing to be aware of

Version 1.11.7-1 is marked for autoremoval from *testing* on 5 September 2026, caused by release-critical bugs in transitive dependencies (fastapi, httpcore, jupyter-notebook, node-playwright, node-yarnpkg, towncrier). That affects testing only, not unstable, and the section names no suite, so the text stays accurate either way.

## Testing

Markdown only. The pre-commit hooks here (actionlint, ruff-check, ruff-format, uv-lock) do not cover markdown. `mkdocs.yml` does not enable the `admonition` extension, so the section uses plain headings and a fenced block, matching the rest of the file.

Closes #287.

Should the README's "How to use it ?" section carry the same line, or is the docs page enough?
