### PR TITLE
Keep at least one pixel per axis when resizing an image

### DIFF
--- a/src/mistral_common/tokens/tokenizers/image.py
+++ b/src/mistral_common/tokens/tokenizers/image.py
@@ -185,8 +185,7 @@ class ImageEncoder:
         w, h = img.size
         ratio = max(h / self.image_config.max_image_size, w / self.image_config.max_image_size)
         if ratio > 1:
-            # Keep at least one pixel per axis: for extreme aspect ratios the shorter
-            # side would otherwise round down to 0 and produce a 0-token axis.
+            # an extreme aspect ratio would otherwise round the shorter side to 0 pixels
             w = max(round(w / ratio), 1)
             h = max(round(h / ratio), 1)
 

--- a/src/mistral_common/tokens/tokenizers/image.py
+++ b/src/mistral_common/tokens/tokenizers/image.py
@@ -185,8 +185,10 @@ class ImageEncoder:
         w, h = img.size
         ratio = max(h / self.image_config.max_image_size, w / self.image_config.max_image_size)
         if ratio > 1:
-            w = round(w / ratio)
-            h = round(h / ratio)
+            # Keep at least one pixel per axis: for extreme aspect ratios the shorter
+            # side would otherwise round down to 0 and produce a 0-token axis.
+            w = max(round(w / ratio), 1)
+            h = max(round(h / ratio), 1)
 
         width_tokens = (w - 1) // (self.image_config.image_patch_size * self.image_config.spatial_merge_size) + 1
         height_tokens = (h - 1) // (self.image_config.image_patch_size * self.image_config.spatial_merge_size) + 1

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -42,21 +42,20 @@ def test_image_to_num_tokens(spatial_merge_size: int, special_token_ids: Special
 
 
 @pytest.mark.parametrize("spatial_merge_size", [1, 2])
-def test_image_to_num_tokens_extreme_aspect_ratio(spatial_merge_size: int, special_token_ids: SpecialImageIDs) -> None:
-    # For a very wide or very tall image the resize used to round the shorter side
-    # down to 0 pixels, which made the token count for that axis 0 and crashed the
-    # encoder on valid input. The shorter side must clamp to at least one token.
+@pytest.mark.parametrize("size", [(1, 512), (4, 10000), (10000, 4), (2, 4096)])
+def test_image_to_num_tokens_extreme_aspect_ratio(
+    special_token_ids: SpecialImageIDs, size: tuple[int, int], spatial_merge_size: int
+) -> None:
     image_config = ImageConfig(
         image_patch_size=16 // spatial_merge_size, max_image_size=128, spatial_merge_size=spatial_merge_size
     )
     image_encoder = ImageEncoder(image_config, special_token_ids)
 
-    for size in [(1, 512), (4, 10000), (10000, 4), (2, 4096)]:
-        img = Image.new("RGB", size, "red")
-        w_tokens, h_tokens = image_encoder._image_to_num_tokens(img)
-        assert w_tokens >= 1 and h_tokens >= 1, (size, w_tokens, h_tokens)
-        encoding = image_encoder(ImageChunk(image=img))
-        assert len(encoding.tokens) == (w_tokens + 1) * h_tokens
+    img = Image.new("RGB", size, "red")
+    w_tokens, h_tokens = image_encoder._image_to_num_tokens(img)
+    assert w_tokens >= 1 and h_tokens >= 1
+    encoding = image_encoder(ImageChunk(image=img))
+    assert len(encoding.tokens) == (w_tokens + 1) * h_tokens
 
 
 @pytest.mark.parametrize("spatial_merge_size", [1, 2])

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -42,6 +42,24 @@ def test_image_to_num_tokens(spatial_merge_size: int, special_token_ids: Special
 
 
 @pytest.mark.parametrize("spatial_merge_size", [1, 2])
+def test_image_to_num_tokens_extreme_aspect_ratio(spatial_merge_size: int, special_token_ids: SpecialImageIDs) -> None:
+    # For a very wide or very tall image the resize used to round the shorter side
+    # down to 0 pixels, which made the token count for that axis 0 and crashed the
+    # encoder on valid input. The shorter side must clamp to at least one token.
+    image_config = ImageConfig(
+        image_patch_size=16 // spatial_merge_size, max_image_size=128, spatial_merge_size=spatial_merge_size
+    )
+    image_encoder = ImageEncoder(image_config, special_token_ids)
+
+    for size in [(1, 512), (4, 10000), (10000, 4), (2, 4096)]:
+        img = Image.new("RGB", size, "red")
+        w_tokens, h_tokens = image_encoder._image_to_num_tokens(img)
+        assert w_tokens >= 1 and h_tokens >= 1, (size, w_tokens, h_tokens)
+        encoding = image_encoder(ImageChunk(image=img))
+        assert len(encoding.tokens) == (w_tokens + 1) * h_tokens
+
+
+@pytest.mark.parametrize("spatial_merge_size", [1, 2])
 def test_download_image(spatial_merge_size: int, special_token_ids: SpecialImageIDs) -> None:
     image_config = ImageConfig(
         image_patch_size=16 // spatial_merge_size, max_image_size=128, spatial_merge_size=spatial_merge_size


### PR DESCRIPTION
## The bug

An image with a very extreme aspect ratio crashes the encoder on valid input. At the production config (`image_patch_size=16`, `max_image_size=1024`), a 4 by 10000 pixel image raises a bare `AssertionError`:

```python
cfg = ImageConfig(image_patch_size=16, max_image_size=1024, spatial_merge_size=1)
enc = ImageEncoder(cfg, SpecialImageIDs(img=10, img_break=11, img_end=12))
enc(ImageChunk(image=Image.new("RGB", (4, 10000))))   # AssertionError
```

Same for 1 by 4096 and 3 by 8000. Nothing about those images is invalid: they are just tall.

## Why

In `_image_to_num_tokens`, when the image is larger than `max_image_size` the two sides are divided by the ratio and rounded. For a ratio above twice the shorter side, `round()` takes that side to 0, so the token count for that axis is `(0 - 1) // patch + 1`, which is 0, and `__call__` then trips its own `assert w > 0`.

## The change

Both axes clamp to a minimum of one pixel after the resize, so an extremely thin image encodes as a single row or column of tokens instead of crashing. Nothing else changes: any image whose shorter side survives the resize is unaffected, and the existing expectations in `test_image_to_num_tokens` still hold.

## Tests

`test_image_to_num_tokens_extreme_aspect_ratio` covers 1x512, 4x10000, 10000x4 and 2x4096 at both `spatial_merge_size` values, asserting both that the axis counts are at least 1 and that the encoder produces the expected token count. It fails on `main` at both parameter values and passes here. The rest of `tests/test_image.py` is green (22 passed).
