### PR TITLE
Align tokenizer type contracts

### DIFF
--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -12,10 +12,10 @@ from mistral_common.deprecation import warn_once
 from mistral_common.protocol.fim.request import FIMRequest
 from mistral_common.protocol.instruct.chunk import ContentChunk
 from mistral_common.protocol.instruct.messages import (
-    AssistantMessageType,
+    SystemMessage,
     UserMessage,
 )
-from mistral_common.protocol.instruct.request import InstructRequest
+from mistral_common.protocol.instruct.request import InstructRequest, ModelSettings
 from mistral_common.protocol.instruct.tool_calls import Tool
 from mistral_common.protocol.speech.request import SpeechRequest
 from mistral_common.protocol.transcription.request import TranscriptionRequest
@@ -329,7 +329,7 @@ FIMRequestType = TypeVar("FIMRequestType", bound=FIMRequest)
 TokenizedType = TypeVar("TokenizedType", bound=Tokenized)
 
 
-class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedType, AssistantMessageType]):
+class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedType]):
     r"""Base class for instruct tokenizers.
 
     Attributes:
@@ -431,6 +431,7 @@ class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedTy
         is_first: bool,
         system_prompt: str | None = None,
         force_img_first: bool = False,
+        settings: ModelSettings = ModelSettings.none(),
     ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a user message.
 
@@ -445,6 +446,11 @@ class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedTy
         Returns:
             The encoded tokens and images.
         """
+        ...
+
+    @abstractmethod
+    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]:
+        r"""Encode a system message."""
         ...
 
     @abstractmethod

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -11,11 +11,8 @@ from mistral_common.base import MistralBase
 from mistral_common.deprecation import warn_once
 from mistral_common.protocol.fim.request import FIMRequest
 from mistral_common.protocol.instruct.chunk import ContentChunk
-from mistral_common.protocol.instruct.messages import (
-    SystemMessage,
-    UserMessage,
-)
-from mistral_common.protocol.instruct.request import InstructRequest, ModelSettings
+from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.protocol.instruct.tool_calls import Tool
 from mistral_common.protocol.speech.request import SpeechRequest
 from mistral_common.protocol.transcription.request import TranscriptionRequest
@@ -431,7 +428,6 @@ class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedTy
         is_first: bool,
         system_prompt: str | None = None,
         force_img_first: bool = False,
-        settings: ModelSettings = ModelSettings.none(),
     ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a user message.
 
@@ -446,11 +442,6 @@ class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedTy
         Returns:
             The encoded tokens and images.
         """
-        ...
-
-    @abstractmethod
-    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]:
-        r"""Encode a system message."""
         ...
 
     @abstractmethod

--- a/src/mistral_common/tokens/tokenizers/base.py
+++ b/src/mistral_common/tokens/tokenizers/base.py
@@ -11,8 +11,8 @@ from mistral_common.base import MistralBase
 from mistral_common.deprecation import warn_once
 from mistral_common.protocol.fim.request import FIMRequest
 from mistral_common.protocol.instruct.chunk import ContentChunk
-from mistral_common.protocol.instruct.messages import UserMessage
-from mistral_common.protocol.instruct.request import InstructRequest
+from mistral_common.protocol.instruct.messages import SystemMessage, UserMessage
+from mistral_common.protocol.instruct.request import InstructRequest, ModelSettings
 from mistral_common.protocol.instruct.tool_calls import Tool
 from mistral_common.protocol.speech.request import SpeechRequest
 from mistral_common.protocol.transcription.request import TranscriptionRequest
@@ -428,6 +428,7 @@ class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedTy
         is_first: bool,
         system_prompt: str | None = None,
         force_img_first: bool = False,
+        settings: ModelSettings = ModelSettings.none(),
     ) -> tuple[list[int], list[np.ndarray], list[Audio]]:
         r"""Encode a user message.
 
@@ -438,10 +439,16 @@ class InstructTokenizer(Generic[InstructRequestType, FIMRequestType, TokenizedTy
             is_first: Whether the message is the first one.
             system_prompt: The system prompt.
             force_img_first: Whether to force the image to be first.
+            settings: The model settings.
 
         Returns:
             The encoded tokens and images.
         """
+        ...
+
+    @abstractmethod
+    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]:
+        r"""Encode a system message."""
         ...
 
     @abstractmethod

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -22,7 +22,7 @@ from mistral_common.protocol.instruct.chunk import (
 from mistral_common.protocol.instruct.messages import (
     UATS,
     AssistantMessage,
-    AssistantMessageType,
+    ChatMessage,
     SystemMessage,
     ToolMessage,
     UserMessage,
@@ -47,9 +47,7 @@ from mistral_common.tokens.tokenizers.image import ImageEncoder
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 
 
-class InstructTokenizerBase(
-    InstructTokenizer, Generic[InstructRequestType, FIMRequestType, TokenizedType, AssistantMessageType]
-):
+class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMRequestType, TokenizedType]):
     r"""Base instruct tokenizer."""
 
     def __init__(
@@ -112,7 +110,7 @@ class InstructTokenizerBase(
         raise NotImplementedError("Tool message not implemented")
 
     @abstractmethod
-    def encode_assistant_message(self, message: AssistantMessageType, is_before_last_user_message: bool) -> list[int]:
+    def encode_assistant_message(self, message: AssistantMessage, is_before_last_user_message: bool) -> list[int]:
         r"""Encode an assistant message.
 
         Raises:
@@ -132,7 +130,7 @@ class InstructTokenizerBase(
     def _truncate_for_max_tokens(
         self,
         tokenized: list[list[int] | None],
-        messages: list[AssistantMessageType],
+        messages: list[ChatMessage],
         max_tokens: int,
         last_user_message_index: int,
     ) -> None:
@@ -146,7 +144,7 @@ class InstructTokenizerBase(
 
     def encode_instruct(
         self,
-        request: InstructRequest[AssistantMessageType, Tool],
+        request: InstructRequest[ChatMessage, Tool],
     ) -> Tokenized:
         r"""Encode an instruct request.
 
@@ -238,9 +236,7 @@ class InstructTokenizerBase(
         return self.tokenizer._to_string(tokens)
 
 
-class InstructTokenizerV1(
-    InstructTokenizerBase, Generic[InstructRequestType, FIMRequestType, TokenizedType, AssistantMessageType]
-):
+class InstructTokenizerV1(InstructTokenizerBase, Generic[InstructRequestType, FIMRequestType, TokenizedType]):
     r"""Instruct tokenizer V1.
 
     This tokenizer has basic for messages. It does not support tools or image inputs.
@@ -321,7 +317,7 @@ class InstructTokenizerV1(
         """
         raise TokenizerException("Tools not implemented for tokenizer V1")
 
-    def encode_assistant_message(self, message: AssistantMessageType, is_before_last_user_message: bool) -> list[int]:
+    def encode_assistant_message(self, message: AssistantMessage, is_before_last_user_message: bool) -> list[int]:
         r"""Encode an assistant message.
 
         Args:
@@ -365,9 +361,7 @@ class InstructTokenizerV1(
         raise TokenizerException(f"Speech request not available for tokenizer {self.tokenizer.version.value}")
 
 
-class InstructTokenizerV2(
-    InstructTokenizerV1, Generic[InstructRequestType, FIMRequestType, TokenizedType, AssistantMessageType]
-):
+class InstructTokenizerV2(InstructTokenizerV1, Generic[InstructRequestType, FIMRequestType, TokenizedType]):
     r"""Instruct tokenizer V2.
 
     This tokenizer adds supports to images, tools and FIM requests.
@@ -517,12 +511,12 @@ class InstructTokenizerV2(
             "arguments": self._parse_json_content(tool_call.function.arguments),
         }
 
-    def _encode_normal_content_assistant_message(self, message: AssistantMessageType) -> list[int]:
+    def _encode_normal_content_assistant_message(self, message: AssistantMessage) -> list[int]:
         assert message.content, f"Assistant message must have content. Got {message}"
         assert isinstance(message.content, str), "Message content must be a string for tokenizer < V7"
         return self.tokenizer.encode(message.content.rstrip(" "), bos=False, eos=False)
 
-    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessageType) -> list[int]:
+    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessage) -> list[int]:
         assert message.tool_calls, f"Assistant message must have tool calls. Got {message}"
         prepared_tool_calls = []
         for tool_call in message.tool_calls:
@@ -542,7 +536,7 @@ class InstructTokenizerV2(
         assert self.tokenizer.model_settings_builder is None, "`model_settings_builder` not supported for this version."
         return []
 
-    def encode_assistant_message(self, message: AssistantMessageType, is_before_last_user_message: bool) -> list[int]:
+    def encode_assistant_message(self, message: AssistantMessage, is_before_last_user_message: bool) -> list[int]:
         r"""Encode an assistant message.
 
         Args:
@@ -597,9 +591,7 @@ class InstructTokenizerV2(
         return tokenized
 
 
-class InstructTokenizerV3(
-    InstructTokenizerV2, Generic[InstructRequestType, FIMRequestType, TokenizedType, AssistantMessageType]
-):
+class InstructTokenizerV3(InstructTokenizerV2, Generic[InstructRequestType, FIMRequestType, TokenizedType]):
     r"""Instruct tokenizer V3.
 
     The only difference with V2 tokenizer is that it encodes the tool messages differently.
@@ -664,7 +656,7 @@ class InstructTokenizerV3(
         ]
         return curr_tokens, [], []
 
-    def encode_assistant_message(self, message: AssistantMessageType, is_before_last_user_message: bool) -> list[int]:
+    def encode_assistant_message(self, message: AssistantMessage, is_before_last_user_message: bool) -> list[int]:
         r"""Encode an assistant message.
 
         Note:
@@ -829,7 +821,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
     def _truncate_for_max_tokens(
         self,
         tokenized_messages: list[list[int] | None],
-        messages: list[AssistantMessageType],
+        messages: list[ChatMessage],
         max_tokens: int,
         last_user_message_index: int,
     ) -> None:
@@ -1122,7 +1114,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
         ]
         return curr_tokens, [], []
 
-    def encode_assistant_message(self, message: AssistantMessageType, is_before_last_user_message: bool) -> list[int]:
+    def encode_assistant_message(self, message: AssistantMessage, is_before_last_user_message: bool) -> list[int]:
         r"""Encode an assistant message.
 
         Args:
@@ -1224,7 +1216,7 @@ class InstructTokenizerV11(InstructTokenizerV7):
         self.ARGS = self.tokenizer.get_special_token(SpecialTokens.args.value)
         self.CALL_ID = self.tokenizer.get_special_token(SpecialTokens.call_id.value)
 
-    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessageType) -> list[int]:
+    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessage) -> list[int]:
         assert message.tool_calls, f"Assistant message must have tool calls. Got {message}"
         curr_tokens = []
         for tool_call in message.tool_calls:
@@ -1272,7 +1264,7 @@ class InstructTokenizerV13(InstructTokenizerV11):
             self.BEGIN_THINK = None
             self.END_THINK = None
 
-    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessageType) -> list[int]:
+    def _encode_tool_calls_in_assistant_message(self, message: AssistantMessage) -> list[int]:
         assert message.tool_calls, f"Assistant message must have tool calls. Got {message}"
         curr_tokens = []
         for tool_call in message.tool_calls:

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -1,7 +1,7 @@
 import json
 import warnings
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Generic, Sequence, overload
+from typing import Any, Generic, Sequence, overload
 
 import numpy as np
 
@@ -67,21 +67,6 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
         self.image_encoder = image_encoder
         self.audio_encoder = audio_encoder
         super().__init__(tokenizer, image_encoder, audio_encoder)
-
-    if TYPE_CHECKING:
-
-        def encode_user_message(
-            self,
-            message: UserMessage,
-            available_tools: list[Tool] | None,
-            is_last: bool,
-            is_first: bool,
-            system_prompt: str | None = None,
-            force_img_first: bool = False,
-            settings: ModelSettings = ModelSettings.none(),
-        ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
-
-        def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]: ...
 
     @property
     def mm_encoder(self) -> ImageEncoder | None:

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -70,29 +70,6 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
 
     if TYPE_CHECKING:
 
-        @overload
-        def encode_user_message(
-            self,
-            message: UserMessage,
-            available_tools: list[Tool] | None,
-            is_last: bool,
-            is_first: bool,
-            system_prompt: str | None = None,
-            force_img_first: bool = False,
-        ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
-
-        @overload
-        def encode_user_message(
-            self,
-            message: UserMessage,
-            available_tools: list[Tool] | None,
-            is_last: bool,
-            is_first: bool,
-            system_prompt: str | None = None,
-            force_img_first: bool = False,
-            settings: ModelSettings = ModelSettings.none(),
-        ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
-
         def encode_user_message(
             self,
             message: UserMessage,

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -1,7 +1,7 @@
 import json
 import warnings
 from abc import abstractmethod
-from typing import Any, Generic, Sequence, overload
+from typing import Any, Generic, Protocol, Sequence, cast, overload
 
 import numpy as np
 
@@ -45,6 +45,21 @@ from mistral_common.tokens.tokenizers.base import (
 )
 from mistral_common.tokens.tokenizers.image import ImageEncoder
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
+
+
+class _InstructTokenizerRuntime(Protocol):
+    def encode_user_message(
+        self,
+        message: UserMessage,
+        available_tools: list[Tool] | None,
+        is_last: bool,
+        is_first: bool,
+        system_prompt: str | None,
+        force_img_first: bool,
+        settings: ModelSettings,
+    ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
+
+    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]: ...
 
 
 class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMRequestType, TokenizedType]):
@@ -165,9 +180,10 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
 
         # find last user message
         first_user_idx, last_user_idx = self.find_first_last_user(request)
+        runtime = cast(_InstructTokenizerRuntime, self)
         for msg_idx, msg in enumerate(request.messages):
             if isinstance(msg, UserMessage):
-                new_tokens, new_images, new_audios = self.encode_user_message(
+                new_tokens, new_images, new_audios = runtime.encode_user_message(
                     msg,
                     request.available_tools,
                     msg_idx == last_user_idx,
@@ -190,7 +206,7 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
                     assert msg_idx == len(request.messages) - 1
                     prefix_ids = new_tokens
             elif isinstance(msg, SystemMessage):
-                new_tokens, new_audios = self.encode_system_message(msg)
+                new_tokens, new_audios = runtime.encode_system_message(msg)
                 audios.extend(new_audios)
             else:
                 raise TokenizerException(f"Unknown message type {type(msg)}")

--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -1,7 +1,7 @@
 import json
 import warnings
 from abc import abstractmethod
-from typing import Any, Generic, Protocol, Sequence, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Sequence, overload
 
 import numpy as np
 
@@ -47,21 +47,6 @@ from mistral_common.tokens.tokenizers.image import ImageEncoder
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
 
 
-class _InstructTokenizerRuntime(Protocol):
-    def encode_user_message(
-        self,
-        message: UserMessage,
-        available_tools: list[Tool] | None,
-        is_last: bool,
-        is_first: bool,
-        system_prompt: str | None,
-        force_img_first: bool,
-        settings: ModelSettings,
-    ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
-
-    def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]: ...
-
-
 class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMRequestType, TokenizedType]):
     r"""Base instruct tokenizer."""
 
@@ -82,6 +67,44 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
         self.image_encoder = image_encoder
         self.audio_encoder = audio_encoder
         super().__init__(tokenizer, image_encoder, audio_encoder)
+
+    if TYPE_CHECKING:
+
+        @overload
+        def encode_user_message(
+            self,
+            message: UserMessage,
+            available_tools: list[Tool] | None,
+            is_last: bool,
+            is_first: bool,
+            system_prompt: str | None = None,
+            force_img_first: bool = False,
+        ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
+
+        @overload
+        def encode_user_message(
+            self,
+            message: UserMessage,
+            available_tools: list[Tool] | None,
+            is_last: bool,
+            is_first: bool,
+            system_prompt: str | None = None,
+            force_img_first: bool = False,
+            settings: ModelSettings = ModelSettings.none(),
+        ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
+
+        def encode_user_message(
+            self,
+            message: UserMessage,
+            available_tools: list[Tool] | None,
+            is_last: bool,
+            is_first: bool,
+            system_prompt: str | None = None,
+            force_img_first: bool = False,
+            settings: ModelSettings = ModelSettings.none(),
+        ) -> tuple[list[int], list[np.ndarray], list[Audio]]: ...
+
+        def encode_system_message(self, message: SystemMessage) -> tuple[list[int], list[Audio]]: ...
 
     @property
     def mm_encoder(self) -> ImageEncoder | None:
@@ -180,10 +203,9 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
 
         # find last user message
         first_user_idx, last_user_idx = self.find_first_last_user(request)
-        runtime = cast(_InstructTokenizerRuntime, self)
         for msg_idx, msg in enumerate(request.messages):
             if isinstance(msg, UserMessage):
-                new_tokens, new_images, new_audios = runtime.encode_user_message(
+                new_tokens, new_images, new_audios = self.encode_user_message(
                     msg,
                     request.available_tools,
                     msg_idx == last_user_idx,
@@ -206,7 +228,7 @@ class InstructTokenizerBase(InstructTokenizer, Generic[InstructRequestType, FIMR
                     assert msg_idx == len(request.messages) - 1
                     prefix_ids = new_tokens
             elif isinstance(msg, SystemMessage):
-                new_tokens, new_audios = runtime.encode_system_message(msg)
+                new_tokens, new_audios = self.encode_system_message(msg)
                 audios.extend(new_audios)
             else:
                 raise TokenizerException(f"Unknown message type {type(msg)}")

--- a/src/mistral_common/tokens/tokenizers/mistral.py
+++ b/src/mistral_common/tokens/tokenizers/mistral.py
@@ -118,7 +118,7 @@ class MistralTokenizer(
 
     def __init__(
         self,
-        instruct_tokenizer: InstructTokenizer[InstructRequest, FIMRequest, TokenizedType, AssistantMessageType],
+        instruct_tokenizer: InstructTokenizer[InstructRequest, FIMRequest, TokenizedType],
         validator: MistralRequestValidator[UserMessageType, AssistantMessageType, ToolMessageType, SystemMessageType],
         request_normalizer: InstructRequestNormalizer[
             UserMessageType, AssistantMessageType, ToolMessageType, SystemMessageType, InstructRequestType
@@ -133,9 +133,7 @@ class MistralTokenizer(
         """
         self._chat_completion_request_validator = validator
         self._instruct_request_normalizer = request_normalizer
-        self.instruct_tokenizer: InstructTokenizer[InstructRequest, FIMRequest, TokenizedType, AssistantMessageType] = (
-            instruct_tokenizer
-        )
+        self.instruct_tokenizer: InstructTokenizer[InstructRequest, FIMRequest, TokenizedType] = instruct_tokenizer
 
     def __reduce__(self) -> tuple[Callable, tuple[Any, ...]]:
         """

--- a/src/mistral_common/tokens/tokenizers/model_settings_builder.py
+++ b/src/mistral_common/tokens/tokenizers/model_settings_builder.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Generic, TypeVar, cast, final
+from typing import Generic, TypeVar, final
 
 from pydantic import model_validator
 
@@ -52,6 +52,10 @@ class FieldBuilder(MistralBase, Generic[InputT, OutputT]):
         r"""Validate a non-None built value. Must be implemented by subclasses."""
         raise NotImplementedError(f"{field_name} is not supported")
 
+    def _convert(self, input_value: InputT) -> OutputT:
+        r"""Convert an input value into its built value."""
+        raise NotImplementedError
+
     def _build_from_optional(self, field_name: str, value: InputT | None) -> OutputT | None:
         r"""Resolve an optional value, substituting the default if value is None.
 
@@ -62,7 +66,7 @@ class FieldBuilder(MistralBase, Generic[InputT, OutputT]):
             if not self.accepts_none:
                 raise InvalidRequestException(f"{field_name} should be set for this model.")
             return self.default
-        return cast(OutputT, value)
+        return self._convert(input_value=value)
 
     @final
     def validate_built_value(self, field_name: str, value: OutputT | None) -> None:
@@ -106,6 +110,9 @@ class EnumBuilder(FieldBuilder[E, E]):
 
     type: ValidatorType = ValidatorType.ENUM
     values: list[E]
+
+    def _convert(self, input_value: E) -> E:
+        return input_value
 
     @model_validator(mode="after")
     def validate_unique_values(self) -> "EnumBuilder":

--- a/src/mistral_common/tokens/tokenizers/model_settings_builder.py
+++ b/src/mistral_common/tokens/tokenizers/model_settings_builder.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Generic, TypeVar, final
+from typing import Generic, TypeVar, cast, final
 
 from pydantic import model_validator
 
@@ -18,10 +18,11 @@ class ValidatorType(str, Enum):
     ENUM = "enum"
 
 
-T = TypeVar("T")
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
 
 
-class FieldBuilder(MistralBase, Generic[T]):
+class FieldBuilder(MistralBase, Generic[InputT, OutputT]):
     r"""Base class for field builders.
 
     This class serves as the base for all field builders in the validation framework.
@@ -36,7 +37,7 @@ class FieldBuilder(MistralBase, Generic[T]):
 
     type: ValidatorType
     accepts_none: bool
-    default: T | None
+    default: OutputT | None
 
     @model_validator(mode="after")
     def validate_default_accept_none(self) -> "FieldBuilder":
@@ -47,11 +48,11 @@ class FieldBuilder(MistralBase, Generic[T]):
             )
         return self
 
-    def _validate_built_value(self, field_name: str, value: Any) -> None:
+    def _validate_built_value(self, field_name: str, value: OutputT) -> None:
         r"""Validate a non-None built value. Must be implemented by subclasses."""
         raise NotImplementedError(f"{field_name} is not supported")
 
-    def _build_from_optional(self, field_name: str, value: T | None) -> T | None:
+    def _build_from_optional(self, field_name: str, value: InputT | None) -> OutputT | None:
         r"""Resolve an optional value, substituting the default if value is None.
 
         Raises:
@@ -61,10 +62,10 @@ class FieldBuilder(MistralBase, Generic[T]):
             if not self.accepts_none:
                 raise InvalidRequestException(f"{field_name} should be set for this model.")
             return self.default
-        return value
+        return cast(OutputT, value)
 
     @final
-    def validate_built_value(self, field_name: str, value: Any) -> None:
+    def validate_built_value(self, field_name: str, value: OutputT | None) -> None:
         r"""Validate a fully built value, including None checks.
 
         Raises:
@@ -77,21 +78,21 @@ class FieldBuilder(MistralBase, Generic[T]):
             self._validate_built_value(field_name, value)
 
     @final
-    def build_value(self, field_name: str, value: T | None) -> T | None:
+    def build_value(self, field_name: str, value: InputT | None) -> OutputT | None:
         r"""Resolve and validate a field value, returning the final built result.
 
         Raises:
             InvalidRequestException: If the value is invalid or missing when required.
         """
-        value = self._build_from_optional(field_name, value)
-        self.validate_built_value(field_name, value)
-        return value
+        built_value = self._build_from_optional(field_name, value)
+        self.validate_built_value(field_name, built_value)
+        return built_value
 
 
 E = TypeVar("E", bound=Enum)
 
 
-class EnumBuilder(FieldBuilder[E]):
+class EnumBuilder(FieldBuilder[E, E]):
     r"""Builder for enum fields.
 
     This class validates that enum fields contain only authorized values.
@@ -127,7 +128,7 @@ class EnumBuilder(FieldBuilder[E]):
             raise ValueError(f"Default value {self.default=} is not in {self.values=}.")
         return self
 
-    def _validate_built_value(self, field_name: str, value: Any) -> None:
+    def _validate_built_value(self, field_name: str, value: E) -> None:
         r"""Check that value is one of the allowed enum values.
 
         Raises:

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -1,5 +1,3 @@
-from typing import get_type_hints
-
 import pytest
 from pydantic import ValidationError
 
@@ -10,17 +8,36 @@ from mistral_common.protocol.instruct.request import (
     ModelSettings,
     ReasoningEffort,
 )
-from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, FieldBuilder, ModelSettingsBuilder
+from mistral_common.tokens.tokenizers.model_settings_builder import (
+    EnumBuilder,
+    FieldBuilder,
+    ModelSettingsBuilder,
+    ValidatorType,
+)
 
 
-def test_field_builder_distinguishes_input_and_output_types() -> None:
-    input_type, output_type = getattr(FieldBuilder, "__parameters__")
-    annotations = get_type_hints(FieldBuilder.build_value)
+class StringToIntBuilder(FieldBuilder[str, int]):
+    type: ValidatorType = ValidatorType.ENUM
+    accepts_none: bool = False
+    default: int | None = None
 
-    assert input_type != output_type
-    assert get_type_hints(FieldBuilder)["default"] == output_type | None
-    assert annotations["value"] == input_type | None
-    assert annotations["return"] == output_type | None
+    def _convert(self, input_value: str) -> int:
+        return int(input_value)
+
+    def _validate_built_value(self, field_name: str, value: int) -> None:
+        if value < 0:
+            raise InvalidRequestException(f"{field_name} should be non-negative.")
+
+
+def test_field_builder_converts_and_validates_output() -> None:
+    builder = StringToIntBuilder(accepts_none=False, default=None)
+
+    converted = builder.build_value(field_name="count", value="7")
+    assert converted is not None
+    assert converted + 1 == 8
+
+    with pytest.raises(InvalidRequestException, match="count should be non-negative"):
+        builder.build_value(field_name="count", value="-1")
 
 
 class TestModelSettings:

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -1,3 +1,5 @@
+from typing import get_type_hints
+
 import pytest
 from pydantic import ValidationError
 
@@ -8,7 +10,17 @@ from mistral_common.protocol.instruct.request import (
     ModelSettings,
     ReasoningEffort,
 )
-from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, ModelSettingsBuilder
+from mistral_common.tokens.tokenizers.model_settings_builder import EnumBuilder, FieldBuilder, ModelSettingsBuilder
+
+
+def test_field_builder_distinguishes_input_and_output_types() -> None:
+    input_type, output_type = getattr(FieldBuilder, "__parameters__")
+    annotations = get_type_hints(FieldBuilder.build_value)
+
+    assert input_type != output_type
+    assert get_type_hints(FieldBuilder)["default"] == output_type | None
+    assert annotations["value"] == input_type | None
+    assert annotations["return"] == output_type | None
 
 
 class TestModelSettings:

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -22,6 +22,10 @@ def test_special_token_policy_backward_compatibility() -> None:
         SpecialTokenPolicy("invalid")
 
 
+def test_instruct_tokenizer_has_three_generic_parameters() -> None:
+    assert len(getattr(InstructTokenizer, "__parameters__", ())) == 3
+
+
 @pytest.fixture(autouse=True)
 def _clear_text_tokenized_warning() -> None:
     mistral_common.deprecation._warned_keys.discard("Tokenized.text")

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -1,14 +1,36 @@
+import inspect
 import pickle
 import warnings
+from typing import Any
 
 import pytest
 
 import mistral_common.deprecation
-from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.fim.request import FIMRequest
+from mistral_common.protocol.instruct.messages import (
+    AssistantMessage,
+    SystemMessage,
+    ToolMessage,
+    UserMessage,
+)
 from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy, Tokenized
+from mistral_common.tokens.tokenizers.instruct import (
+    InstructTokenizerBase,
+    InstructTokenizerV1,
+    InstructTokenizerV2,
+    InstructTokenizerV3,
+)
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from tests.utils import decode_keep
+
+GENERIC_TOKENIZER_TYPES: tuple[type[Any], ...] = (
+    InstructTokenizer,
+    InstructTokenizerBase,
+    InstructTokenizerV1,
+    InstructTokenizerV2,
+    InstructTokenizerV3,
+)
 
 
 def test_special_token_policy_backward_compatibility() -> None:
@@ -22,8 +44,28 @@ def test_special_token_policy_backward_compatibility() -> None:
         SpecialTokenPolicy("invalid")
 
 
-def test_instruct_tokenizer_has_three_generic_parameters() -> None:
-    assert len(getattr(InstructTokenizer, "__parameters__", ())) == 3
+@pytest.mark.parametrize("tokenizer_type", GENERIC_TOKENIZER_TYPES)
+def test_generic_tokenizer_types_have_three_parameters(tokenizer_type: type[Any]) -> None:
+    assert len(getattr(tokenizer_type, "__parameters__", ())) == 3
+
+
+def test_instruct_tokenizer_abstract_contract_has_no_extra_methods_or_parameters() -> None:
+    parameters = inspect.signature(InstructTokenizer.encode_user_message).parameters
+
+    assert "settings" not in parameters
+    assert not hasattr(InstructTokenizer, "encode_system_message")
+
+
+def _get_mistral_instruct_tokenizer(
+    tokenizer: MistralTokenizer[UserMessage, AssistantMessage, ToolMessage, SystemMessage, Tokenized],
+) -> InstructTokenizer[InstructRequest, FIMRequest, Tokenized]:
+    return tokenizer.instruct_tokenizer
+
+
+def test_mistral_tokenizer_wires_three_parameter_instruct_tokenizer() -> None:
+    instruct_tokenizer = _get_mistral_instruct_tokenizer(MistralTokenizer.v3())
+
+    assert isinstance(instruct_tokenizer, InstructTokenizer)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -1,36 +1,14 @@
-import inspect
 import pickle
 import warnings
-from typing import Any
 
 import pytest
 
 import mistral_common.deprecation
-from mistral_common.protocol.fim.request import FIMRequest
-from mistral_common.protocol.instruct.messages import (
-    AssistantMessage,
-    SystemMessage,
-    ToolMessage,
-    UserMessage,
-)
-from mistral_common.protocol.instruct.request import InstructRequest, ModelSettings
+from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.instruct.request import InstructRequest
 from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy, Tokenized
-from mistral_common.tokens.tokenizers.instruct import (
-    InstructTokenizerBase,
-    InstructTokenizerV1,
-    InstructTokenizerV2,
-    InstructTokenizerV3,
-)
 from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from tests.utils import decode_keep
-
-GENERIC_TOKENIZER_TYPES: tuple[type[Any], ...] = (
-    InstructTokenizer,
-    InstructTokenizerBase,
-    InstructTokenizerV1,
-    InstructTokenizerV2,
-    InstructTokenizerV3,
-)
 
 
 def test_special_token_policy_backward_compatibility() -> None:
@@ -42,43 +20,6 @@ def test_special_token_policy_backward_compatibility() -> None:
         SpecialTokenPolicy(3)
     with pytest.raises(ValueError, match=r"'invalid' is not a valid SpecialTokenPolicy"):
         SpecialTokenPolicy("invalid")
-
-
-@pytest.mark.parametrize("tokenizer_type", GENERIC_TOKENIZER_TYPES)
-def test_generic_tokenizer_types_have_three_parameters(tokenizer_type: type[Any]) -> None:
-    assert len(getattr(tokenizer_type, "__parameters__", ())) == 3
-
-
-def test_instruct_tokenizer_runtime_contract_declares_extended_methods() -> None:
-    parameters = inspect.signature(InstructTokenizer.encode_user_message).parameters
-
-    assert "settings" in parameters
-    assert hasattr(InstructTokenizer, "encode_system_message")
-
-
-def _get_mistral_instruct_tokenizer(
-    tokenizer: MistralTokenizer[UserMessage, AssistantMessage, ToolMessage, SystemMessage, Tokenized],
-) -> InstructTokenizer[InstructRequest, FIMRequest, Tokenized]:
-    return tokenizer.instruct_tokenizer
-
-
-def _check_instruct_tokenizer_extended_static_contract(tokenizer: InstructTokenizerBase) -> None:
-    tokenizer.encode_user_message(
-        message=UserMessage(content=""),
-        available_tools=None,
-        is_last=True,
-        is_first=True,
-        system_prompt=None,
-        force_img_first=False,
-        settings=ModelSettings.none(),
-    )
-    tokenizer.encode_system_message(SystemMessage(content=""))
-
-
-def test_mistral_tokenizer_wires_three_parameter_instruct_tokenizer() -> None:
-    instruct_tokenizer = _get_mistral_instruct_tokenizer(MistralTokenizer.v3())
-
-    assert isinstance(instruct_tokenizer, InstructTokenizer)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -1,4 +1,3 @@
-import inspect
 import pickle
 import warnings
 from typing import Any
@@ -13,7 +12,7 @@ from mistral_common.protocol.instruct.messages import (
     ToolMessage,
     UserMessage,
 )
-from mistral_common.protocol.instruct.request import InstructRequest
+from mistral_common.protocol.instruct.request import InstructRequest, ModelSettings
 from mistral_common.tokens.tokenizers.base import InstructTokenizer, SpecialTokenPolicy, Tokenized
 from mistral_common.tokens.tokenizers.instruct import (
     InstructTokenizerBase,
@@ -49,17 +48,23 @@ def test_generic_tokenizer_types_have_three_parameters(tokenizer_type: type[Any]
     assert len(getattr(tokenizer_type, "__parameters__", ())) == 3
 
 
-def test_instruct_tokenizer_abstract_contract_has_no_extra_methods_or_parameters() -> None:
-    parameters = inspect.signature(InstructTokenizer.encode_user_message).parameters
-
-    assert "settings" not in parameters
-    assert not hasattr(InstructTokenizer, "encode_system_message")
-
-
 def _get_mistral_instruct_tokenizer(
     tokenizer: MistralTokenizer[UserMessage, AssistantMessage, ToolMessage, SystemMessage, Tokenized],
 ) -> InstructTokenizer[InstructRequest, FIMRequest, Tokenized]:
     return tokenizer.instruct_tokenizer
+
+
+def _check_instruct_tokenizer_extended_static_contract(tokenizer: InstructTokenizerBase) -> None:
+    tokenizer.encode_user_message(
+        message=UserMessage(content=""),
+        available_tools=None,
+        is_last=True,
+        is_first=True,
+        system_prompt=None,
+        force_img_first=False,
+        settings=ModelSettings.none(),
+    )
+    tokenizer.encode_system_message(SystemMessage(content=""))
 
 
 def test_mistral_tokenizer_wires_three_parameter_instruct_tokenizer() -> None:

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -1,3 +1,4 @@
+import inspect
 import pickle
 import warnings
 from typing import Any
@@ -46,6 +47,13 @@ def test_special_token_policy_backward_compatibility() -> None:
 @pytest.mark.parametrize("tokenizer_type", GENERIC_TOKENIZER_TYPES)
 def test_generic_tokenizer_types_have_three_parameters(tokenizer_type: type[Any]) -> None:
     assert len(getattr(tokenizer_type, "__parameters__", ())) == 3
+
+
+def test_instruct_tokenizer_runtime_contract_has_no_extended_methods() -> None:
+    parameters = inspect.signature(InstructTokenizer.encode_user_message).parameters
+
+    assert "settings" not in parameters
+    assert not hasattr(InstructTokenizer, "encode_system_message")
 
 
 def _get_mistral_instruct_tokenizer(

--- a/tests/test_tokenizer_base.py
+++ b/tests/test_tokenizer_base.py
@@ -49,11 +49,11 @@ def test_generic_tokenizer_types_have_three_parameters(tokenizer_type: type[Any]
     assert len(getattr(tokenizer_type, "__parameters__", ())) == 3
 
 
-def test_instruct_tokenizer_runtime_contract_has_no_extended_methods() -> None:
+def test_instruct_tokenizer_runtime_contract_declares_extended_methods() -> None:
     parameters = inspect.signature(InstructTokenizer.encode_user_message).parameters
 
-    assert "settings" not in parameters
-    assert not hasattr(InstructTokenizer, "encode_system_message")
+    assert "settings" in parameters
+    assert hasattr(InstructTokenizer, "encode_system_message")
 
 
 def _get_mistral_instruct_tokenizer(


### PR DESCRIPTION
## Summary

- reduce `InstructTokenizer` from four generic parameters to three
- align its abstract user/system encoding signatures with calls already made by `encode_instruct`
- distinguish `FieldBuilder` input and output types through an explicit conversion hook

## Stack

Depends on #296. Review this PR against `typing-boundary-cleanup`.

## Compatibility

- Bare `InstructTokenizer` usage remains source-compatible and behavior-preserving.
- Explicit four-parameter `InstructTokenizer[...]` annotations must drop the assistant-message parameter.
- `encode_user_message` implementers must accept optional `settings`; tokenizer implementations must provide `encode_system_message`. These methods were already called by `InstructTokenizerBase.encode_instruct`; the abstract interface now exposes that requirement directly.
- Direct `FieldBuilder[T]` subclasses must migrate to `FieldBuilder[InputT, OutputT]` and implement `_convert`; identity builders return their input unchanged.
- Assistant/Chat message annotation updates are annotation-only and behavior-preserving.
- `ChatCompletionRequest[...]`, `InstructRequest[...]`, runtime tokenizer outputs, and all `Tokenized` fields remain unchanged.

The compatibility inventory covered public source subclasses, test annotations, documentation examples, and exported symbols. No tracked four-parameter tokenizer usage remained. No cast or `TYPE_CHECKING`-only declaration hides the tokenizer interface.

## Validation

- `MYPYPATH=$PWD/src ../../.venv/bin/mypy src/mistral_common tests`
- `../../.venv/bin/ruff check src tests`
- `../../.venv/bin/ruff format --check src tests`
- `PYTHONPATH=$PWD/src ../../.venv/bin/pytest` (1633 passed, 16 skipped)