### PR TITLE
fix: allow v11 system prompts with audio

### DIFF
--- a/src/mistral_common/tokens/tokenizers/instruct.py
+++ b/src/mistral_common/tokens/tokenizers/instruct.py
@@ -1077,7 +1077,7 @@ class InstructTokenizerV7(InstructTokenizerV3):
         return any(
             isinstance(message, UserMessage)
             and isinstance(message.content, list)
-            and any(isinstance(chunk, AudioChunk) for chunk in message.content)
+            and any(isinstance(chunk, (AudioChunk, AudioURLChunk)) for chunk in message.content)
             for message in messages
         )
 
@@ -1215,6 +1215,11 @@ class InstructTokenizerV11(InstructTokenizerV7):
         super().__init__(tokenizer, image_encoder, audio_encoder)
         self.ARGS = self.tokenizer.get_special_token(SpecialTokens.args.value)
         self.CALL_ID = self.tokenizer.get_special_token(SpecialTokens.call_id.value)
+
+    @classmethod
+    def validate_messages(cls, messages: list[UATS]) -> None:
+        r"""V11 allows system prompts alongside audio."""
+        return
 
     def _encode_tool_calls_in_assistant_message(self, message: AssistantMessage) -> list[int]:
         assert message.tool_calls, f"Assistant message must have tool calls. Got {message}"

--- a/tests/test_tokenizer_v11.py
+++ b/tests/test_tokenizer_v11.py
@@ -1,11 +1,19 @@
 import pytest
 
-from mistral_common.protocol.instruct.messages import AssistantMessage
+from mistral_common.protocol.instruct.chunk import AudioChunk, AudioURLChunk
+from mistral_common.protocol.instruct.messages import AssistantMessage, SystemMessage, UserMessage
+from mistral_common.protocol.instruct.normalize import InstructRequestNormalizerV13
+from mistral_common.protocol.instruct.request import ChatCompletionRequest
 from mistral_common.protocol.instruct.tool_calls import FunctionCall, ToolCall
-from mistral_common.tokens.tokenizers.base import TokenizerVersion
+from mistral_common.protocol.instruct.validator import MistralRequestValidatorV11
+from mistral_common.tokens.tokenizers.audio import AudioConfig, AudioEncoder, AudioSpectrogramConfig, SpecialAudioIDs
+from mistral_common.tokens.tokenizers.base import SpecialTokens, TokenizerVersion
 from mistral_common.tokens.tokenizers.instruct import InstructTokenizerV11
+from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
 from mistral_common.tokens.tokenizers.tekken import Tekkenizer
+from tests.fixtures.audio import get_dummy_audio_chunk, get_dummy_audio_url_chunk
 from tests.test_tekken import get_special_tokens, quick_vocab
+from tests.utils import decode_keep
 
 
 @pytest.fixture(scope="session")
@@ -146,3 +154,60 @@ def test_tokenize_assistant_message_train(tekkenizer: InstructTokenizerV11) -> N
         2,
     ]
     assert tekkenizer.tokenizer._to_string(tokens) == ('[TOOL_CALLS]a_a_a[CALL_ID]ABC[ARGS]"blabla"</s>')
+
+
+@pytest.fixture(scope="session")
+def v11_tekkenizer_audio() -> InstructTokenizerV11:
+    special_tokens = get_special_tokens(TokenizerVersion.v11, add_audio=True)
+    tokenizer = Tekkenizer(
+        quick_vocab([b"a", b"b", b"c", b"f", b"de"]),
+        special_tokens=special_tokens,
+        pattern=r".+",
+        vocab_size=256 + 100,
+        num_special_tokens=100,
+        version=TokenizerVersion.v11,
+    )
+    audio_config = AudioConfig(
+        sampling_rate=24_000,
+        frame_rate=12.5,
+        encoding_config=AudioSpectrogramConfig(
+            num_mel_bins=128,
+            window_size=400,
+            hop_length=160,
+        ),
+    )
+    special_audio_ids = SpecialAudioIDs(
+        audio=tokenizer.get_special_token(SpecialTokens.audio.value),
+        begin_audio=tokenizer.get_special_token(SpecialTokens.begin_audio.value),
+        streaming_pad=None,
+        text_to_audio=None,
+        audio_to_text=None,
+    )
+    audio_encoder = AudioEncoder(audio_config, special_audio_ids)
+    return InstructTokenizerV11(tokenizer, audio_encoder=audio_encoder)
+
+
+@pytest.fixture(params=["audio_chunk", "audio_url_chunk"])
+def audio_fixture(request: pytest.FixtureRequest) -> AudioChunk | AudioURLChunk:
+    if request.param == "audio_chunk":
+        return get_dummy_audio_chunk()
+    return get_dummy_audio_url_chunk()
+
+
+def test_v11_allows_system_message_with_audio(
+    v11_tekkenizer_audio: InstructTokenizerV11, audio_fixture: AudioChunk | AudioURLChunk
+) -> None:
+    """V11 should accept system messages alongside audio (unlike V7)."""
+    request_normalizer = InstructRequestNormalizerV13.normalizer()
+    validator = MistralRequestValidatorV11()
+    messages = [
+        SystemMessage(content="hello"),
+        UserMessage(content=[audio_fixture]),
+    ]
+    mistral_tokenizer = MistralTokenizer(
+        instruct_tokenizer=v11_tekkenizer_audio, validator=validator, request_normalizer=request_normalizer
+    )
+    encoded = mistral_tokenizer.encode_chat_completion(ChatCompletionRequest(messages=messages))
+    text = decode_keep(mistral_tokenizer, encoded)
+    assert "[SYSTEM_PROMPT]hello[/SYSTEM_PROMPT]" in text
+    assert len(encoded.audios) == 1

--- a/tests/test_tokenizer_v7_audio.py
+++ b/tests/test_tokenizer_v7_audio.py
@@ -350,6 +350,13 @@ def test_no_audio_in_system_message_before_v7() -> None:
             ],
             "System messages are not yet allowed when audio is present",
         ),
+        (
+            [
+                SystemMessage(content="a b c d"),
+                UserMessage(content=[TextChunk(text="a"), AudioURLChunk(audio_url="https://example.com/a.wav")]),
+            ],
+            "System messages are not yet allowed when audio is present",
+        ),
     ],
 )
 def test_tokenize_audio_raise(tekkenizer: InstructTokenizerV7, messages: list[UATS], match_regex: str) -> None:


### PR DESCRIPTION
## Summary

Allow the V11 instruct tokenizer path to accept system prompts when audio content is present.

This keeps the V7 behavior unchanged for audio requests while extending audio detection to include `AudioURLChunk`, and adds regression coverage for both inline audio chunks and audio URL chunks.

## Test Plan

- `python -m py_compile src\mistral_common\tokens\tokenizers\instruct.py tests\test_tokenizer_v11.py tests\test_tokenizer_v7_audio.py`
- `git diff --check`
- `PRE_COMMIT_HOME=.pre-commit-cache python -m pre_commit run --all-files --show-diff-on-failure`
  - Lint GitHub Actions workflow files: Passed
  - ruff check: Passed
  - ruff format: Passed
  - uv-lock: Passed