### PR TITLE
fix(tokenizer): validate ImageConfig fields to prevent ZeroDivisionError

### DIFF
--- a/src/mistral_common/tokens/tokenizers/image.py
+++ b/src/mistral_common/tokens/tokenizers/image.py
@@ -102,6 +102,11 @@ class ImageConfig:
     max_image_size: int
     spatial_merge_size: int = 1
 
+    def __post_init__(self) -> None:
+        assert self.image_patch_size > 0, f"image_patch_size must be > 0, got {self.image_patch_size}"
+        assert self.max_image_size > 0, f"max_image_size must be > 0, got {self.max_image_size}"
+        assert self.spatial_merge_size > 0, f"spatial_merge_size must be > 0, got {self.spatial_merge_size}"
+
 
 def _convert_to_rgb(image: Image.Image) -> Image.Image:
     r"""Convert a PIL image to RGB.


### PR DESCRIPTION
Fixes cryptic ZeroDivisionError when ImageConfig is constructed with invalid zero values.

**Bug:** `ImageConfig(image_patch_size=0)` raises `ZeroDivisionError` deep in `ImageEncoder._image_to_num_tokens` at `width_tokens = (w-1)//(image_patch_size*spatial_merge_size)+1` (image.py:97). Similarly `spatial_merge_size=0` and `max_image_size=0` give cryptic division errors far from the misconfiguration.

**Fix:** Add `__post_init__` to `ImageConfig` mirroring `AudioConfig.__post_init__` hardening in #253/#292. Validates `image_patch_size > 0`, `max_image_size > 0`, `spatial_merge_size > 0` with descriptive messages, failing fast at construction.

**Evidence:** Verified RED->GREEN - before fix `ImageConfig(0,1024,1)._image_to_num_tokens` raised `ZeroDivisionError: integer division or modulo by zero`, after fix it raises `AssertionError: image_patch_size must be > 0, got 0`. All 28 tests in `tests/test_image.py` pass.

Written in conjunction with my pair programmer Claude.