### PR TITLE
Update uv tooling to 0.12.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,6 @@ repos:
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes]
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.14
+    rev: 0.12.6
     hooks:
       - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test-integrations = [
 
 
 [tool.uv]
-required-version = "==0.11.14"
+required-version = "==0.12.6"
 
 [tool.ruff]
 lint.select = ["E", "F", "W", "Q", "I"]


### PR DESCRIPTION
## Summary

- update the project-required uv version to 0.12.6
- update the matching uv-pre-commit hook revision
- preserve the existing lockfile because it remains valid under uv 0.12.6

## Testing

- `uv 0.12.6 lock --check`
- `pre-commit run uv-lock --all-files`
- `./.venv/bin/pytest -q` (1622 passed, 16 skipped)