### PR TITLE
Fix OpenCV assertion when imports fail

### DIFF
--- a/src/mistral_common/imports.py
+++ b/src/mistral_common/imports.py
@@ -86,7 +86,8 @@ def assert_llguidance_installed() -> None:
 
 @lru_cache()
 def assert_opencv_installed() -> None:
-    assert_package_installed("cv2", _get_dependency_error_message("opencv", "opencv"))
+    if not is_opencv_installed():
+        raise ImportError(_get_dependency_error_message("opencv", "opencv"))
 
 
 @lru_cache()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -51,11 +51,6 @@ _ASSERT_TO_TESTS = {
         "`llguidance` is not installed. Please install it with `pip install mistral-common[guidance]`",
     ),
     (
-        is_opencv_installed,
-        assert_opencv_installed,
-        "`opencv` is not installed. Please install it with `pip install mistral-common[opencv]`",
-    ),
-    (
         is_sentencepiece_installed,
         assert_sentencepiece_installed,
         "`sentencepiece` is not installed. Please install it with `pip install mistral-common[sentencepiece]`",
@@ -112,6 +107,19 @@ def test_is_opencv_installed() -> None:
         assert is_opencv_installed() is False
 
     is_opencv_installed.cache_clear()
+
+
+def test_assert_opencv_installed_checks_import() -> None:
+    assert_opencv_installed.cache_clear()
+
+    with (
+        patch("mistral_common.imports.is_package_installed", return_value=True),
+        patch("mistral_common.imports.is_opencv_installed", return_value=False) as mock_is_opencv_installed,
+        pytest.raises(ImportError, match=r"`opencv` is not installed"),
+    ):
+        assert_opencv_installed()
+
+    mock_is_opencv_installed.assert_called_once_with()
 
 
 @patch("mistral_common.imports.is_package_installed")


### PR DESCRIPTION
## Summary

- use the existing OpenCV import probe in `assert_opencv_installed()`
- raise the actionable optional-dependency error when `cv2` is discoverable but fails to import
- add regression coverage for an installed-but-unimportable OpenCV package

## Why

`is_package_installed("cv2")` only checks whether an import spec exists. A broken OpenCV installation can pass that check even though `is_opencv_installed()` has already caught an import failure, leaving callers to encounter a later `NameError`. The assertion now agrees with the actual import path.

## Testing

- `pytest tests/test_imports.py -q` — 16 passed
- `pytest --cov=mistral_common tests/ --ignore=tests/integrations -q` — 1,151 passed, 16 skipped, 90% coverage
- `pytest --doctest-modules ./src -q` — 52 passed
- `ruff check .`
- `ruff format . --check`
- `mypy .`
- `uv build`
