### PR TITLE
Parallelize unit and integration test suites

### DIFF
--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -123,14 +123,4 @@ jobs:
 
       - name: Integration Tests
         run: |
-          integration_roots=()
-          for root in tests/integrations tests/integration; do
-            if [[ -d "$root" ]]; then
-              integration_roots+=("$root")
-            fi
-          done
-          if ((${#integration_roots[@]} == 0)); then
-            echo "No integration test root found: expected tests/integrations or tests/integration." >&2
-            exit 1
-          fi
-          uv run --no-sync pytest "${integration_roots[@]}" -n auto --dist load -v
+          uv run --no-sync pytest tests/integrations/ -n auto --dist load -v

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -69,7 +69,7 @@ jobs:
       # PyTest
       - name: Tests
         run: |
-          uv run pytest --cov=mistral_common tests/ --ignore=tests/integrations --ignore=tests/integration -n auto --dist load --cov-report "xml:coverage.xml"
+          uv run pytest --cov=mistral_common tests/ --ignore=tests/integrations --ignore=tests/integration -n auto --dist loadfile --cov-report "xml:coverage.xml"
       
       # Doctests
       - name: Doctests
@@ -123,4 +123,4 @@ jobs:
 
       - name: Integration Tests
         run: |
-          uv run --no-sync pytest tests/integrations/ -n auto --dist load -v
+          uv run --no-sync pytest tests/integrations/ -n auto --dist loadfile -v

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -129,4 +129,8 @@ jobs:
               integration_roots+=("$root")
             fi
           done
+          if ((${#integration_roots[@]} == 0)); then
+            echo "No integration test root found: expected tests/integrations or tests/integration." >&2
+            exit 1
+          fi
           uv run --no-sync pytest "${integration_roots[@]}" -n auto --dist load -v

--- a/.github/workflows/lint_build_test.yaml
+++ b/.github/workflows/lint_build_test.yaml
@@ -69,7 +69,7 @@ jobs:
       # PyTest
       - name: Tests
         run: |
-          uv run pytest --cov=mistral_common tests/ --ignore=tests/integrations --cov-report "xml:coverage.xml"
+          uv run pytest --cov=mistral_common tests/ --ignore=tests/integrations --ignore=tests/integration -n auto --dist load --cov-report "xml:coverage.xml"
       
       # Doctests
       - name: Doctests
@@ -123,4 +123,10 @@ jobs:
 
       - name: Integration Tests
         run: |
-          uv run --no-sync pytest tests/integrations/ -v
+          integration_roots=()
+          for root in tests/integrations tests/integration; do
+            if [[ -d "$root" ]]; then
+              integration_roots+=("$root")
+            fi
+          done
+          uv run --no-sync pytest "${integration_roots[@]}" -n auto --dist load -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,30 +150,17 @@ mistral-common/
 - Aim for high, meaningful coverage. Prioritise tests that verify behaviour over hitting a line-count target.
 - New and changed code should be covered by tests.
 - Avoid coverage-only comments. Prefer restructuring so branches are genuinely reachable and tested (e.g. validate inputs and test the error path) over excluding lines.
-- Retain existing local `pytest-cov`, coverage.py, and diff-cover workflows and the unit-only CI coverage output unchanged. The unit-only percentage is not an authoritative whole-suite signal.
-- Defer combined coverage measurement, thresholds, baselines, historical comparisons, and the 90% aspiration until the test architecture stabilises. Do not distort production design or behavior to improve a coverage number.
 
 ### Test Suite Modernization
 
-#### Layout and classification
-- New tests belong under `tests/unit/`, `tests/integration/`, `tests/utils/`, or `tests/utils_tests/`. Unit tests mirror the source package structure; integration tests follow public workflows rather than private implementation boundaries.
-- During migration, `tests/integrations/` and `tests/integration/` are both integration roots. Legacy tests outside those roots remain in the unit lane until they move to a target path. A test move must preserve its existing coverage atomically; no test ID may disappear or be collected by both lanes.
-- Unit tests are hermetic and exercise one module or a narrowly bounded unit with controlled inputs. Integration tests exercise public multi-module workflows with real artifacts and resources appropriate to that workflow.
-- Split test packages by behavior and ownership, not by arbitrary file size. Group related tests by class or function, and use source-mirroring paths for unit tests. There is no numeric file-size limit; split a file when its behavior or ownership becomes unclear.
-
-#### Test cases, fixtures, and compatibility
-- Parametrization IDs describe the semantic feature, input, or version under test. Use complete compatible feature and version matrices; do not omit supported combinations merely to shorten a run.
-- Error tests assert the exact exception type and stable message or error details that form part of the contract.
-- Fixtures own data at the nearest scope that uses it. Return fresh mutable values for each test. Use session-scoped fixtures only for expensive immutable resources, and promote a fixture to a broader scope after real reuse justifies it.
-
-#### Parallel execution
-- Both unit and integration lanes are required for every supported Python version and must run with `pytest-xdist` using its default `load` distribution. Keep xdist activation explicit for those suites rather than making every pytest invocation parallel by default.
-- Serial and parallel collection must be deterministic and produce identical test IDs. A collection mismatch or timeout blocks the lane and must be diagnosed and fixed; do not mask it with ordering, sleeps, or broad serialization.
-- Add a serial or grouped exception only after reproducing and documenting a process-safety failure. Do not add ordering constraints, sleeps, serial markers, or shared global state to make parallel tests pass.
-
-#### Migration and production behavior
-- Replace legacy test behavior atomically while retaining coverage and observable behavior. Do not combine test-path migration with an unrelated production defect fix.
-- Production defects found during migration require a separate PR with a characterized test that records the existing behavior before the production change.
+- Unit tests belong under `tests/unit/` and mirror the source package structure. Integration tests belong under `tests/integration/` and exercise public multi-module workflows with real artifacts; the current `tests/integrations/` path remains an integration lane during migration. Other existing test paths are legacy and are removed as migration completes.
+- Unit tests are hermetic; integration tests use realistic public workflows. Split test packages by behavior or ownership, not by an arbitrary line count.
+- Group related tests by production class or function. Use semantic IDs only for parametrized cases; clear test and class names are sufficient otherwise.
+- Use fresh mutable fixtures at the narrowest useful scope. Broader scopes are reserved for expensive immutable resources with real reuse.
+- Error tests assert the exact exception type and stable message or error details.
+- Unit and integration lanes run with `pytest-xdist` using default `load` distribution. Serial and grouped exceptions require a reproduced process-safety failure.
+- Serial and parallel collection must produce identical test IDs. Diagnose collection mismatches and timeouts; do not mask them with sleeps or broad serialization.
+- Replace legacy tests atomically. Keep production fixes in separate PRs with characterization tests.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,7 @@ mistral-common/
 
 #### Parallel execution
 - Both unit and integration lanes are required for every supported Python version and must run with `pytest-xdist` using its default `load` distribution. Keep xdist activation explicit for those suites rather than making every pytest invocation parallel by default.
+- Serial and parallel collection must be deterministic and produce identical test IDs. A collection mismatch or timeout blocks the lane and must be diagnosed and fixed; do not mask it with ordering, sleeps, or broad serialization.
 - Add a serial or grouped exception only after reproducing and documenting a process-safety failure. Do not add ordering constraints, sleeps, serial markers, or shared global state to make parallel tests pass.
 
 #### Migration and production behavior

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,29 @@ mistral-common/
 - Aim for high, meaningful coverage. Prioritise tests that verify behaviour over hitting a line-count target.
 - New and changed code should be covered by tests.
 - Avoid coverage-only comments. Prefer restructuring so branches are genuinely reachable and tested (e.g. validate inputs and test the error path) over excluding lines.
+- Retain existing local `pytest-cov`, coverage.py, and diff-cover workflows and the unit-only CI coverage output unchanged. The unit-only percentage is not an authoritative whole-suite signal.
+- Defer combined coverage measurement, thresholds, baselines, historical comparisons, and the 90% aspiration until the test architecture stabilises. Do not distort production design or behavior to improve a coverage number.
+
+### Test Suite Modernization
+
+#### Layout and classification
+- New tests belong under `tests/unit/`, `tests/integration/`, `tests/utils/`, or `tests/utils_tests/`. Unit tests mirror the source package structure; integration tests follow public workflows rather than private implementation boundaries.
+- During migration, `tests/integrations/` and `tests/integration/` are both integration roots. Legacy tests outside those roots remain in the unit lane until they move to a target path. A test move must preserve its existing coverage atomically; no test ID may disappear or be collected by both lanes.
+- Unit tests are hermetic and exercise one module or a narrowly bounded unit with controlled inputs. Integration tests exercise public multi-module workflows with real artifacts and resources appropriate to that workflow.
+- Split test packages by behavior and ownership, not by arbitrary file size. Group related tests by class or function, and use source-mirroring paths for unit tests. There is no numeric file-size limit; split a file when its behavior or ownership becomes unclear.
+
+#### Test cases, fixtures, and compatibility
+- Parametrization IDs describe the semantic feature, input, or version under test. Use complete compatible feature and version matrices; do not omit supported combinations merely to shorten a run.
+- Error tests assert the exact exception type and stable message or error details that form part of the contract.
+- Fixtures own data at the nearest scope that uses it. Return fresh mutable values for each test. Use session-scoped fixtures only for expensive immutable resources, and promote a fixture to a broader scope after real reuse justifies it.
+
+#### Parallel execution
+- Both unit and integration lanes are required for every supported Python version and must run with `pytest-xdist` using its default `load` distribution. Keep xdist activation explicit for those suites rather than making every pytest invocation parallel by default.
+- Add a serial or grouped exception only after reproducing and documenting a process-safety failure. Do not add ordering constraints, sleeps, serial markers, or shared global state to make parallel tests pass.
+
+#### Migration and production behavior
+- Replace legacy test behavior atomically while retaining coverage and observable behavior. Do not combine test-path migration with an unrelated production defect fix.
+- Production defects found during migration require a separate PR with a characterized test that records the existing behavior before the production change.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,15 +151,11 @@ mistral-common/
 - New and changed code should be covered by tests.
 - Avoid coverage-only comments. Prefer restructuring so branches are genuinely reachable and tested (e.g. validate inputs and test the error path) over excluding lines.
 
-### Test Suite Modernization
+### Test organization
 
-- Unit tests belong under `tests/unit/` and mirror the source package structure. Integration tests belong under `tests/integration/` and exercise public multi-module workflows with real artifacts. Other existing test paths, including the current `tests/integrations/` path, are legacy and are removed as migration completes; update CI in the same PR when moving that path.
-- Unit tests are hermetic; integration tests use realistic public workflows. Split test packages by behavior or ownership, not by an arbitrary line count.
-- Group related tests by production class or function. Use semantic IDs only for parametrized cases; clear test and class names are sufficient otherwise.
-- Use the broadest safe fixture scope. Share immutable reusable resources broadly; keep mutable or stateful fixtures narrower when mutation could leak between tests.
-- Error tests assert the exact exception type and stable message or error details.
-- Unit and integration lanes run with `pytest-xdist` using `loadfile` distribution so each test file stays on one worker. Serial and grouped exceptions require a reproduced process-safety failure.
-- Serial and parallel collection must produce identical test IDs. Diagnose collection mismatches and timeouts; do not mask them with sleeps or broad serialization.
+- New unit tests belong under `tests/unit/` and mirror the source package structure.
+- New integration tests belong under `tests/integration/` and exercise public workflows.
+- Existing tests elsewhere are legacy during the ongoing migration and are removed as their replacements land.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ mistral-common/
 - Group related tests by production class or function. Use semantic IDs only for parametrized cases; clear test and class names are sufficient otherwise.
 - Use the broadest safe fixture scope. Share immutable reusable resources broadly; keep mutable or stateful fixtures narrower when mutation could leak between tests.
 - Error tests assert the exact exception type and stable message or error details.
-- Unit and integration lanes run with `pytest-xdist` using default `load` distribution. Serial and grouped exceptions require a reproduced process-safety failure.
+- Unit and integration lanes run with `pytest-xdist` using `loadfile` distribution so each test file stays on one worker. Serial and grouped exceptions require a reproduced process-safety failure.
 - Serial and parallel collection must produce identical test IDs. Diagnose collection mismatches and timeouts; do not mask them with sleeps or broad serialization.
 
 ## Development Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,11 +156,10 @@ mistral-common/
 - Unit tests belong under `tests/unit/` and mirror the source package structure. Integration tests belong under `tests/integration/` and exercise public multi-module workflows with real artifacts; the current `tests/integrations/` path remains an integration lane during migration. Other existing test paths are legacy and are removed as migration completes.
 - Unit tests are hermetic; integration tests use realistic public workflows. Split test packages by behavior or ownership, not by an arbitrary line count.
 - Group related tests by production class or function. Use semantic IDs only for parametrized cases; clear test and class names are sufficient otherwise.
-- Use fresh mutable fixtures at the narrowest useful scope. Broader scopes are reserved for expensive immutable resources with real reuse.
+- Use the broadest safe fixture scope. Share immutable reusable resources broadly; keep mutable or stateful fixtures narrower when mutation could leak between tests.
 - Error tests assert the exact exception type and stable message or error details.
 - Unit and integration lanes run with `pytest-xdist` using default `load` distribution. Serial and grouped exceptions require a reproduced process-safety failure.
 - Serial and parallel collection must produce identical test IDs. Diagnose collection mismatches and timeouts; do not mask them with sleeps or broad serialization.
-- Replace legacy tests atomically. Keep production fixes in separate PRs with characterization tests.
 
 ## Development Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ mistral-common/
 
 ### Test Suite Modernization
 
-- Unit tests belong under `tests/unit/` and mirror the source package structure. Integration tests belong under `tests/integration/` and exercise public multi-module workflows with real artifacts; the current `tests/integrations/` path remains an integration lane during migration. Other existing test paths are legacy and are removed as migration completes.
+- Unit tests belong under `tests/unit/` and mirror the source package structure. Integration tests belong under `tests/integration/` and exercise public multi-module workflows with real artifacts. Other existing test paths, including the current `tests/integrations/` path, are legacy and are removed as migration completes; update CI in the same PR when moving that path.
 - Unit tests are hermetic; integration tests use realistic public workflows. Split test packages by behavior or ownership, not by an arbitrary line count.
 - Group related tests by production class or function. Use semantic IDs only for parametrized cases; clear test and class names are sufficient otherwise.
 - Use the broadest safe fixture scope. Share immutable reusable resources broadly; keep mutable or stateful fixtures narrower when mutation could leak between tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "ruff>=0.2.2",
     "mypy>=1.8.0",
     "pytest-cov>=4.1.0",
+    "pytest-xdist>=3.8.0",
     "diff-cover>=8.0.3",
     "types-Pillow>=10.2.0",
     "types-requests>=2.32",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -34,7 +34,7 @@ _IS_INSTALLED_TO_TESTS = [
     is_soxr_installed,
 ]
 
-_ASSERT_TO_TESTS = {
+_ASSERT_TO_TESTS = [
     (
         is_hf_hub_installed,
         assert_hf_hub_installed,
@@ -70,7 +70,7 @@ _ASSERT_TO_TESTS = {
         assert_soxr_installed,
         "`soxr` is not installed. Please install it with `pip install mistral-common[soxr]`",
     ),
-}
+]
 
 
 @patch("importlib.util.find_spec")

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
@@ -945,6 +954,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-jsonschema" },
     { name = "types-pillow" },
@@ -1006,6 +1016,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=7.4.4" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.2.2" },
     { name = "types-jsonschema", specifier = ">=4.21.0.20240118" },
     { name = "types-pillow", specifier = ">=10.2.0" },
@@ -1997,6 +2008,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add pytest-xdist and run unit and integration suites in parallel on Python 3.10–3.14.
- Preserve existing coverage tooling and unit-only coverage output; defer coverage redesign.
- Add explicit old/new integration-root handling and fix nondeterministic import-test collection.
- Document the test-suite modernization rules in AGENTS.md.

## Verification

- Unit suite with xdist and existing coverage command: 1165 passed, 16 skipped.
- Integration suite with xdist: 457 passed.
- Doctests: 52 passed.
- Ruff, formatting, mypy, YAML/actionlint, and collection parity checks passed.

Draft PR for review; no runtime library behavior changes.