### PR TITLE
Reject AudioConfig where audio_length_per_tok floors to zero

### DIFF
--- a/src/mistral_common/tokens/tokenizers/audio.py
+++ b/src/mistral_common/tokens/tokenizers/audio.py
@@ -352,6 +352,11 @@ class AudioConfig:
             f"sampling_rate must be >= frame_rate so that each token spans at least one sample, "
             f"got sampling_rate={self.sampling_rate} and frame_rate={self.frame_rate}"
         )
+        assert self.audio_length_per_tok > 0, (
+            f"sampling_rate / frame_rate must be >= hop_length so that each token spans at least one "
+            f"spectrogram frame, got sampling_rate={self.sampling_rate}, frame_rate={self.frame_rate} "
+            f"and hop_length={self.encoding_config.hop_length}"
+        )
 
         if self.chunk_length_s is not None:
             assert self.chunk_length_s > 0, self.chunk_length_s

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -34,6 +34,14 @@ def test_audio_config_rejects_sampling_rate_below_frame_rate() -> None:
         AudioConfig(sampling_rate=1, frame_rate=2.0, encoding_config=encoding_config)
 
 
+def test_audio_config_rejects_audio_length_per_tok_of_zero() -> None:
+    encoding_config = AudioSpectrogramConfig(num_mel_bins=80, hop_length=160, window_size=400)
+    # sampling_rate >= frame_rate holds, but sampling_rate / frame_rate < hop_length floors
+    # audio_length_per_tok to 0, which previously made num_audio_tokens raise ZeroDivisionError.
+    with pytest.raises(AssertionError):
+        AudioConfig(sampling_rate=200, frame_rate=2.0, encoding_config=encoding_config)
+
+
 def test_audio_resample() -> None:
     sampling_rate = 44_000
     original_array = sin_wave(sampling_rate, 1)


### PR DESCRIPTION
#253 added a guard requiring `sampling_rate >= frame_rate` to prevent a ZeroDivisionError in `num_audio_tokens`. That guard does not cover the case where the ratio is positive but smaller than `hop_length`: `audio_length_per_tok` is `int((sampling_rate / frame_rate) / hop_length)`, which floors to 0 and the same ZeroDivisionError survives.

One-line repro on current main:

```python
AudioConfig(sampling_rate=200, frame_rate=2.0, encoding_config=AudioSpectrogramConfig(num_mel_bins=80, hop_length=160, window_size=400)).num_audio_tokens(500)  # ZeroDivisionError
```

This adds a second assert in `__post_init__`, in the same style as #253, requiring `audio_length_per_tok > 0` with a message naming `sampling_rate`, `frame_rate`, and `hop_length`, plus a test alongside #253's. Full suite: 1434 passed, 17 skipped (baseline 1433 plus the new test).
