### PR TITLE
Improve typing at dynamic tokenizer boundaries

### DIFF
--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -1,6 +1,6 @@
 import json
 import warnings
-from typing import Generic, Sequence
+from typing import Generic, Sequence, cast
 
 from typing_extensions import assert_never
 
@@ -181,6 +181,35 @@ class InstructRequestNormalizer(
                 f"model_settings_builder should be None for {type(self).__name__}, got {self._model_settings_builder}"
             )
         return ModelSettings.none()
+
+    def _build_instruct_request(
+        self,
+        *,
+        messages: list[UATS],
+        system_prompt: str | None,
+        request: ChatCompletionRequest[UATS],
+        settings: ModelSettings,
+    ) -> InstructRequestType:
+        r"""Construct the configured instruct request class.
+
+        Args:
+            messages: The normalized messages.
+            system_prompt: The normalized system prompt.
+            request: The source chat completion request.
+            settings: The model settings.
+
+        Returns:
+            The configured instruct request.
+        """
+        return cast(
+            InstructRequestType,
+            self._instruct_request_class(
+                messages=messages,
+                system_prompt=system_prompt,
+                available_tools=request.tools,
+                settings=settings,
+            ),
+        )
 
     def _normalize_json_content(self, content: str | None) -> str:
         if content is None or len(content) == 0:
@@ -376,10 +405,10 @@ class InstructRequestNormalizer(
         if settings != ModelSettings.none():
             raise InvalidRequestException(f"Model settings are not supported for {type(self).__name__}, got {settings}")
 
-        return self._instruct_request_class(
+        return self._build_instruct_request(
             messages=messages,
             system_prompt=system_prompt,
-            available_tools=request.tools,
+            request=request,
             settings=settings,
         )
 
@@ -488,22 +517,11 @@ class InstructRequestNormalizerV7(
         settings = self.build_settings(request)
         if settings != ModelSettings.none():
             raise InvalidRequestException(f"Model settings are not supported for {type(self).__name__}, got {settings}")
-<<<<<<< HEAD
-        return self._instruct_request_class(  # type: ignore[no-any-return]
+        return self._build_instruct_request(
             messages=messages,
             system_prompt=None,
-            available_tools=request.tools,
+            request=request,
             settings=settings,
-=======
-        return self._instruct_request_class.model_validate(
-            {
-                "messages": messages,
-                "system_prompt": None,
-                "available_tools": request.tools,
-                "continue_final_message": request.continue_final_message,
-                "settings": settings,
-            }
->>>>>>> a2d85a1 (refactor: tighten normalizer typing)
         )
 
 
@@ -632,22 +650,11 @@ class InstructRequestNormalizerV15(
         """
         messages = self._aggregate_messages(request.messages)
         settings = self.build_settings(request)
-<<<<<<< HEAD
-        return self._instruct_request_class(  # type: ignore[no-any-return]
+        return self._build_instruct_request(
             messages=messages,
             system_prompt=None,
-            available_tools=request.tools,
+            request=request,
             settings=settings,
-=======
-        return self._instruct_request_class.model_validate(
-            {
-                "messages": messages,
-                "system_prompt": None,
-                "available_tools": request.tools,
-                "continue_final_message": request.continue_final_message,
-                "settings": settings,
-            }
->>>>>>> a2d85a1 (refactor: tighten normalizer typing)
         )
 
 

--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -1,6 +1,6 @@
 import json
 import warnings
-from typing import Generic, Sequence, cast
+from typing import Generic, Sequence
 
 from typing_extensions import assert_never
 
@@ -201,14 +201,11 @@ class InstructRequestNormalizer(
         Returns:
             The configured instruct request.
         """
-        return cast(
-            InstructRequestType,
-            self._instruct_request_class(
-                messages=messages,
-                system_prompt=system_prompt,
-                available_tools=request.tools,
-                settings=settings,
-            ),
+        return self._instruct_request_class(
+            messages=messages,
+            system_prompt=system_prompt,
+            available_tools=request.tools,
+            settings=settings,
         )
 
     def _normalize_json_content(self, content: str | None) -> str:

--- a/src/mistral_common/protocol/instruct/normalize.py
+++ b/src/mistral_common/protocol/instruct/normalize.py
@@ -384,7 +384,11 @@ class InstructRequestNormalizer(
         )
 
 
-class InstructRequestNormalizerV7(InstructRequestNormalizer):
+class InstructRequestNormalizerV7(
+    InstructRequestNormalizer[
+        UserMessageType, AssistantMessageType, ToolMessageType, SystemMessageType, InstructRequestType
+    ]
+):
     r"""Normalizer for the v7 tokenizer.
 
     Examples:
@@ -460,7 +464,7 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
     def _aggregate_system_prompts(self, messages: list[UATS]) -> str | None:
         raise NotImplementedError("We should not aggregate system prompts")
 
-    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:  # type: ignore[type-var, misc]
+    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:
         r"""Converts a chat completion request to an instruct request.
 
         Args:
@@ -484,15 +488,30 @@ class InstructRequestNormalizerV7(InstructRequestNormalizer):
         settings = self.build_settings(request)
         if settings != ModelSettings.none():
             raise InvalidRequestException(f"Model settings are not supported for {type(self).__name__}, got {settings}")
+<<<<<<< HEAD
         return self._instruct_request_class(  # type: ignore[no-any-return]
             messages=messages,
             system_prompt=None,
             available_tools=request.tools,
             settings=settings,
+=======
+        return self._instruct_request_class.model_validate(
+            {
+                "messages": messages,
+                "system_prompt": None,
+                "available_tools": request.tools,
+                "continue_final_message": request.continue_final_message,
+                "settings": settings,
+            }
+>>>>>>> a2d85a1 (refactor: tighten normalizer typing)
         )
 
 
-class InstructRequestNormalizerV13(InstructRequestNormalizerV7):
+class InstructRequestNormalizerV13(
+    InstructRequestNormalizerV7[
+        UserMessageType, AssistantMessageType, ToolMessageType, SystemMessageType, InstructRequestType
+    ]
+):
     r"""Normalizer for the v13 tokenizer.
 
     It reorders tool messages based on the tool call order.
@@ -540,7 +559,11 @@ class InstructRequestNormalizerV13(InstructRequestNormalizerV7):
         return tool_messages
 
 
-class InstructRequestNormalizerV15(InstructRequestNormalizerV13):
+class InstructRequestNormalizerV15(
+    InstructRequestNormalizerV13[
+        UserMessageType, AssistantMessageType, ToolMessageType, SystemMessageType, InstructRequestType
+    ]
+):
     r"""Normalizer for the v15 tokenizer.
 
     It reorders tool messages based on the tool call order and builds model settings.
@@ -598,7 +621,7 @@ class InstructRequestNormalizerV15(InstructRequestNormalizerV13):
             raise InvalidRequestException(f"model_settings_builder must not be None for {type(self).__name__}")
         return self._model_settings_builder.build_settings(request)
 
-    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:  # type: ignore[type-var, misc]
+    def from_chat_completion_request(self, request: ChatCompletionRequest[UATS]) -> InstructRequestType:
         r"""Converts a chat completion request to an instruct request.
 
         Args:
@@ -609,11 +632,22 @@ class InstructRequestNormalizerV15(InstructRequestNormalizerV13):
         """
         messages = self._aggregate_messages(request.messages)
         settings = self.build_settings(request)
+<<<<<<< HEAD
         return self._instruct_request_class(  # type: ignore[no-any-return]
             messages=messages,
             system_prompt=None,
             available_tools=request.tools,
             settings=settings,
+=======
+        return self._instruct_request_class.model_validate(
+            {
+                "messages": messages,
+                "system_prompt": None,
+                "available_tools": request.tools,
+                "continue_final_message": request.continue_final_message,
+                "settings": settings,
+            }
+>>>>>>> a2d85a1 (refactor: tighten normalizer typing)
         )
 
 

--- a/src/mistral_common/protocol/instruct/request.py
+++ b/src/mistral_common/protocol/instruct/request.py
@@ -304,6 +304,7 @@ class ChatCompletionRequest(BaseCompletionRequest, Generic[ChatMessageType]):
         converted_tools = convert_openai_tools(tools) if tools is not None else None
 
         return cls(
+            # Pydantic cannot express the runtime-selected request class's message generic here.
             messages=converted_messages,  # type: ignore[arg-type]
             tools=converted_tools,
             random_seed=random_seed,

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -3,7 +3,7 @@ import os
 import warnings
 from functools import cached_property
 from pathlib import Path
-from typing import TypeGuard
+from typing import Protocol, TypeGuard, cast
 
 import numpy as np
 
@@ -31,6 +31,32 @@ warnings.filterwarnings(
 
 if is_sentencepiece_installed():
     from sentencepiece import SentencePieceProcessor
+
+
+class _SentencePieceModel(Protocol):
+    """Typed surface of the optional SentencePiece model used by this module."""
+
+    def piece_to_id(self, piece: str) -> int: ...
+
+    def vocab_size(self) -> int: ...
+
+    def get_piece_size(self) -> int: ...
+
+    def id_to_piece(self, piece_id: int) -> str: ...
+
+    def IsControl(self, token: int) -> bool: ...
+
+    def encode(self, input: str) -> list[int]: ...
+
+    def decode(self, tokens: list[int]) -> str: ...
+
+    def bos_id(self) -> int: ...
+
+    def eos_id(self) -> int: ...
+
+    def pad_id(self) -> int: ...
+
+    def unk_id(self) -> int: ...
 
 
 def is_sentencepiece(path: str | Path) -> bool:
@@ -97,8 +123,9 @@ class SentencePieceTokenizer(Tokenizer):
         self._logger = logging.getLogger(self.__class__.__name__)
         # reload tokenizer
         assert os.path.isfile(model_path), model_path
-        self._model = SentencePieceProcessor(
-            model_file=model_path if isinstance(model_path, str) else model_path.as_posix()
+        self._model: _SentencePieceModel = cast(
+            _SentencePieceModel,
+            SentencePieceProcessor(model_file=model_path if isinstance(model_path, str) else model_path.as_posix()),
         )
 
         assert self._model.vocab_size() == self._model.get_piece_size()
@@ -128,7 +155,7 @@ class SentencePieceTokenizer(Tokenizer):
 
     def get_special_token(self, s: str) -> int:
         r"""Get the special token for the given string."""
-        return self._model.piece_to_id(s)  # type: ignore
+        return self._model.piece_to_id(s)
 
     def get_control_token(self, s: str) -> int:
         warnings.warn("`get_control_token` is deprecated. Use `get_special_token` instead.", FutureWarning)
@@ -137,7 +164,7 @@ class SentencePieceTokenizer(Tokenizer):
     @property
     def n_words(self) -> int:
         r"""Vocabulary size of the tokenizer."""
-        return self._model.vocab_size()  # type: ignore
+        return self._model.vocab_size()
 
     @property
     def num_special_tokens(self) -> int:
@@ -151,20 +178,20 @@ class SentencePieceTokenizer(Tokenizer):
     @cached_property
     def bos_id(self) -> int:
         r"""The beginning of sentence token id."""
-        return self._model.bos_id()  # type: ignore
+        return self._model.bos_id()
 
     @cached_property
     def eos_id(self) -> int:
         r"""The end of sentence token id."""
-        return self._model.eos_id()  # type: ignore
+        return self._model.eos_id()
 
     def is_special(self, token: int | np.integer | str) -> bool:
         """Return `True` if the passed `token` is a special token."""
         if isinstance(token, (int, np.integer)):
-            return self._model.IsControl(int(token))  # type: ignore
+            return self._model.IsControl(int(token))
         elif isinstance(token, str):
             token_int = self._model.piece_to_id(token)
-            return self._model.IsControl(token_int)  # type: ignore
+            return self._model.IsControl(token_int)
         else:
             raise TypeError(f"Expected int or str, got {type(token).__name__}")
 
@@ -230,7 +257,7 @@ class SentencePieceTokenizer(Tokenizer):
 
     def id_to_piece(self, token_id: int) -> str:
         r"""Convert the given token id to a token piece."""
-        return self._model.id_to_piece(token_id)  # type: ignore
+        return self._model.id_to_piece(token_id)
 
     def _decode_with_special_tokens(self, tokens: list[int], special_token_policy: SpecialTokenPolicy) -> str:
         text_list = []
@@ -262,12 +289,12 @@ class SentencePieceTokenizer(Tokenizer):
     @property
     def pad_id(self) -> int:
         r"""The padding token id."""
-        return self._model.pad_id()  # type: ignore
+        return self._model.pad_id()
 
     @property
     def unk_id(self) -> int:
         r"""The unknown token id."""
-        return self._model.unk_id()  # type: ignore
+        return self._model.unk_id()
 
 
 def is_sentencepiece_tokenizer(tokenizer: Tokenizer) -> TypeGuard[SentencePieceTokenizer]:

--- a/src/mistral_common/tokens/tokenizers/sentencepiece.py
+++ b/src/mistral_common/tokens/tokenizers/sentencepiece.py
@@ -123,6 +123,7 @@ class SentencePieceTokenizer(Tokenizer):
         self._logger = logging.getLogger(self.__class__.__name__)
         # reload tokenizer
         assert os.path.isfile(model_path), model_path
+        # SentencePiece is optional and conditionally imported, so narrow its dynamic result to this local protocol.
         self._model: _SentencePieceModel = cast(
             _SentencePieceModel,
             SentencePieceProcessor(model_file=model_path if isinstance(model_path, str) else model_path.as_posix()),

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -778,6 +778,28 @@ class TestFineTuningNormalizer:
         assert isinstance(result, CustomInstructRequest)
         assert result.system_prompt == "set by custom init"
 
+    def test_configured_request_constructor_preserves_static_type(self) -> None:
+        normalizer: InstructRequestNormalizer[
+            UserMessage,
+            AssistantMessage,
+            ToolMessage,
+            SystemMessage,
+            CustomInstructRequest,
+        ] = InstructRequestNormalizer(
+            UserMessage, AssistantMessage, ToolMessage, SystemMessage, CustomInstructRequest, None
+        )
+
+        result = normalizer._instruct_request_class(
+            messages=[UserMessage(content="a")],
+            system_prompt=None,
+            available_tools=None,
+            continue_final_message=False,
+            settings=ModelSettings.none(),
+        )
+
+        assert_type(result, CustomInstructRequest)
+        assert result.system_prompt == "set by custom init"
+
 
 class TestChatCompletionRequestNormalizationV13:
     @pytest.fixture(autouse=True)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any, NoReturn
 
 import pytest
 from typing_extensions import assert_type
@@ -45,16 +44,6 @@ def mock_chat_completion(messages: list[ChatMessage]) -> ChatCompletionRequest:
         top_p=1.0,
         temperature=0.7,
     )
-
-
-class CustomInstructRequest(InstructRequest[ChatMessage, Tool]):
-    def __init__(self, **data: Any) -> None:
-        data["system_prompt"] = "set by custom init"
-        super().__init__(**data)
-
-    @classmethod
-    def model_validate(cls, obj: Any, **kwargs: Any) -> NoReturn:
-        raise AssertionError("normalizer must use the configured request constructor")
 
 
 class TestChatCompletionRequestNormalization:
@@ -759,24 +748,6 @@ class TestFineTuningNormalizer:
 
         assert_type(result, InstructRequest[FinetuningMessage, Tool])
         assert result == InstructRequest[FinetuningMessage, Tool](messages=[UserMessage(content="a")])
-
-    def test_custom_instruct_request_constructor_is_called(self) -> None:
-        normalizer: InstructRequestNormalizer[
-            UserMessage,
-            AssistantMessage,
-            ToolMessage,
-            SystemMessage,
-            CustomInstructRequest,
-        ] = InstructRequestNormalizer(
-            UserMessage, AssistantMessage, ToolMessage, SystemMessage, CustomInstructRequest, None
-        )
-        request = ChatCompletionRequest[ChatMessage](messages=[UserMessage(content="a")])
-
-        result = normalizer.from_chat_completion_request(request)
-
-        assert_type(result, CustomInstructRequest)
-        assert isinstance(result, CustomInstructRequest)
-        assert result.system_prompt == "set by custom init"
 
 
 class TestChatCompletionRequestNormalizationV13:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,7 +1,10 @@
 import json
+from pathlib import Path
+from typing import assert_type
 
 import pytest
 
+from mistral_common.protocol.instruct import normalize as normalize_module
 from mistral_common.protocol.instruct.chunk import (
     AudioChunk,
     ChunkTypes,
@@ -426,6 +429,12 @@ class TestChatCompletionRequestNormalization:
             ],
         )
 
+    def test_normalizer_does_not_use_broad_mypy_suppressions(self) -> None:
+        source = Path(normalize_module.__file__).read_text()
+
+        assert "type: ignore[type-var, misc]" not in source
+        assert "type: ignore[no-any-return]" not in source
+
 
 class TestChatCompletionRequestNormalizationV7:
     @pytest.fixture(autouse=True)
@@ -730,6 +739,23 @@ class TestFineTuningNormalizer:
         )
         normalized = normalizer.from_chat_completion_request(request)
         assert normalized == expected
+
+    def test_return_type_matches_configured_request_class(self) -> None:
+        normalizer: InstructRequestNormalizer[
+            UserMessage,
+            FinetuningAssistantMessage,
+            ToolMessage,
+            SystemMessage,
+            InstructRequest[FinetuningMessage, Tool],
+        ] = InstructRequestNormalizer(
+            UserMessage, FinetuningAssistantMessage, ToolMessage, SystemMessage, InstructRequest, None
+        )
+        request = ChatCompletionRequest[FinetuningMessage](messages=[UserMessage(content="a")])
+
+        result = normalizer.from_chat_completion_request(request)
+
+        assert_type(result, InstructRequest[FinetuningMessage, Tool])
+        assert result == InstructRequest[FinetuningMessage, Tool](messages=[UserMessage(content="a")])
 
 
 class TestChatCompletionRequestNormalizationV13:

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -778,28 +778,6 @@ class TestFineTuningNormalizer:
         assert isinstance(result, CustomInstructRequest)
         assert result.system_prompt == "set by custom init"
 
-    def test_configured_request_constructor_preserves_static_type(self) -> None:
-        normalizer: InstructRequestNormalizer[
-            UserMessage,
-            AssistantMessage,
-            ToolMessage,
-            SystemMessage,
-            CustomInstructRequest,
-        ] = InstructRequestNormalizer(
-            UserMessage, AssistantMessage, ToolMessage, SystemMessage, CustomInstructRequest, None
-        )
-
-        result = normalizer._instruct_request_class(
-            messages=[UserMessage(content="a")],
-            system_prompt=None,
-            available_tools=None,
-            continue_final_message=False,
-            settings=ModelSettings.none(),
-        )
-
-        assert_type(result, CustomInstructRequest)
-        assert result.system_prompt == "set by custom init"
-
 
 class TestChatCompletionRequestNormalizationV13:
     @pytest.fixture(autouse=True)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,10 +1,9 @@
 import json
-from pathlib import Path
-from typing import assert_type
+from typing import Any, NoReturn
 
 import pytest
+from typing_extensions import assert_type
 
-from mistral_common.protocol.instruct import normalize as normalize_module
 from mistral_common.protocol.instruct.chunk import (
     AudioChunk,
     ChunkTypes,
@@ -46,6 +45,16 @@ def mock_chat_completion(messages: list[ChatMessage]) -> ChatCompletionRequest:
         top_p=1.0,
         temperature=0.7,
     )
+
+
+class CustomInstructRequest(InstructRequest[ChatMessage, Tool]):
+    def __init__(self, **data: Any) -> None:
+        data["system_prompt"] = "set by custom init"
+        super().__init__(**data)
+
+    @classmethod
+    def model_validate(cls, obj: Any, **kwargs: Any) -> NoReturn:
+        raise AssertionError("normalizer must use the configured request constructor")
 
 
 class TestChatCompletionRequestNormalization:
@@ -429,12 +438,6 @@ class TestChatCompletionRequestNormalization:
             ],
         )
 
-    def test_normalizer_does_not_use_broad_mypy_suppressions(self) -> None:
-        source = Path(normalize_module.__file__).read_text()
-
-        assert "type: ignore[type-var, misc]" not in source
-        assert "type: ignore[no-any-return]" not in source
-
 
 class TestChatCompletionRequestNormalizationV7:
     @pytest.fixture(autouse=True)
@@ -756,6 +759,24 @@ class TestFineTuningNormalizer:
 
         assert_type(result, InstructRequest[FinetuningMessage, Tool])
         assert result == InstructRequest[FinetuningMessage, Tool](messages=[UserMessage(content="a")])
+
+    def test_custom_instruct_request_constructor_is_called(self) -> None:
+        normalizer: InstructRequestNormalizer[
+            UserMessage,
+            AssistantMessage,
+            ToolMessage,
+            SystemMessage,
+            CustomInstructRequest,
+        ] = InstructRequestNormalizer(
+            UserMessage, AssistantMessage, ToolMessage, SystemMessage, CustomInstructRequest, None
+        )
+        request = ChatCompletionRequest[ChatMessage](messages=[UserMessage(content="a")])
+
+        result = normalizer.from_chat_completion_request(request)
+
+        assert_type(result, CustomInstructRequest)
+        assert isinstance(result, CustomInstructRequest)
+        assert result.system_prompt == "set by custom init"
 
 
 class TestChatCompletionRequestNormalizationV13:

--- a/tests/test_sentencepiece.py
+++ b/tests/test_sentencepiece.py
@@ -1,11 +1,33 @@
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
 from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
+
+if TYPE_CHECKING:
+    from mistral_common.tokens.tokenizers.sentencepiece import _SentencePieceModel
+
+
+def _exercise_sentencepiece_model(
+    model: "_SentencePieceModel",
+) -> tuple[int, int, str, bool, list[int], str, int, int, int, int, int]:
+    return (
+        model.piece_to_id(piece="<s>"),
+        model.vocab_size(),
+        model.id_to_piece(piece_id=0),
+        model.IsControl(token=0),
+        model.encode(input="text"),
+        model.decode(tokens=[0]),
+        model.get_piece_size(),
+        model.bos_id(),
+        model.eos_id(),
+        model.pad_id(),
+        model.unk_id(),
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_sentencepiece.py
+++ b/tests/test_sentencepiece.py
@@ -1,33 +1,11 @@
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
-from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy
+from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, Tokenizer
 from mistral_common.tokens.tokenizers.sentencepiece import SentencePieceTokenizer
-
-if TYPE_CHECKING:
-    from mistral_common.tokens.tokenizers.sentencepiece import _SentencePieceModel
-
-
-def _exercise_sentencepiece_model(
-    model: "_SentencePieceModel",
-) -> tuple[int, int, str, bool, list[int], str, int, int, int, int, int]:
-    return (
-        model.piece_to_id(piece="<s>"),
-        model.vocab_size(),
-        model.id_to_piece(piece_id=0),
-        model.IsControl(token=0),
-        model.encode(input="text"),
-        model.decode(tokens=[0]),
-        model.get_piece_size(),
-        model.bos_id(),
-        model.eos_id(),
-        model.pad_id(),
-        model.unk_id(),
-    )
 
 
 @pytest.fixture(scope="module")
@@ -40,6 +18,19 @@ def tokenizer_v7() -> SentencePieceTokenizer:
         / "mistral_instruct_tokenizer_241114.model.v7"
     )
     return SentencePieceTokenizer(model_path=_model_path)
+
+
+def test_sentencepiece_tokenizer_matches_tokenizer_contract(tokenizer_v7: SentencePieceTokenizer) -> None:
+    tokenizer: Tokenizer = tokenizer_v7
+    vocab = tokenizer.vocab()
+
+    assert tokenizer.n_words == len(vocab)
+    assert vocab[tokenizer.bos_id] == "<s>"
+    assert vocab[tokenizer.eos_id] == "</s>"
+    assert tokenizer.get_special_token("<s>") == tokenizer.bos_id
+    assert tokenizer.get_special_token("</s>") == tokenizer.eos_id
+    assert tokenizer.id_to_piece(tokenizer.unk_id) == "<unk>"
+    assert tokenizer.pad_id == -1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- preserve concrete request types through generic normalizers without broad mypy suppressions
- describe the optional SentencePiece API through a local protocol
- narrow and document the remaining Pydantic generic-boundary ignore

## Compatibility

No public runtime signatures, request fields, tokenizer behavior, or `Tokenized` fields change.

## Validation

- `../../.venv/bin/mypy src/mistral_common tests`
- `../../.venv/bin/ruff check src tests`
- `../../.venv/bin/ruff format --check src tests`
- `../../.venv/bin/pytest` (1625 passed, 16 skipped)