### PR TITLE
docs: fix typo in experimental usage guide

### DIFF
--- a/docs/usage/experimental.md
+++ b/docs/usage/experimental.md
@@ -39,7 +39,7 @@ pip install mistral-common[server]
 
 ### Launching the Server
 
-You can launch the server using the follwing CLI command:
+You can launch the server using the following CLI command:
 
 ```bash
 mistral_common serve mistralai/Magistral-Small-2507 [validation_mode] \


### PR DESCRIPTION
Fixes `follwing` → `following` in `docs/usage/experimental.md`. Docs-only change.