### PR TITLE
Strip mistral-specific fields in `SpeechRequest.to_openai`

### DIFF
--- a/src/mistral_common/protocol/speech/request.py
+++ b/src/mistral_common/protocol/speech/request.py
@@ -30,10 +30,12 @@ class SpeechRequest(BaseCompletionRequest):
     voice: str | None = None
     ref_audio: str | bytes | None = None
 
-    def to_openai(self, **kwargs: Any) -> dict[str, Any]:
+    def to_openai(self, exclude: tuple = (), **kwargs: Any) -> dict[str, Any]:
         r"""Convert this SpeechRequest to an OpenAI-compatible request dictionary.
 
         Args:
+            exclude: Fields to exclude from the conversion, in addition to the
+                mistral-specific fields that are always stripped.
             **kwargs: Additional key-value pairs to include in the request dictionary.
 
         Returns:
@@ -61,6 +63,13 @@ class SpeechRequest(BaseCompletionRequest):
 
         openai_request["seed"] = openai_request.pop("random_seed")
         openai_request.update(kwargs)
+
+        # remove mistral-specific fields, mirroring TranscriptionRequest.to_openai
+        # TODO: revisit which fields to expose in the OpenAI format
+        default_exclude = ("id", "max_tokens", "strict_audio_validation", "streaming")
+        default_exclude += exclude
+        for k in default_exclude:
+            openai_request.pop(k, None)
 
         return openai_request
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1283,6 +1283,24 @@ def test_speech_to_openai_bytes_invalid_format() -> None:
         request.to_openai()
 
 
+def test_speech_to_openai_excludes_mistral_specific_fields() -> None:
+    """SpeechRequest.to_openai must strip mistral-internal fields, mirroring
+    TranscriptionRequest.to_openai, rather than leaking e.g. `id`/`max_tokens`
+    into the OpenAI-compatible payload."""
+    request = SpeechRequest(id="req-123", input="Hello world", voice="female", model="tts-1")
+
+    openai_dict = request.to_openai()
+
+    assert "id" not in openai_dict
+    assert "max_tokens" not in openai_dict
+    # OpenAI-relevant fields are preserved.
+    assert openai_dict["input"] == "Hello world"
+    assert openai_dict["voice"] == "female"
+    assert openai_dict["model"] == "tts-1"
+    # The caller-supplied `exclude` is applied on top of the defaults.
+    assert "voice" not in request.to_openai(exclude=("voice",))
+
+
 @pytest.mark.parametrize(
     ["voice", "with_ref_audio", "random_seed"],
     [


### PR DESCRIPTION
## What

`SpeechRequest.to_openai()` leaks mistral-internal fields (`id`, `max_tokens`) into the OpenAI-compatible request payload, while its sibling `TranscriptionRequest.to_openai()` deliberately strips them.

```python
SpeechRequest(id="req-123", input="hi", voice="female", model="tts-1").to_openai()
# {'id': 'req-123', 'max_tokens': None, 'temperature': 0.7, 'top_p': 1.0, 'model': ..., 'input': ..., 'voice': ..., 'seed': ...}
#  ^^^^ leaked                ^^^^^^^^^^ leaked
```

## Why

`SpeechRequest.to_openai` does `self.model_dump(...)` and returns it directly, so every internal field ends up in the OpenAI request. `TranscriptionRequest.to_openai` already handles exactly this:

```python
# transcription/request.py
# remove mistral-specific
# TODO: revisit which fields to expose in the OpenAI format
default_exclude = ("id", "max_tokens", "strict_audio_validation", "streaming")
default_exclude += exclude
for k in default_exclude:
    openai_request.pop(k, None)
```

So the two `to_openai` conversions are inconsistent, and a `SpeechRequest`'s internal `id` / `max_tokens` are sent to the OpenAI endpoint.

## How

Apply the same exclusion in `SpeechRequest.to_openai`, and add an `exclude` parameter for parity with `TranscriptionRequest.to_openai`:

```diff
-    def to_openai(self, **kwargs: Any) -> dict[str, Any]:
+    def to_openai(self, exclude: tuple = (), **kwargs: Any) -> dict[str, Any]:
         ...
         openai_request["seed"] = openai_request.pop("random_seed")
         openai_request.update(kwargs)
+
+        # remove mistral-specific fields, mirroring TranscriptionRequest.to_openai
+        # TODO: revisit which fields to expose in the OpenAI format
+        default_exclude = ("id", "max_tokens", "strict_audio_validation", "streaming")
+        default_exclude += exclude
+        for k in default_exclude:
+            openai_request.pop(k, None)
```

(I kept the exclusion list identical to `TranscriptionRequest` so the two stay in sync; `strict_audio_validation`/`streaming` simply aren't present on `SpeechRequest` and `pop(..., None)` is a no-op for them.)

## Tests

Added `test_speech_to_openai_excludes_mistral_specific_fields`: asserts `id`/`max_tokens` are stripped, the OpenAI fields (`model`/`input`/`voice`) are preserved, and the `exclude` argument is honored. It **fails on `main`** (`id` is present) and passes with this change; the speech `to_openai` tests stay green (10 passed). `ruff check` is clean.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*